### PR TITLE
Android keyboard burndown: rendering, lifecycle, theming, and touch fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ local.properties
 .playwright-mcp/
 keyjawn-site-*.png
 *.jks
+*.jks.bak
 *.keystore
 *.p8
 play-service-account.json

--- a/app/src/full/java/com/keyjawn/UploadHandler.kt
+++ b/app/src/full/java/com/keyjawn/UploadHandler.kt
@@ -27,6 +27,7 @@ class UploadHandler(private val context: Context) {
     private var activeHost: HostConfig? = null
     private var inputConnectionProvider: (() -> InputConnection?)? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var destroyed = false
 
     init {
         activeHost = HostStorage(context).getActiveHost()
@@ -100,6 +101,8 @@ class UploadHandler(private val context: Context) {
     }
 
     fun destroy() {
+        if (destroyed) return
+        destroyed = true
         scope.cancel()
     }
 

--- a/app/src/full/java/com/keyjawn/UploadHandler.kt
+++ b/app/src/full/java/com/keyjawn/UploadHandler.kt
@@ -28,6 +28,13 @@ class UploadHandler(private val context: Context) {
     private var inputConnectionProvider: (() -> InputConnection?)? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
+    /**
+     * Routes upload status messages to the keyboard's in-context feedback surface
+     * (the tooltip bar). When unset, status falls back to a Toast so a misconfigured
+     * wiring still surfaces the result instead of dropping it silently.
+     */
+    var onShowStatus: ((String) -> Unit)? = null
+
     init {
         activeHost = HostStorage(context).getActiveHost()
     }
@@ -62,12 +69,12 @@ class UploadHandler(private val context: Context) {
 
     fun createPickerIntent(): Intent? {
         if (!hasMediaPermission()) {
-            showToast("Image permission required. Opening settings.")
+            showStatus("Image permission required. Opening settings.")
             openAppSettings()
             return null
         }
         if (!hasHostConfigured()) {
-            showToast("No host configured. Open KeyJawn settings to add one.")
+            showStatus("No host configured. Open KeyJawn settings to add one.")
             return null
         }
         return Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI).apply {
@@ -79,7 +86,7 @@ class UploadHandler(private val context: Context) {
         if (uri == null) return
         val host = activeHost
         if (host == null) {
-            showToast("No host configured. Open KeyJawn settings to add one.")
+            showStatus("No host configured. Open KeyJawn settings to add one.")
             return
         }
 
@@ -89,10 +96,10 @@ class UploadHandler(private val context: Context) {
             val result = scpUploader.upload(host, localFile, knownHostsManager)
             withContext(Dispatchers.Main) {
                 if (result.success) {
-                    showToast("Uploaded -> ${result.remotePath}")
+                    showStatus("Uploaded -> ${result.remotePath}")
                     inputConnectionProvider?.invoke()?.commitText(result.remotePath, 1)
                 } else {
-                    showToast("Upload failed: ${result.error}")
+                    showStatus("Upload failed: ${result.error}")
                 }
                 localFile.delete()
             }
@@ -118,12 +125,17 @@ class UploadHandler(private val context: Context) {
             inputStream.close()
             tempFile
         } catch (e: Exception) {
-            showToast("Failed to read image")
+            showStatus("Failed to read image")
             null
         }
     }
 
-    private fun showToast(message: String) {
-        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+    private fun showStatus(message: String) {
+        val callback = onShowStatus
+        if (callback != null) {
+            callback(message)
+        } else {
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
     }
 }

--- a/app/src/lite/java/com/keyjawn/UploadHandler.kt
+++ b/app/src/lite/java/com/keyjawn/UploadHandler.kt
@@ -8,6 +8,10 @@ import android.view.inputmethod.InputConnection
 class UploadHandler(private val context: Context) {
     val isAvailable = false
 
+    // No-op in the lite flavor; present for source parity with the full flavor
+    // so shared code can set it unconditionally.
+    var onShowStatus: ((String) -> Unit)? = null
+
     fun setHost(host: HostConfig) {}
 
     fun setInputConnectionProvider(provider: () -> InputConnection?) {}

--- a/app/src/main/java/com/keyjawn/AltKeyMappings.kt
+++ b/app/src/main/java/com/keyjawn/AltKeyMappings.kt
@@ -2,7 +2,8 @@ package com.keyjawn
 
 object AltKeyMappings {
 
-    private val mappings = mapOf(
+    // Lowercase (and caseless) key labels mapped to their alt characters.
+    private val lowerMappings = mapOf(
         // Number row -> shifted symbols
         "1" to listOf("!"),
         "2" to listOf("@"),
@@ -33,14 +34,20 @@ object AltKeyMappings {
         "-" to listOf("\u2014", "\u2013")
     )
 
-    fun getAlts(label: String): List<String>? {
-        val lower = label.lowercase()
-        val alts = mappings[lower] ?: return null
-        return if (label != lower) {
-            // Uppercase: uppercase the alt chars
-            alts.map { it.uppercase() }
-        } else {
-            alts
+    // Both case variants precomputed once, keyed by the exact key label, so
+    // getAlts is a pure lookup with no per-call lowercasing or per-element
+    // uppercasing. The uppercase entry is added only when the label actually has
+    // a distinct uppercase form (letters); digits and punctuation map to
+    // themselves and need no second entry.
+    private val mappings: Map<String, List<String>> = buildMap {
+        for ((label, alts) in lowerMappings) {
+            put(label, alts)
+            val upperLabel = label.uppercase()
+            if (upperLabel != label) {
+                put(upperLabel, alts.map { it.uppercase() })
+            }
         }
     }
+
+    fun getAlts(label: String): List<String>? = mappings[label]
 }

--- a/app/src/main/java/com/keyjawn/AltKeyPopup.kt
+++ b/app/src/main/java/com/keyjawn/AltKeyPopup.kt
@@ -17,93 +17,12 @@ class AltKeyPopup(
 
     private var popup: PopupWindow? = null
 
-    fun show(anchor: android.view.View, alts: List<String>, onSelect: ((String) -> Unit)? = null) {
-        dismiss()
-        val context = anchor.context
-        val density = context.resources.displayMetrics.density
-
-        val row = LinearLayout(context).apply {
-            orientation = LinearLayout.HORIZONTAL
-            val pad = (4 * density + 0.5f).toInt()
-            setPadding(pad, pad, pad, pad)
-        }
-
-        val btnSize = (40 * density + 0.5f).toInt()
-        val btnHeight = (44 * density + 0.5f).toInt()
-        val margin = (2 * density + 0.5f).toInt()
-
-        for (alt in alts) {
-            val btn = Button(context).apply {
-                text = alt
-                isAllCaps = false
-                val tm = themeManager
-                if (tm != null) {
-                    background = tm.createKeyDrawable(tm.keyBg())
-                    setTextColor(tm.keyText())
-                } else {
-                    setBackgroundResource(R.drawable.key_bg)
-                    setTextColor(context.getColor(R.color.key_text))
-                }
-                gravity = Gravity.CENTER
-                setPadding(0, 0, 0, 0)
-                minWidth = 0
-                minimumWidth = 0
-                minHeight = 0
-                minimumHeight = 0
-                typeface = Typeface.MONOSPACE
-                setTextSize(TypedValue.COMPLEX_UNIT_SP, 18f)
-                setOnClickListener {
-                    if (onSelect != null) {
-                        onSelect(alt)
-                    } else {
-                        val ic = inputConnectionProvider() ?: return@setOnClickListener
-                        keySender.sendText(ic, alt)
-                    }
-                    dismiss()
-                }
-            }
-            val params = LinearLayout.LayoutParams(btnSize, btnHeight)
-            params.setMargins(margin, 0, margin, 0)
-            btn.layoutParams = params
-            row.addView(btn)
-        }
-
-        val window = PopupWindow(
-            row,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            true
-        )
-        val bg = android.graphics.drawable.GradientDrawable().apply {
-            setColor(themeManager?.keyboardBg() ?: 0xFF2B2B30.toInt())
-            cornerRadius = 8 * density
-            setStroke((1 * density + 0.5f).toInt(), themeManager?.divider() ?: 0xFF38383E.toInt())
-        }
-        window.setBackgroundDrawable(bg)
-        window.elevation = 8 * density
-        window.isOutsideTouchable = true
-        window.isTouchable = true
-
-        // Position above the anchor key
-        val anchorLoc = IntArray(2)
-        anchor.getLocationInWindow(anchorLoc)
-        val popupHeight = btnHeight + (8 * density + 0.5f).toInt()
-        val yOffset = -(anchor.height + popupHeight)
-
-        // Center the popup horizontally on the anchor
-        val popupWidth = alts.size * (btnSize + 2 * margin) + (8 * density + 0.5f).toInt()
-        val xOffset = (anchor.width - popupWidth) / 2
-
-        window.showAsDropDown(anchor, xOffset, yOffset)
-        popup = window
-    }
-
     /**
      * Opens the candidate row for a slide-and-release gesture and returns a
-     * [SlideSession] the host key's touch listener drives. Unlike [show], the
-     * candidates carry no click listeners (selection comes from the in-flight
-     * finger, not a second tap) and the window is non-focusable so it does not
-     * steal the gesture the host view already owns.
+     * [SlideSession] the host key's touch listener drives. The candidates carry
+     * no click listeners (selection comes from the in-flight finger, not a second
+     * tap) and the window is non-focusable so it does not steal the gesture the
+     * host view already owns.
      *
      * Candidate screen-space [Rect]s are precomputed from the same sizing
      * constants the button row is built with, so hit-testing never depends on
@@ -170,9 +89,10 @@ class AltKeyPopup(
         window.isTouchable = false
 
         val popupHeight = btnHeight + (8 * density + 0.5f).toInt()
+        // Vertical is not clamped: a bottom-anchored IME always has room above the
+        // key for the candidate row, so popupTop stays on screen.
         val yOffset = -(anchor.height + popupHeight)
         val popupWidth = alts.size * (btnSize + 2 * margin) + (8 * density + 0.5f).toInt()
-        val xOffset = (anchor.width - popupWidth) / 2
 
         // The popup top-left in screen space. showAsDropDown places the window at
         // (anchorScreen + offset), so the same arithmetic gives candidate bounds
@@ -181,7 +101,19 @@ class AltKeyPopup(
         anchor.getLocationOnScreen(anchorLoc)
         val anchorScreenX = anchorLoc[0]
         val anchorScreenY = anchorLoc[1]
-        val popupLeft = anchorScreenX + xOffset
+
+        // Centering a wide candidate row over a narrow edge key pushes the
+        // requested left off screen. showAsDropDown (clipping enabled by default)
+        // would slide the window back on screen but leave our precomputed rects at
+        // the off-screen origin, desyncing hit-testing from the visible buttons.
+        // Clamp horizontally ourselves to the same bounds the framework would, then
+        // derive both the rects AND the offset we pass to showAsDropDown from the
+        // clamped left, so the framework finds the window already fits and leaves
+        // it where we put it.
+        val screenWidth = context.resources.displayMetrics.widthPixels
+        val requestedLeft = anchorScreenX + (anchor.width - popupWidth) / 2
+        val clampedLeft = clampPopupLeft(requestedLeft, popupWidth, screenWidth)
+        val clampedXOffset = clampedLeft - anchorScreenX
         val popupTop = anchorScreenY + yOffset
 
         // Each candidate sits at popup-internal x = pad + i*(btnSize + 2*margin) +
@@ -190,12 +122,12 @@ class AltKeyPopup(
         // top y = pad.
         val rects = ArrayList<Rect>(alts.size)
         for (i in alts.indices) {
-            val left = popupLeft + pad + i * (btnSize + 2 * margin) + margin
+            val left = clampedLeft + pad + i * (btnSize + 2 * margin) + margin
             val top = popupTop + pad
             rects.add(Rect(left, top, left + btnSize, top + btnHeight))
         }
 
-        window.showAsDropDown(anchor, xOffset, yOffset)
+        window.showAsDropDown(anchor, clampedXOffset, yOffset)
         popup = window
 
         return SlideSession(buttons, rects, themeManager) { dismiss() }
@@ -204,6 +136,23 @@ class AltKeyPopup(
     fun dismiss() {
         popup?.dismiss()
         popup = null
+    }
+
+    companion object {
+        /**
+         * Clamp the requested popup left edge to the screen so the precomputed
+         * candidate rects stay aligned with where showAsDropDown actually places
+         * the window. A popup wider than the screen pins to 0; one that overflows
+         * left or right is slid inward by exactly the overflow; one that already
+         * fits is unchanged. Pure arithmetic so it is unit-testable without a
+         * rendered popup.
+         */
+        fun clampPopupLeft(requestedLeft: Int, popupWidth: Int, screenWidth: Int): Int = when {
+            popupWidth >= screenWidth -> 0
+            requestedLeft < 0 -> 0
+            requestedLeft + popupWidth > screenWidth -> screenWidth - popupWidth
+            else -> requestedLeft
+        }
     }
 
     /**

--- a/app/src/main/java/com/keyjawn/AltKeyPopup.kt
+++ b/app/src/main/java/com/keyjawn/AltKeyPopup.kt
@@ -106,13 +106,17 @@ class AltKeyPopup(
         // requested left off screen. showAsDropDown (clipping enabled by default)
         // would slide the window back on screen but leave our precomputed rects at
         // the off-screen origin, desyncing hit-testing from the visible buttons.
-        // Clamp horizontally ourselves to the same bounds the framework would, then
-        // derive both the rects AND the offset we pass to showAsDropDown from the
-        // clamped left, so the framework finds the window already fits and leaves
-        // it where we put it.
-        val screenWidth = context.resources.displayMetrics.widthPixels
+        // Clamp horizontally ourselves to the anchor window's visible display frame
+        // -- the same Rect showAsDropDown clips against -- then derive both the rects
+        // AND the offset we pass to showAsDropDown from the clamped left, so the
+        // framework finds the window already fits and leaves it where we put it. In
+        // split-screen/freeform the frame's left can be > 0 and its width far narrower
+        // than displayMetrics.widthPixels, so the raw screen width would let the
+        // framework re-slide the window past our clamp.
+        val displayFrame = Rect()
+        anchor.getWindowVisibleDisplayFrame(displayFrame)
         val requestedLeft = anchorScreenX + (anchor.width - popupWidth) / 2
-        val clampedLeft = clampPopupLeft(requestedLeft, popupWidth, screenWidth)
+        val clampedLeft = clampPopupLeft(requestedLeft, popupWidth, displayFrame.left, displayFrame.right)
         val clampedXOffset = clampedLeft - anchorScreenX
         val popupTop = anchorScreenY + yOffset
 
@@ -140,18 +144,23 @@ class AltKeyPopup(
 
     companion object {
         /**
-         * Clamp the requested popup left edge to the screen so the precomputed
-         * candidate rects stay aligned with where showAsDropDown actually places
-         * the window. A popup wider than the screen pins to 0; one that overflows
-         * left or right is slid inward by exactly the overflow; one that already
-         * fits is unchanged. Pure arithmetic so it is unit-testable without a
-         * rendered popup.
+         * Clamp the requested popup left edge to the anchor window's visible display
+         * frame -- the same frame showAsDropDown clips against -- so the precomputed
+         * candidate rects stay aligned with where the window actually lands in any
+         * window mode (full-screen, split-screen, or freeform). [frameLeft] and
+         * [frameRight] are screen-space, matching getLocationOnScreen. A popup wider
+         * than the frame pins to [frameLeft]; one that overflows left or right is slid
+         * inward to the frame edge; one that already fits is unchanged. Pure arithmetic
+         * so it is unit-testable without a rendered popup.
          */
-        fun clampPopupLeft(requestedLeft: Int, popupWidth: Int, screenWidth: Int): Int = when {
-            popupWidth >= screenWidth -> 0
-            requestedLeft < 0 -> 0
-            requestedLeft + popupWidth > screenWidth -> screenWidth - popupWidth
-            else -> requestedLeft
+        fun clampPopupLeft(requestedLeft: Int, popupWidth: Int, frameLeft: Int, frameRight: Int): Int {
+            val maxLeft = frameRight - popupWidth
+            return when {
+                maxLeft <= frameLeft -> frameLeft
+                requestedLeft < frameLeft -> frameLeft
+                requestedLeft > maxLeft -> maxLeft
+                else -> requestedLeft
+            }
         }
     }
 

--- a/app/src/main/java/com/keyjawn/AltKeyPopup.kt
+++ b/app/src/main/java/com/keyjawn/AltKeyPopup.kt
@@ -1,5 +1,6 @@
 package com.keyjawn
 
+import android.graphics.Rect
 import android.graphics.Typeface
 import android.util.TypedValue
 import android.view.Gravity
@@ -97,8 +98,188 @@ class AltKeyPopup(
         popup = window
     }
 
+    /**
+     * Opens the candidate row for a slide-and-release gesture and returns a
+     * [SlideSession] the host key's touch listener drives. Unlike [show], the
+     * candidates carry no click listeners (selection comes from the in-flight
+     * finger, not a second tap) and the window is non-focusable so it does not
+     * steal the gesture the host view already owns.
+     *
+     * Candidate screen-space [Rect]s are precomputed from the same sizing
+     * constants the button row is built with, so hit-testing never depends on
+     * the popup window being measured or laid out.
+     */
+    fun openForSlide(anchor: android.view.View, alts: List<String>): SlideSession {
+        dismiss()
+        val context = anchor.context
+        val density = context.resources.displayMetrics.density
+        val tm = themeManager
+
+        val pad = (4 * density + 0.5f).toInt()
+        val row = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            setPadding(pad, pad, pad, pad)
+        }
+
+        val btnSize = (40 * density + 0.5f).toInt()
+        val btnHeight = (44 * density + 0.5f).toInt()
+        val margin = (2 * density + 0.5f).toInt()
+
+        val buttons = ArrayList<Button>(alts.size)
+        for (alt in alts) {
+            val btn = Button(context).apply {
+                text = alt
+                isAllCaps = false
+                if (tm != null) {
+                    background = tm.createKeyDrawable(tm.keyBg())
+                    setTextColor(tm.keyText())
+                } else {
+                    setBackgroundResource(R.drawable.key_bg)
+                    setTextColor(context.getColor(R.color.key_text))
+                }
+                gravity = Gravity.CENTER
+                setPadding(0, 0, 0, 0)
+                minWidth = 0
+                minimumWidth = 0
+                minHeight = 0
+                minimumHeight = 0
+                typeface = Typeface.MONOSPACE
+                setTextSize(TypedValue.COMPLEX_UNIT_SP, 18f)
+            }
+            val params = LinearLayout.LayoutParams(btnSize, btnHeight)
+            params.setMargins(margin, 0, margin, 0)
+            btn.layoutParams = params
+            row.addView(btn)
+            buttons.add(btn)
+        }
+
+        val window = PopupWindow(
+            row,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            false
+        )
+        val bg = android.graphics.drawable.GradientDrawable().apply {
+            setColor(tm?.keyboardBg() ?: 0xFF2B2B30.toInt())
+            cornerRadius = 8 * density
+            setStroke((1 * density + 0.5f).toInt(), tm?.divider() ?: 0xFF38383E.toInt())
+        }
+        window.setBackgroundDrawable(bg)
+        window.elevation = 8 * density
+        window.isOutsideTouchable = true
+        window.isTouchable = false
+
+        val popupHeight = btnHeight + (8 * density + 0.5f).toInt()
+        val yOffset = -(anchor.height + popupHeight)
+        val popupWidth = alts.size * (btnSize + 2 * margin) + (8 * density + 0.5f).toInt()
+        val xOffset = (anchor.width - popupWidth) / 2
+
+        // The popup top-left in screen space. showAsDropDown places the window at
+        // (anchorScreen + offset), so the same arithmetic gives candidate bounds
+        // without waiting for a layout pass.
+        val anchorLoc = IntArray(2)
+        anchor.getLocationOnScreen(anchorLoc)
+        val anchorScreenX = anchorLoc[0]
+        val anchorScreenY = anchorLoc[1]
+        val popupLeft = anchorScreenX + xOffset
+        val popupTop = anchorScreenY + yOffset
+
+        // Each candidate sits at popup-internal x = pad + i*(btnSize + 2*margin) +
+        // margin (the LinearLayout's left padding, the preceding buttons' cells,
+        // and this button's own left margin), spanning btnSize x btnHeight at
+        // top y = pad.
+        val rects = ArrayList<Rect>(alts.size)
+        for (i in alts.indices) {
+            val left = popupLeft + pad + i * (btnSize + 2 * margin) + margin
+            val top = popupTop + pad
+            rects.add(Rect(left, top, left + btnSize, top + btnHeight))
+        }
+
+        window.showAsDropDown(anchor, xOffset, yOffset)
+        popup = window
+
+        return SlideSession(buttons, rects, themeManager) { dismiss() }
+    }
+
     fun dismiss() {
         popup?.dismiss()
         popup = null
+    }
+
+    /**
+     * Tracks the slide gesture over an open candidate row. The host key's touch
+     * listener feeds it screen-space pointer coordinates; it owns the hover
+     * highlight and resolves the selected alt on release. Hit-testing is pure
+     * arithmetic over precomputed [candidateRects], so it is unit-testable
+     * without a rendered popup window.
+     */
+    class SlideSession internal constructor(
+        private val buttons: List<Button>,
+        private val candidateRects: List<Rect>,
+        private val themeManager: ThemeManager?,
+        private val onDismiss: () -> Unit
+    ) {
+        val alts: List<String> = buttons.map { it.text.toString() }
+
+        var hoveredIndex: Int = -1
+            private set
+
+        private var dismissed = false
+
+        /** Candidate screen-space bounds, exposed so a test can drive synthetic points. */
+        fun candidateRectsForTest(): List<Rect> = candidateRects
+
+        /** Index of the candidate at the given screen point, or -1 if outside all. */
+        fun indexAt(screenX: Float, screenY: Float): Int {
+            val x = screenX.toInt()
+            val y = screenY.toInt()
+            for (i in candidateRects.indices) {
+                if (candidateRects[i].contains(x, y)) return i
+            }
+            return -1
+        }
+
+        /** Update the hovered candidate from a screen-space pointer position. */
+        fun onMove(screenX: Float, screenY: Float) {
+            if (dismissed) return
+            val newIndex = indexAt(screenX, screenY)
+            if (newIndex != hoveredIndex) {
+                hoveredIndex = newIndex
+                updateHighlight()
+            }
+        }
+
+        /**
+         * Resolve the release point. Returns the selected alt when the finger
+         * lifts over a candidate, or null when it lifts outside all of them.
+         * Does not dismiss; the caller dismisses after committing.
+         */
+        fun onRelease(screenX: Float, screenY: Float): String? {
+            if (dismissed) return null
+            val index = indexAt(screenX, screenY)
+            hoveredIndex = index
+            return if (index >= 0) alts[index] else null
+        }
+
+        /** Repaint candidate backgrounds so only [hoveredIndex] reads as active. */
+        fun updateHighlight() {
+            val tm = themeManager ?: return
+            for (i in buttons.indices) {
+                buttons[i].background = if (i == hoveredIndex) {
+                    tm.createFlatDrawable(tm.accent())
+                } else {
+                    tm.createKeyDrawable(tm.keyBg())
+                }
+            }
+        }
+
+        fun isShowing(): Boolean = !dismissed
+
+        fun dismiss() {
+            if (dismissed) return
+            dismissed = true
+            hoveredIndex = -1
+            onDismiss()
+        }
     }
 }

--- a/app/src/main/java/com/keyjawn/AltKeyPopup.kt
+++ b/app/src/main/java/com/keyjawn/AltKeyPopup.kt
@@ -95,8 +95,9 @@ class AltKeyPopup(
         val popupWidth = alts.size * (btnSize + 2 * margin) + (8 * density + 0.5f).toInt()
 
         // The popup top-left in screen space. showAsDropDown places the window at
-        // (anchorScreen + offset), so the same arithmetic gives candidate bounds
-        // without waiting for a layout pass.
+        // the anchor's bottom-left plus the offset, so the same arithmetic gives
+        // candidate bounds without waiting for a layout pass (see popupScreenTop
+        // for the vertical anchoring, clampPopupLeft for the horizontal clamp).
         val anchorLoc = IntArray(2)
         anchor.getLocationOnScreen(anchorLoc)
         val anchorScreenX = anchorLoc[0]
@@ -118,7 +119,7 @@ class AltKeyPopup(
         val requestedLeft = anchorScreenX + (anchor.width - popupWidth) / 2
         val clampedLeft = clampPopupLeft(requestedLeft, popupWidth, displayFrame.left, displayFrame.right)
         val clampedXOffset = clampedLeft - anchorScreenX
-        val popupTop = anchorScreenY + yOffset
+        val popupTop = popupScreenTop(anchorScreenY, anchor.height, yOffset)
 
         // Each candidate sits at popup-internal x = pad + i*(btnSize + 2*margin) +
         // margin (the LinearLayout's left padding, the preceding buttons' cells,
@@ -143,6 +144,18 @@ class AltKeyPopup(
     }
 
     companion object {
+        /**
+         * The popup's actual top edge in screen space. showAsDropDown anchors the
+         * window to the anchor's BOTTOM-left, so the real top is the anchor bottom
+         * ([anchorScreenY] + [anchorHeight]) plus [yOffset] -- not [anchorScreenY] +
+         * [yOffset]. The candidate hit-test rects derive from this value, so the
+         * naive form shifts every Rect up by one key height and a slide onto the
+         * visible candidate row hit-tests as outside, committing nothing. Pure
+         * arithmetic so it is unit-testable without a rendered popup.
+         */
+        fun popupScreenTop(anchorScreenY: Int, anchorHeight: Int, yOffset: Int): Int =
+            anchorScreenY + anchorHeight + yOffset
+
         /**
          * Clamp the requested popup left edge to the anchor window's visible display
          * frame -- the same frame showAsDropDown clips against -- so the precomputed

--- a/app/src/main/java/com/keyjawn/ClipboardHistoryManager.kt
+++ b/app/src/main/java/com/keyjawn/ClipboardHistoryManager.kt
@@ -13,6 +13,7 @@ class ClipboardHistoryManager(context: Context) {
     private val pinned = mutableListOf<String>()
     private val maxHistory = 30
     private val maxPinned = 15
+    private var destroyed = false
 
     private val clipListener = ClipboardManager.OnPrimaryClipChangedListener {
         val clip = clipboard.primaryClip ?: return@OnPrimaryClipChangedListener
@@ -82,6 +83,8 @@ class ClipboardHistoryManager(context: Context) {
     }
 
     fun destroy() {
+        if (destroyed) return
+        destroyed = true
         clipboard.removePrimaryClipChangedListener(clipListener)
     }
 

--- a/app/src/main/java/com/keyjawn/CtrlState.kt
+++ b/app/src/main/java/com/keyjawn/CtrlState.kt
@@ -6,6 +6,17 @@ enum class CtrlMode {
     LOCKED
 }
 
+/**
+ * Short transition tooltip for a [CtrlMode], or null when none should show.
+ * OFF returns null because it fires on every armed-key consumption, which would
+ * pop a tooltip on every keystroke.
+ */
+fun ctrlTransitionMessage(mode: CtrlMode): String? = when (mode) {
+    CtrlMode.ARMED -> "Ctrl armed"
+    CtrlMode.LOCKED -> "Ctrl locked"
+    CtrlMode.OFF -> null
+}
+
 class CtrlState {
 
     var mode: CtrlMode = CtrlMode.OFF

--- a/app/src/main/java/com/keyjawn/ExtraRowManager.kt
+++ b/app/src/main/java/com/keyjawn/ExtraRowManager.kt
@@ -254,6 +254,10 @@ class ExtraRowManager(
 
     private fun wireUpload() {
         val uploadButton = view.findViewById<View>(R.id.key_upload)
+        // Route upload status to the in-keyboard tooltip bar instead of a Toast.
+        // Upload results land after a picker round-trip, so use the longer duration
+        // (the same the voice permission path uses) to give the user time to read.
+        uploadHandler?.onShowStatus = { msg -> showTooltip(msg, 2500L) }
         if (menuPanelView != null && menuListView != null && themeManager != null && appPrefs != null) {
             val mp = MenuPanel(
                 panel = menuPanelView,

--- a/app/src/main/java/com/keyjawn/ExtraRowManager.kt
+++ b/app/src/main/java/com/keyjawn/ExtraRowManager.kt
@@ -79,12 +79,17 @@ class ExtraRowManager(
         }
     }
 
-    fun showTooltip(message: String, durationMs: Long = 1500L) {
+    fun showTooltip(message: String, durationMs: Long = 1500L, critical: Boolean = false) {
         val bar = tooltipBar ?: return
-        // Reuse the injected long-lived AppPrefs instead of constructing a new
-        // one (and a getSharedPreferences lookup) on every tooltip. Wiring paths
-        // that pass no appPrefs keep the prior default-on behavior.
-        if (appPrefs?.isTooltipsEnabled() == false) return
+        // The tooltips preference governs transient hints only (long-press
+        // discoverability, paste no-ops, state-transition feedback). Critical
+        // messages -- upload results and speech-recognition errors/permission
+        // prompts -- are the user's only feedback for an action they took, so
+        // they bypass the gate. Reuse the injected long-lived AppPrefs instead
+        // of constructing a new one (and a getSharedPreferences lookup) on every
+        // tooltip. Wiring paths that pass no appPrefs keep the prior default-on
+        // behavior.
+        if (!critical && appPrefs?.isTooltipsEnabled() == false) return
         tooltipDismissRunnable?.let { handler.removeCallbacks(it) }
         bar.text = message
         extraRow.visibility = View.GONE
@@ -268,7 +273,9 @@ class ExtraRowManager(
         // Route upload status to the in-keyboard tooltip bar instead of a Toast.
         // Upload results land after a picker round-trip, so use the longer duration
         // (the same the voice permission path uses) to give the user time to read.
-        uploadHandler?.onShowStatus = { msg -> showTooltip(msg, 2500L) }
+        // Critical: an upload's success/failure is its only feedback, so it must
+        // surface even when transient tooltips are disabled (was a Toast before).
+        uploadHandler?.onShowStatus = { msg -> showTooltip(msg, 2500L, critical = true) }
         if (menuPanelView != null && menuListView != null && themeManager != null && appPrefs != null) {
             val mp = MenuPanel(
                 panel = menuPanelView,
@@ -317,7 +324,9 @@ class ExtraRowManager(
             }
         } else {
             micButton.setOnClickListener {
-                showTooltip("Voice input not available")
+                // Critical: tapping the mic with no handler must explain why
+                // nothing happened, even when transient tooltips are off.
+                showTooltip("Voice input not available", critical = true)
             }
         }
 
@@ -325,7 +334,9 @@ class ExtraRowManager(
             voiceInputHandler?.stopListening()
         }
 
-        voiceInputHandler?.onPermissionNeeded = { msg -> showTooltip(msg, 2500L) }
+        // Critical: a permission prompt is actionable feedback the user must see
+        // to proceed, so it bypasses the transient-tooltips gate.
+        voiceInputHandler?.onPermissionNeeded = { msg -> showTooltip(msg, 2500L, critical = true) }
 
         voiceInputHandler?.listener = object : VoiceInputListener {
             override fun onVoiceStart() {
@@ -364,7 +375,9 @@ class ExtraRowManager(
 
             override fun onError(error: Int) {
                 voiceText?.text = ""
-                showTooltip(voiceErrorMessage(error))
+                // Critical: a speech-recognition failure is the only signal the
+                // user gets that dictation stopped, so it must always surface.
+                showTooltip(voiceErrorMessage(error), critical = true)
             }
         }
     }

--- a/app/src/main/java/com/keyjawn/ExtraRowManager.kt
+++ b/app/src/main/java/com/keyjawn/ExtraRowManager.kt
@@ -4,6 +4,8 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.text.SpannableString
+import android.text.style.UnderlineSpan
 import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
 import android.view.View
@@ -68,7 +70,12 @@ class ExtraRowManager(
 
         applyThemeColors()
 
-        ctrlState.onStateChanged = { mode -> updateCtrlAppearance(mode) }
+        ctrlState.onStateChanged = { mode ->
+            updateCtrlAppearance(mode)
+            // Brief transition feedback; OFF (fired on every armed-key consumption)
+            // returns null so it doesn't pop a tooltip on every keystroke.
+            ctrlTransitionMessage(mode)?.let { showTooltip(it, 900L) }
+        }
     }
 
     fun showTooltip(message: String, durationMs: Long = 1500L) {
@@ -365,6 +372,7 @@ class ExtraRowManager(
 
     private fun updateCtrlAppearance(mode: CtrlMode) {
         view.performHapticFeedback(HapticFeedbackConstants.CONTEXT_CLICK)
+        applyCtrlLabel(mode)
         val tm = themeManager
         if (tm != null) {
             when (mode) {
@@ -379,6 +387,21 @@ class ExtraRowManager(
                 CtrlMode.LOCKED -> R.drawable.key_bg_locked
             }
             ctrlButton.setBackgroundResource(bgRes)
+        }
+    }
+
+    /**
+     * Carries the locked distinction through shape, not color alone: LOCKED
+     * underlines the label so it survives color-blindness and dim screens, while
+     * OFF and ARMED keep the plain label.
+     */
+    private fun applyCtrlLabel(mode: CtrlMode) {
+        if (mode == CtrlMode.LOCKED) {
+            val locked = SpannableString("Ctrl")
+            locked.setSpan(UnderlineSpan(), 0, locked.length, SpannableString.SPAN_INCLUSIVE_EXCLUSIVE)
+            ctrlButton.text = locked
+        } else {
+            ctrlButton.text = "Ctrl"
         }
     }
 }

--- a/app/src/main/java/com/keyjawn/ExtraRowManager.kt
+++ b/app/src/main/java/com/keyjawn/ExtraRowManager.kt
@@ -324,7 +324,11 @@ class ExtraRowManager(
 
             override fun onVoiceStop() {
                 voiceBar?.visibility = View.GONE
-                extraRow.visibility = View.VISIBLE
+                // An error in onError() may have raised the tooltip bar in place
+                // of the extra row; don't clobber it by re-showing the extra row.
+                if (tooltipBar?.visibility != View.VISIBLE) {
+                    extraRow.visibility = View.VISIBLE
+                }
             }
 
             override fun onPartialResult(text: String) {
@@ -342,8 +346,9 @@ class ExtraRowManager(
                 voiceWaveform?.updateRms(rmsdB)
             }
 
-            override fun onError() {
+            override fun onError(error: Int) {
                 voiceText?.text = ""
+                showTooltip(voiceErrorMessage(error))
             }
         }
     }

--- a/app/src/main/java/com/keyjawn/ExtraRowManager.kt
+++ b/app/src/main/java/com/keyjawn/ExtraRowManager.kt
@@ -33,7 +33,8 @@ class ExtraRowManager(
     private val isFullFlavor: Boolean = false,
     private val onOpenSettings: (() -> Unit)? = null,
     private val onThemeChanged: (() -> Unit)? = null,
-    private val currentPackageProvider: (() -> String)? = null
+    private val currentPackageProvider: (() -> String)? = null,
+    private val onAutocorrectChanged: (() -> Unit)? = null
 ) {
 
     val ctrlState = CtrlState()
@@ -80,7 +81,10 @@ class ExtraRowManager(
 
     fun showTooltip(message: String, durationMs: Long = 1500L) {
         val bar = tooltipBar ?: return
-        if (!AppPrefs(view.context).isTooltipsEnabled()) return
+        // Reuse the injected long-lived AppPrefs instead of constructing a new
+        // one (and a getSharedPreferences lookup) on every tooltip. Wiring paths
+        // that pass no appPrefs keep the prior default-on behavior.
+        if (appPrefs?.isTooltipsEnabled() == false) return
         tooltipDismissRunnable?.let { handler.removeCallbacks(it) }
         bar.text = message
         extraRow.visibility = View.GONE
@@ -277,7 +281,8 @@ class ExtraRowManager(
                 onThemeChanged = { onThemeChanged?.invoke() },
                 onShowTooltip = { msg -> showTooltip(msg) },
                 currentPackageProvider = currentPackageProvider ?: { "unknown" },
-                onBottomPaddingChanged = { onBottomPaddingChanged?.invoke() }
+                onBottomPaddingChanged = { onBottomPaddingChanged?.invoke() },
+                onAutocorrectChanged = { onAutocorrectChanged?.invoke() }
             )
             menuPanel = mp
             uploadButton.setOnClickListener {

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -120,8 +120,11 @@ class KeyJawnService : InputMethodService() {
             onAutocorrectChanged = {
                 // Refresh the cached flag and re-render so the spacebar keycap
                 // ("space" vs "SPACE") reflects the new setting immediately.
+                // The layer is unchanged, so use the force path: a plain
+                // setLayer(currentLayer) is swallowed by render()'s same-layer
+                // guard and would leave the keycap stale.
                 qwertyKeyboard?.refreshAutocorrect()
-                qwertyKeyboard?.let { it.setLayer(it.currentLayer) }
+                qwertyKeyboard?.refreshRender()
             }
         )
         extraRowManager = erm
@@ -153,7 +156,9 @@ class KeyJawnService : InputMethodService() {
         qwertyKeyboard = qwerty
 
         erm.onQuickKeyChanged = { _ ->
-            qwerty.setLayer(qwerty.currentLayer)
+            // The quick-key label changes without a layer change, so force the
+            // rebuild past render()'s same-layer guard.
+            qwerty.refreshRender()
         }
 
         // Bottom padding: user-configurable via menu slider (default 0)

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -18,7 +18,9 @@ class KeyJawnService : InputMethodService() {
     private var voiceInputHandler: VoiceInputHandler? = null
     private var slashCommandRegistry: SlashCommandRegistry? = null
     private var uploadHandler: UploadHandler? = null
-    private var clipboardHistoryManager: ClipboardHistoryManager? = null
+    // internal (module-scoped) so unit tests in the same module can assert the
+    // manager instance is reused across input-view rebuilds. Not public.
+    internal var clipboardHistoryManager: ClipboardHistoryManager? = null
 
     companion object {
         var pendingUploadHandler: UploadHandler? = null
@@ -80,8 +82,11 @@ class KeyJawnService : InputMethodService() {
 
         // Reuse the hoisted clipboard manager (built once in onCreate) rather than
         // constructing a new one per rebuild, which would drop unpinned history.
-        val clipManager = clipboardHistoryManager ?: ClipboardHistoryManager(this).also {
-            clipboardHistoryManager = it
+        // onCreate() always runs before onCreateInputView(), so the manager must
+        // already exist here. Fail loudly if a future change drops the onCreate()
+        // construction instead of silently reconstructing per rebuild.
+        val clipManager = requireNotNull(clipboardHistoryManager) {
+            "clipboardHistoryManager must be created in onCreate() before onCreateInputView()"
         }
 
         val clipPanel = view.findViewById<ScrollView>(R.id.clipboard_panel)

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -32,16 +32,24 @@ class KeyJawnService : InputMethodService() {
             themeManager.currentTheme = KeyboardTheme.DARK
         }
         slashCommandRegistry = SlashCommandRegistry(this)
+        // The clipboard manager holds the user's unpinned clip history in memory and
+        // registers a system clipboard listener in its constructor. Build it once for
+        // the service lifetime so a theme-change input-view rebuild reuses the same
+        // instance instead of stranding the listener and resetting history to empty.
+        // It keeps no reference to the input view, so reuse is safe; ExtraRowManager
+        // re-wires the new view's clipboard panel to this instance on each rebuild.
+        clipboardHistoryManager = ClipboardHistoryManager(this)
     }
 
     override fun onCreateInputView(): View {
         // A theme change rebuilds the input view via setInputView(onCreateInputView()).
-        // Tear down the previous handlers before constructing replacements so their
-        // clipboard listener, IO scope, and SpeechRecognizer are released instead of
-        // leaking until the process dies. destroy() on each is idempotent.
+        // Tear down the previous voice and upload handlers before constructing
+        // replacements so their SpeechRecognizer and IO scope are released instead of
+        // leaking until the process dies. destroy() on each is idempotent. The
+        // clipboard manager is intentionally not torn down here: it is hoisted to
+        // onCreate() and reused so the user's unpinned clip history survives a reskin.
         voiceInputHandler?.destroy()
         uploadHandler?.destroy()
-        clipboardHistoryManager?.destroy()
         pendingUploadHandler = null
 
         val view = LayoutInflater.from(this).inflate(R.layout.keyboard_view, null)
@@ -65,8 +73,11 @@ class KeyJawnService : InputMethodService() {
         } else null
         uploadHandler = upload
 
-        val clipManager = ClipboardHistoryManager(this)
-        clipboardHistoryManager = clipManager
+        // Reuse the hoisted clipboard manager (built once in onCreate) rather than
+        // constructing a new one per rebuild, which would drop unpinned history.
+        val clipManager = clipboardHistoryManager ?: ClipboardHistoryManager(this).also {
+            clipboardHistoryManager = it
+        }
 
         val clipPanel = view.findViewById<ScrollView>(R.id.clipboard_panel)
         val clipList = view.findViewById<LinearLayout>(R.id.clipboard_list)

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -46,6 +46,11 @@ class KeyJawnService : InputMethodService() {
 
         val view = LayoutInflater.from(this).inflate(R.layout.keyboard_view, null)
         val tm = themeManager
+        // The theme can be changed from SettingsActivity (a separate
+        // ThemeManager instance writing the shared pref). The palette is cached,
+        // so re-resolve it from prefs before applying colors to pick up a change
+        // made while this service's view was torn down.
+        tm.refresh()
         val isFullFlavor = BuildConfig.FLAVOR == "full"
 
         // Apply theme colors to layout backgrounds
@@ -96,7 +101,12 @@ class KeyJawnService : InputMethodService() {
             },
             onThemeChanged = { setInputView(onCreateInputView()) },
             currentPackageProvider = { qwertyKeyboard?.currentPackage ?: "unknown" },
-            onAutocorrectChanged = { qwertyKeyboard?.refreshAutocorrect() }
+            onAutocorrectChanged = {
+                // Refresh the cached flag and re-render so the spacebar keycap
+                // ("space" vs "SPACE") reflects the new setting immediately.
+                qwertyKeyboard?.refreshAutocorrect()
+                qwertyKeyboard?.let { it.setLayer(it.currentLayer) }
+            }
         )
         extraRowManager = erm
 
@@ -144,6 +154,13 @@ class KeyJawnService : InputMethodService() {
 
     override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
+
+        // If the theme was changed from settings while this view was cached,
+        // rebuild the input view so the new theme applies on this open (the
+        // settings screen tells the user it applies on the next keyboard open).
+        if (themeManager.isThemeStale()) {
+            setInputView(onCreateInputView())
+        }
 
         // Pass EditorInfo to keyboard before updatePackage triggers render
         val imeAction = (info?.imeOptions ?: 0) and EditorInfo.IME_MASK_ACTION

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -35,6 +35,15 @@ class KeyJawnService : InputMethodService() {
     }
 
     override fun onCreateInputView(): View {
+        // A theme change rebuilds the input view via setInputView(onCreateInputView()).
+        // Tear down the previous handlers before constructing replacements so their
+        // clipboard listener, IO scope, and SpeechRecognizer are released instead of
+        // leaking until the process dies. destroy() on each is idempotent.
+        voiceInputHandler?.destroy()
+        uploadHandler?.destroy()
+        clipboardHistoryManager?.destroy()
+        pendingUploadHandler = null
+
         val view = LayoutInflater.from(this).inflate(R.layout.keyboard_view, null)
         val tm = themeManager
         val isFullFlavor = BuildConfig.FLAVOR == "full"

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -52,6 +52,12 @@ class KeyJawnService : InputMethodService() {
         // onCreate() and reused so the user's unpinned clip history survives a reskin.
         voiceInputHandler?.destroy()
         uploadHandler?.destroy()
+        // Nulling pendingUploadHandler here cannot strand an in-flight picker
+        // result. This method and PickerActivity.onActivityResult both run on the
+        // main thread, and for the full flavor this same synchronous call repoints
+        // pendingUploadHandler to the freshly built handler below before returning.
+        // A result delivered after a rebuild therefore always observes the live
+        // handler (wired to the current input connection), never this transient null.
         pendingUploadHandler = null
 
         val view = LayoutInflater.from(this).inflate(R.layout.keyboard_view, null)

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -95,7 +95,8 @@ class KeyJawnService : InputMethodService() {
                 startActivity(intent)
             },
             onThemeChanged = { setInputView(onCreateInputView()) },
-            currentPackageProvider = { qwertyKeyboard?.currentPackage ?: "unknown" }
+            currentPackageProvider = { qwertyKeyboard?.currentPackage ?: "unknown" },
+            onAutocorrectChanged = { qwertyKeyboard?.refreshAutocorrect() }
         )
         extraRowManager = erm
 

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -116,7 +116,8 @@ class KeyJawnService : InputMethodService() {
                 onDismissedEmpty = {
                     val ic = currentInputConnection ?: return@SlashCommandPopup
                     keySender.sendText(ic, "/")
-                }
+                },
+                themeManager = tm
             )
         } else null
 

--- a/app/src/main/java/com/keyjawn/KeyPreview.kt
+++ b/app/src/main/java/com/keyjawn/KeyPreview.kt
@@ -19,7 +19,11 @@ class KeyPreview(
 
     private val density = container.context.resources.displayMetrics.density
     private val previewSize = (48 * density + 0.5f).toInt()
-    private var currentAnimator: AnimatorSet? = null
+
+    // The background drawable and bounce animators depend only on the theme,
+    // which does not change between presses, so build them once and reuse
+    // them on every show() instead of reallocating per keystroke.
+    private val bounceAnimator: AnimatorSet
 
     init {
         previewView = TextView(container.context).apply {
@@ -30,24 +34,41 @@ class KeyPreview(
             layoutParams = FrameLayout.LayoutParams(previewSize, previewSize)
             elevation = 12 * density
         }
-        updateBackground()
+        previewView.background = buildBackground()
+
+        val scaleX = ObjectAnimator.ofFloat(previewView, "scaleX", 0.8f, 1f)
+        val scaleY = ObjectAnimator.ofFloat(previewView, "scaleY", 0.8f, 1f)
+        bounceAnimator = AnimatorSet().apply {
+            playTogether(scaleX, scaleY)
+            duration = 100
+            interpolator = OvershootInterpolator(1.5f)
+        }
+
         container.addView(previewView)
     }
 
-    private fun updateBackground() {
-        val bg = GradientDrawable().apply {
+    private fun buildBackground(): GradientDrawable {
+        return GradientDrawable().apply {
             shape = GradientDrawable.RECTANGLE
             cornerRadius = 8 * density
             setColor(themeManager.keyBg())
             setStroke((1 * density + 0.5f).toInt(), themeManager.keyHint())
         }
-        previewView.background = bg
+    }
+
+    /**
+     * Rebuilds the themed background and text color. Call when the theme
+     * changes if this KeyPreview is reused across a theme switch. The current
+     * service recreates the whole input view on theme change, so this is here
+     * for callers that keep the same instance.
+     */
+    fun refresh() {
+        previewView.background = buildBackground()
+        previewView.setTextColor(themeManager.keyText())
     }
 
     fun show(anchor: View, label: String) {
-        currentAnimator?.cancel()
-        updateBackground()
-        previewView.setTextColor(themeManager.keyText())
+        bounceAnimator.cancel()
 
         previewView.text = label
 
@@ -72,23 +93,16 @@ class KeyPreview(
 
         previewView.visibility = View.VISIBLE
 
-        // Bounce animation: scale from 0.8 to 1.0 with overshoot
+        // Bounce animation: scale from 0.8 to 1.0 with overshoot. The animator
+        // is built once in init and replayed here, so no objects are allocated
+        // per keystroke.
         previewView.scaleX = 0.8f
         previewView.scaleY = 0.8f
-        val scaleX = ObjectAnimator.ofFloat(previewView, "scaleX", 0.8f, 1f)
-        val scaleY = ObjectAnimator.ofFloat(previewView, "scaleY", 0.8f, 1f)
-        val animator = AnimatorSet().apply {
-            playTogether(scaleX, scaleY)
-            duration = 100
-            interpolator = OvershootInterpolator(1.5f)
-        }
-        currentAnimator = animator
-        animator.start()
+        bounceAnimator.start()
     }
 
     fun hide() {
-        currentAnimator?.cancel()
-        currentAnimator = null
+        bounceAnimator.cancel()
         previewView.visibility = View.GONE
         previewView.alpha = 1f
     }

--- a/app/src/main/java/com/keyjawn/KeyPreview.kt
+++ b/app/src/main/java/com/keyjawn/KeyPreview.kt
@@ -56,17 +56,6 @@ class KeyPreview(
         }
     }
 
-    /**
-     * Rebuilds the themed background and text color. Call when the theme
-     * changes if this KeyPreview is reused across a theme switch. The current
-     * service recreates the whole input view on theme change, so this is here
-     * for callers that keep the same instance.
-     */
-    fun refresh() {
-        previewView.background = buildBackground()
-        previewView.setTextColor(themeManager.keyText())
-    }
-
     fun show(anchor: View, label: String) {
         bounceAnimator.cancel()
 

--- a/app/src/main/java/com/keyjawn/MenuPanel.kt
+++ b/app/src/main/java/com/keyjawn/MenuPanel.kt
@@ -20,7 +20,8 @@ class MenuPanel(
     private val onThemeChanged: () -> Unit,
     private val onShowTooltip: (String) -> Unit,
     private val currentPackageProvider: () -> String,
-    private val onBottomPaddingChanged: () -> Unit = {}
+    private val onBottomPaddingChanged: () -> Unit = {},
+    private val onAutocorrectChanged: () -> Unit = {}
 ) {
 
     private val context: Context get() = panel.context
@@ -127,7 +128,11 @@ class MenuPanel(
         )
         addToggleRow("Autocorrect", fullOnly = false,
             isOn = { appPrefs.isAutocorrectEnabled(currentPackageProvider()) },
-            onToggle = { appPrefs.toggleAutocorrect(currentPackageProvider()); populateMenu() }
+            onToggle = {
+                appPrefs.toggleAutocorrect(currentPackageProvider())
+                onAutocorrectChanged()
+                populateMenu()
+            }
         )
         addToggleRow("Tooltips", fullOnly = true,
             isOn = { appPrefs.isTooltipsEnabled() },

--- a/app/src/main/java/com/keyjawn/MenuPanel.kt
+++ b/app/src/main/java/com/keyjawn/MenuPanel.kt
@@ -312,11 +312,10 @@ class MenuPanel(
         val selected = themeManager.currentTheme
 
         for (theme in themeManager.getAvailableThemes()) {
-            val preview = ThemeManager(context)
-            preview.currentTheme = theme
-            val bgColor = preview.keyboardBg()
-            val keyColor = preview.keyBg()
-            val textColor = preview.keyText()
+            val palette = themeManager.swatch(theme)
+            val bgColor = palette.keyboardBg
+            val keyColor = palette.keyBg
+            val textColor = palette.keyText
 
             val swatch = LinearLayout(context).apply {
                 orientation = LinearLayout.VERTICAL
@@ -374,9 +373,6 @@ class MenuPanel(
 
             strip.addView(swatch)
         }
-
-        // Restore real theme after creating previews
-        themeManager.currentTheme = selected
 
         list.addView(strip)
         addDivider()

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -184,7 +184,8 @@ class QwertyKeyboard(
         // Character keys with alt characters render their key background on the
         // wrapping FrameLayout, so the button itself stays transparent. Resolve
         // alts up front and skip building a button background that would only be
-        // discarded for those keys.
+        // discarded for those keys; the button's platform-default background is
+        // cleared instead so the themed frame shows through.
         val alts = if (key.output is KeyOutput.Character) AltKeyMappings.getAlts(key.label) else null
         val buttonHasOwnBackground = alts == null
         val button = Button(context).apply {
@@ -193,11 +194,15 @@ class QwertyKeyboard(
             if (tm != null) {
                 if (buttonHasOwnBackground) {
                     background = tm.createKeyDrawable(tm.keyBg())
+                } else {
+                    background = null
                 }
                 setTextColor(tm.keyText())
             } else {
                 if (buttonHasOwnBackground) {
                     setBackgroundResource(R.drawable.key_bg)
+                } else {
+                    background = null
                 }
                 setTextColor(context.getColor(R.color.key_text))
             }

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -70,10 +70,22 @@ class QwertyKeyboard(
     // Touch drag-off long-press handler
     private val longPressHandler = Handler(Looper.getMainLooper())
 
+    // Cached per-package autocorrect flag, read from prefs only at the boundary
+    // events that can change it (package change and the autocorrect toggle)
+    // instead of on every render and Space-key handler call. refreshAutocorrect()
+    // is the single update point so every write site invalidates the same field.
+    private var autocorrectOn: Boolean = appPrefs?.isAutocorrectEnabled(currentPackage) ?: false
+
     fun updatePackage(packageName: String) {
         if (packageName == currentPackage) return
         currentPackage = packageName
+        refreshAutocorrect()
         render()
+    }
+
+    /** Re-read the autocorrect flag for the current package into the cache. */
+    fun refreshAutocorrect() {
+        autocorrectOn = appPrefs?.isAutocorrectEnabled(currentPackage) ?: false
     }
 
     fun resetTransientState() {
@@ -95,9 +107,7 @@ class QwertyKeyboard(
         }
     }
 
-    fun isAutocorrectOn(): Boolean {
-        return appPrefs?.isAutocorrectEnabled(currentPackage) ?: false
-    }
+    fun isAutocorrectOn(): Boolean = autocorrectOn
 
     fun setLayer(layer: Int) {
         currentLayer = layer
@@ -284,6 +294,7 @@ class QwertyKeyboard(
                 onTap = { handleKeyPress(key) },
                 onLongPress = {
                     val enabled = appPrefs?.toggleAutocorrect(currentPackage) ?: false
+                    autocorrectOn = enabled
                     val state = if (enabled) "on" else "off"
                     extraRowManager.showTooltip("Autocorrect $state")
                     render()

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -166,14 +166,24 @@ class QwertyKeyboard(
     private fun createKeyView(key: Key): View {
         val context = container.context
         val tm = themeManager
+        // Character keys with alt characters render their key background on the
+        // wrapping FrameLayout, so the button itself stays transparent. Resolve
+        // alts up front and skip building a button background that would only be
+        // discarded for those keys.
+        val alts = if (key.output is KeyOutput.Character) AltKeyMappings.getAlts(key.label) else null
+        val buttonHasOwnBackground = alts == null
         val button = Button(context).apply {
             text = key.label
             isAllCaps = false
             if (tm != null) {
-                background = tm.createKeyDrawable(tm.keyBg())
+                if (buttonHasOwnBackground) {
+                    background = tm.createKeyDrawable(tm.keyBg())
+                }
                 setTextColor(tm.keyText())
             } else {
-                setBackgroundResource(R.drawable.key_bg)
+                if (buttonHasOwnBackground) {
+                    setBackgroundResource(R.drawable.key_bg)
+                }
                 setTextColor(context.getColor(R.color.key_text))
             }
             gravity = Gravity.CENTER
@@ -292,7 +302,7 @@ class QwertyKeyboard(
         }
 
         // Character key touch handling with drag-off cancellation (item 4)
-        val alts = if (key.output is KeyOutput.Character) AltKeyMappings.getAlts(key.label) else null
+        // (alts was resolved at the top of this method.)
         if (key.output is KeyOutput.Character) {
             val previewLabel = key.label
             var touchStarted = false
@@ -359,10 +369,11 @@ class QwertyKeyboard(
             }
         }
 
-        // Wrap character keys that have alts in a FrameLayout with a hint label
+        // Wrap character keys that have alts in a FrameLayout with a hint label.
+        // The button background was never built for these keys (see top of
+        // createKeyView); the key surface lives on the wrapping frame instead.
         if (key.output is KeyOutput.Character && alts != null) {
             val hintChar = if (alts.size == 1) alts[0] else alts[0]
-            button.background = null
             val frame = FrameLayout(context).apply {
                 if (tm != null) {
                     background = tm.createKeyDrawable(tm.keyBg())

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -66,6 +66,7 @@ class QwertyKeyboard(
     private val longPressHandler = Handler(Looper.getMainLooper())
 
     fun updatePackage(packageName: String) {
+        if (packageName == currentPackage) return
         currentPackage = packageName
         render()
     }

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -38,6 +38,28 @@ class QwertyKeyboard(
     private val altKeyPopup = AltKeyPopup(keySender, inputConnectionProvider, themeManager)
     private var quickKeyButton: Button? = null
 
+    // The layer the current view tree was last built for. render() compares it
+    // against currentLayer and bails when nothing structural changed, so the most
+    // common interactions (same-layer re-renders) do not tear the grid down.
+    // -1 means "nothing built yet" so the first render always runs.
+    private var renderedLayer: Int = -1
+
+    // One holder per Character key in the built grid, in row/col order. The holder
+    // is the single source of truth for what a character key currently shows and
+    // emits: its touch listener dereferences holder.key at touch time (never a
+    // build-time capture), so the visible label and the sent character cannot
+    // diverge. applyShiftCase() mutates holder.key in place on a shift toggle.
+    private class CharKeyHolder(
+        val rowIndex: Int,
+        val colIndex: Int,
+        val button: Button,
+        var key: Key
+    ) {
+        var hint: TextView? = null
+    }
+
+    private val charHolders = mutableListOf<CharKeyHolder>()
+
     // Display density never changes for the keyboard view's lifetime (the view
     // is rebuilt on a configuration change), so cache it once instead of reading
     // resources.displayMetrics on every dpToPx call across every key per render.
@@ -80,7 +102,11 @@ class QwertyKeyboard(
         if (packageName == currentPackage) return
         currentPackage = packageName
         refreshAutocorrect()
-        render()
+        // Per-package autocorrect can flip the spacebar keycap ("space" vs
+        // "SPACE") without a layer change, so force a re-render even though the
+        // layer is unchanged. The same-package early-return above means this only
+        // runs on a genuine package switch.
+        refreshRender()
     }
 
     /** Re-read the autocorrect flag for the current package into the cache. */
@@ -110,16 +136,50 @@ class QwertyKeyboard(
     fun isAutocorrectOn(): Boolean = autocorrectOn
 
     fun setLayer(layer: Int) {
+        val previous = currentLayer
         currentLayer = layer
-        render()
+        // A shift toggle (lower<->upper) swaps only the per-key labels; the grid
+        // structure is position-identical between the two layers. When the other
+        // case is already built, relabel the existing letter buttons in place
+        // instead of tearing the grid down. Any other transition (to/from the
+        // symbol layers) swaps the whole key SET and key COUNT, so it must do a
+        // full rebuild.
+        val isShiftToggle =
+            (previous == KeyboardLayouts.LAYER_LOWER && layer == KeyboardLayouts.LAYER_UPPER) ||
+            (previous == KeyboardLayouts.LAYER_UPPER && layer == KeyboardLayouts.LAYER_LOWER)
+        if (isShiftToggle && charHolders.isNotEmpty()) {
+            applyShiftCase(layer)
+        } else {
+            render()
+        }
     }
 
-    private fun render() {
+    /**
+     * Force a rebuild of the grid even when the layer is unchanged. Use this from
+     * any caller that changes what a key DISPLAYS without changing the layer (the
+     * spacebar "space"/"SPACE" keycap, the quick-key label). A plain setLayer to
+     * the current layer is a no-op under render()'s same-layer guard, so those
+     * refreshers must come through here.
+     */
+    fun refreshRender() = render(force = true)
+
+    /**
+     * Rebuilds the QWERTY grid from scratch for [currentLayer].
+     *
+     * Guarded so a same-layer call is a no-op: re-rendering the layer that is
+     * already on screen would tear down and re-inflate ~34 views for nothing.
+     * Any caller that needs to refresh displayed content WITHOUT a layer change
+     * (spacebar keycap, quick-key label) must use [refreshRender] / force = true,
+     * not a setLayer(currentLayer) that this guard would swallow.
+     */
+    private fun render(force: Boolean = false) {
+        if (!force && currentLayer == renderedLayer) return
         container.removeAllViews()
+        charHolders.clear()
         val layout = KeyboardLayouts.getLayer(currentLayer)
         val context = container.context
 
-        for (row in layout) {
+        for ((rowIndex, row) in layout.withIndex()) {
             val rowLayout = LinearLayout(context).apply {
                 orientation = LinearLayout.HORIZONTAL
                 layoutParams = LinearLayout.LayoutParams(
@@ -131,8 +191,8 @@ class QwertyKeyboard(
                 setPadding(hPad, vPad, hPad, vPad)
             }
 
-            for (key in row) {
-                val keyView = createKeyView(key)
+            for ((colIndex, key) in row.withIndex()) {
+                val keyView = createKeyView(key, rowIndex, colIndex)
                 val params = LinearLayout.LayoutParams(0, dpToPx(48), key.weight)
                 val margin = dpToPx(2)
                 params.setMargins(margin, margin, margin, margin)
@@ -142,6 +202,7 @@ class QwertyKeyboard(
 
             container.addView(rowLayout)
         }
+        renderedLayer = currentLayer
 
         // Swipe gestures on each row's padding area (not on the container,
         // which can interfere with child button touch dispatch)
@@ -178,7 +239,7 @@ class QwertyKeyboard(
         }
     }
 
-    private fun createKeyView(key: Key): View {
+    private fun createKeyView(key: Key, rowIndex: Int, colIndex: Int): View {
         val context = container.context
         val tm = themeManager
         // Character keys with alt characters render their key background on the
@@ -302,7 +363,10 @@ class QwertyKeyboard(
                     autocorrectOn = enabled
                     val state = if (enabled) "on" else "off"
                     extraRowManager.showTooltip("Autocorrect $state")
-                    render()
+                    // The spacebar keycap ("space" vs "SPACE") tracks autocorrect
+                    // but the layer is unchanged, so force the rebuild past the
+                    // same-layer guard.
+                    refreshRender()
                 },
                 hapticView = container,
                 appPrefs = appPrefs
@@ -325,7 +389,13 @@ class QwertyKeyboard(
         // Character key touch handling with drag-off cancellation (item 4)
         // (alts was resolved at the top of this method.)
         if (key.output is KeyOutput.Character) {
-            val previewLabel = key.label
+            // Register this character key so a shift toggle can relabel it in
+            // place. holder.key is the single source of truth: the listener below
+            // reads holder.key at touch time, never the build-time `key`, so the
+            // visible label and the emitted character stay in sync after a
+            // lower<->upper relabel.
+            val holder = CharKeyHolder(rowIndex, colIndex, button, key)
+            charHolders.add(holder)
             var touchStarted = false
             var longPressRunnable: Runnable? = null
 
@@ -335,18 +405,20 @@ class QwertyKeyboard(
                     MotionEvent.ACTION_DOWN -> {
                         touchStarted = true
                         v.isPressed = true
-                        keyPreview?.show(v, previewLabel)
+                        keyPreview?.show(v, holder.key.label)
 
-                        // Schedule long-press for alt keys
-                        if (alts != null) {
+                        // Schedule long-press for alt keys. Resolve alts from the
+                        // CURRENT label so the case matches what is on screen.
+                        val currentAlts = AltKeyMappings.getAlts(holder.key.label)
+                        if (currentAlts != null) {
                             val runnable = Runnable {
                                 touchStarted = false
                                 keyPreview?.hide()
-                                if (alts.size == 1) {
+                                if (currentAlts.size == 1) {
                                     val ic = inputConnectionProvider() ?: return@Runnable
-                                    keySender.sendText(ic, alts[0])
+                                    keySender.sendText(ic, currentAlts[0])
                                 } else {
-                                    altKeyPopup.show(v, alts)
+                                    altKeyPopup.show(v, currentAlts)
                                 }
                             }
                             longPressRunnable = runnable
@@ -371,7 +443,7 @@ class QwertyKeyboard(
                         longPressRunnable?.let { longPressHandler.removeCallbacks(it) }
                         longPressRunnable = null
                         if (touchStarted && v.isPressed) {
-                            handleKeyPress(key)
+                            handleKeyPress(holder.key)
                         }
                         touchStarted = false
                         v.isPressed = false
@@ -388,40 +460,42 @@ class QwertyKeyboard(
                     else -> false
                 }
             }
-        }
 
-        // Wrap character keys that have alts in a FrameLayout with a hint label.
-        // The button background was never built for these keys (see top of
-        // createKeyView); the key surface lives on the wrapping frame instead.
-        if (key.output is KeyOutput.Character && alts != null) {
-            val hintChar = if (alts.size == 1) alts[0] else alts[0]
-            val frame = FrameLayout(context).apply {
-                if (tm != null) {
-                    background = tm.createKeyDrawable(tm.keyBg())
-                } else {
-                    setBackgroundResource(R.drawable.key_bg)
+            // Wrap character keys that have alts in a FrameLayout with a hint
+            // label. The button background was never built for these keys (see top
+            // of createKeyView); the key surface lives on the wrapping frame. The
+            // hint TextView is captured on the holder so applyShiftCase() can
+            // update it to the case-correct alt in place.
+            if (alts != null) {
+                val frame = FrameLayout(context).apply {
+                    if (tm != null) {
+                        background = tm.createKeyDrawable(tm.keyBg())
+                    } else {
+                        setBackgroundResource(R.drawable.key_bg)
+                    }
                 }
-            }
-            button.layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT
-            )
-            frame.addView(button)
-            val hint = TextView(context).apply {
-                text = hintChar
-                setTextColor(if (tm != null) tm.keyHint() else context.getColor(R.color.key_hint))
-                setTextSize(TypedValue.COMPLEX_UNIT_SP, 9f)
-                layoutParams = FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.WRAP_CONTENT,
-                    FrameLayout.LayoutParams.WRAP_CONTENT,
-                    Gravity.TOP or Gravity.END
-                ).apply {
-                    topMargin = dpToPx(1)
-                    marginEnd = dpToPx(2)
+                button.layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT
+                )
+                frame.addView(button)
+                val hint = TextView(context).apply {
+                    text = alts[0]
+                    setTextColor(if (tm != null) tm.keyHint() else context.getColor(R.color.key_hint))
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, 9f)
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        Gravity.TOP or Gravity.END
+                    ).apply {
+                        topMargin = dpToPx(1)
+                        marginEnd = dpToPx(2)
+                    }
                 }
+                frame.addView(hint)
+                holder.hint = hint
+                return frame
             }
-            frame.addView(hint)
-            return frame
         }
 
         return button
@@ -581,6 +655,42 @@ class QwertyKeyboard(
                 ShiftState.CAPS_LOCK -> button.setBackgroundResource(R.drawable.key_bg_locked)
             }
         }
+    }
+
+    /**
+     * Relabels the existing character buttons in place for a lower<->upper shift
+     * toggle, instead of tearing the grid down and rebuilding it. The lower and
+     * upper layers are position-identical, so every holder's (rowIndex, colIndex)
+     * maps to a Character key in the target layer and only its label, alt hint,
+     * and the holder's key binding change. No view is added or removed, so no
+     * relayout is needed.
+     *
+     * Safety net: if any holder's position falls outside the target layer or the
+     * target key at that position is not a Character (a structural divergence
+     * between the two layers that does not exist today but a future layout edit
+     * could introduce), fall back to a full forced rebuild so the grid can never
+     * end up with a stale or mismatched key. This keeps the core typing path
+     * correct over a fragile fast path.
+     */
+    private fun applyShiftCase(targetLayer: Int) {
+        val layout = KeyboardLayouts.getLayer(targetLayer)
+        for (holder in charHolders) {
+            val row = layout.getOrNull(holder.rowIndex)
+            val targetKey = row?.getOrNull(holder.colIndex)
+            if (targetKey == null || targetKey.output !is KeyOutput.Character) {
+                render(force = true)
+                return
+            }
+            holder.key = targetKey
+            holder.button.text = targetKey.label
+            holder.hint?.let { hint ->
+                AltKeyMappings.getAlts(targetKey.label)?.let { alts ->
+                    hint.text = alts[0]
+                }
+            }
+        }
+        renderedLayer = targetLayer
+        updateShiftAppearance(shiftButton)
     }
 
     private fun dpToPx(dp: Int): Int {

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -95,6 +95,16 @@ class QwertyKeyboard(
     // EditorInfo inputType hints (item 11)
     private var inputTypeQuickKeyOverride: String? = null
 
+    // Set by updateImeAction/updateInputType when the editor-derived display state
+    // (adaptive Enter label, input-type quick-key override) actually changes.
+    // updatePackage consumes it to force one render on a same-package focus switch
+    // -- e.g. moving from a text field to a search or URL field in the same app --
+    // which the #29 same-package early-return would otherwise skip, leaving a stale
+    // Enter label or quick key. Change-detection in the setters keeps a refocus
+    // with identical editor state from forcing a needless rebuild. Cleared by
+    // render() once a rebuild consumes it.
+    private var editorDisplayDirty = false
+
     // Touch drag-off long-press handler
     private val longPressHandler = Handler(Looper.getMainLooper())
 
@@ -108,14 +118,21 @@ class QwertyKeyboard(
     private var previewHideRunnable: Runnable? = null
 
     fun updatePackage(packageName: String) {
-        if (packageName == currentPackage) return
-        currentPackage = packageName
-        refreshAutocorrect()
-        // Per-package autocorrect can flip the spacebar keycap ("space" vs
-        // "SPACE") without a layer change, so force a re-render even though the
-        // layer is unchanged. The same-package early-return above means this only
-        // runs on a genuine package switch.
-        refreshRender()
+        val packageChanged = packageName != currentPackage
+        if (packageChanged) {
+            currentPackage = packageName
+            refreshAutocorrect()
+        }
+        // This is the single render point for a focus change: onStartInputView
+        // calls updateImeAction/updateInputType first (recording any editor-state
+        // change), then this. Render once when the package changed (per-package
+        // autocorrect can flip the spacebar "space"/"SPACE" keycap) OR the editor
+        // display state changed (adaptive Enter label, input-type quick-key
+        // override). A same-package refocus with no change keeps the existing
+        // grid (issue #29). render() clears editorDisplayDirty.
+        if (packageChanged || editorDisplayDirty) {
+            refreshRender()
+        }
     }
 
     /** Re-read the autocorrect flag for the current package into the cache. */
@@ -129,16 +146,25 @@ class QwertyKeyboard(
     }
 
     fun updateImeAction(action: Int, flags: Int) {
-        currentImeAction = action
-        currentImeFlags = flags
+        // Mark the display dirty only on a real change so a refocus with the same
+        // action does not force a rebuild (preserves the #29 same-package skip).
+        if (action != currentImeAction || flags != currentImeFlags) {
+            currentImeAction = action
+            currentImeFlags = flags
+            editorDisplayDirty = true
+        }
     }
 
     fun updateInputType(inputType: Int) {
         val variation = inputType and InputType.TYPE_MASK_VARIATION
-        inputTypeQuickKeyOverride = when (variation) {
+        val override = when (variation) {
             InputType.TYPE_TEXT_VARIATION_URI -> "/"
             InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS -> "@"
             else -> null
+        }
+        if (override != inputTypeQuickKeyOverride) {
+            inputTypeQuickKeyOverride = override
+            editorDisplayDirty = true
         }
     }
 
@@ -212,6 +238,9 @@ class QwertyKeyboard(
             container.addView(rowLayout)
         }
         renderedLayer = currentLayer
+        // This rebuild reflects the current editor state (Enter label, quick-key
+        // override), so any pending editor-display change is now consumed.
+        editorDisplayDirty = false
 
         // Swipe gestures on each row's padding area (not on the container,
         // which can interfere with child button touch dispatch)

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -421,8 +421,7 @@ class QwertyKeyboard(
             is KeyOutput.Character -> {
                 val ctrlActive = extraRowManager.isCtrlActive()
                 if (ctrlActive) {
-                    val charCode = key.output.char.lowercase()[0]
-                    val keyCode = KeyEvent.keyCodeFromString("KEYCODE_${charCode.uppercaseChar()}")
+                    val keyCode = ctrlKeyCode(key.output.char.firstOrNull() ?: ' ')
                     if (keyCode == KeyEvent.KEYCODE_UNKNOWN) {
                         keySender.sendText(ic, key.output.char)
                     } else {
@@ -555,5 +554,22 @@ class QwertyKeyboard(
     private fun dpToPx(dp: Int): Int {
         val density = container.context.resources.displayMetrics.density
         return (dp * density + 0.5f).toInt()
+    }
+
+    companion object {
+        /**
+         * Maps a character to its Ctrl-combo key code without a reflective
+         * KeyEvent.keyCodeFromString parse. Letters map directly via the
+         * contiguous KEYCODE_A..KEYCODE_Z range; any non-letter returns
+         * KEYCODE_UNKNOWN so the caller falls back to sending plain text.
+         */
+        fun ctrlKeyCode(c: Char): Int {
+            val lower = c.lowercaseChar()
+            return if (lower in 'a'..'z') {
+                KeyEvent.KEYCODE_A + (lower - 'a')
+            } else {
+                KeyEvent.KEYCODE_UNKNOWN
+            }
+        }
     }
 }

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -38,6 +38,11 @@ class QwertyKeyboard(
     private val altKeyPopup = AltKeyPopup(keySender, inputConnectionProvider, themeManager)
     private var quickKeyButton: Button? = null
 
+    // Display density never changes for the keyboard view's lifetime (the view
+    // is rebuilt on a configuration change), so cache it once instead of reading
+    // resources.displayMetrics on every dpToPx call across every key per render.
+    private val density: Float = container.context.resources.displayMetrics.density
+
     var currentLayer: Int = KeyboardLayouts.LAYER_LOWER
         private set
 
@@ -563,7 +568,6 @@ class QwertyKeyboard(
     }
 
     private fun dpToPx(dp: Int): Int {
-        val density = container.context.resources.displayMetrics.density
         return (dp * density + 0.5f).toInt()
     }
 

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -38,6 +38,12 @@ class QwertyKeyboard(
     private val altKeyPopup = AltKeyPopup(keySender, inputConnectionProvider, themeManager)
     private var quickKeyButton: Button? = null
 
+    // The slide-and-release session for the currently open alt-key popup, or null
+    // when no multi-alt popup is up. The character key's touch listener routes the
+    // tracked finger's MOVE/UP into it. Exposed for tests to drive the gesture.
+    internal var currentSlideSession: AltKeyPopup.SlideSession? = null
+        private set
+
     // The layer the current view tree was last built for. render() compares it
     // against currentLayer and bails when nothing structural changed, so the most
     // common interactions (same-layer re-renders) do not tear the grid down.
@@ -398,12 +404,20 @@ class QwertyKeyboard(
             charHolders.add(holder)
             var touchStarted = false
             var longPressRunnable: Runnable? = null
+            // Slide-and-release state. slideSession is non-null once a multi-alt
+            // popup is open for this key; while it is, the tracked finger's
+            // MOVE/UP route into the popup instead of typing the base char.
+            var slideSession: AltKeyPopup.SlideSession? = null
+            var activePointerId = MotionEvent.INVALID_POINTER_ID
+            var anchorScreenX = 0
+            var anchorScreenY = 0
 
             button.setOnClickListener(null) // Remove default click -- handled by touch
             button.setOnTouchListener { v, event ->
-                when (event.action) {
+                when (event.actionMasked) {
                     MotionEvent.ACTION_DOWN -> {
                         touchStarted = true
+                        activePointerId = event.getPointerId(0)
                         v.isPressed = true
                         keyPreview?.show(v, holder.key.label)
 
@@ -418,7 +432,16 @@ class QwertyKeyboard(
                                     val ic = inputConnectionProvider() ?: return@Runnable
                                     keySender.sendText(ic, currentAlts[0])
                                 } else {
-                                    altKeyPopup.show(v, currentAlts)
+                                    // Open the slide popup and capture the anchor's
+                                    // screen position so MOVE can convert key-local
+                                    // pointer coords into the popup's screen space.
+                                    val loc = IntArray(2)
+                                    v.getLocationOnScreen(loc)
+                                    anchorScreenX = loc[0]
+                                    anchorScreenY = loc[1]
+                                    val session = altKeyPopup.openForSlide(v, currentAlts)
+                                    slideSession = session
+                                    currentSlideSession = session
                                 }
                             }
                             longPressRunnable = runnable
@@ -427,14 +450,51 @@ class QwertyKeyboard(
                         true
                     }
                     MotionEvent.ACTION_MOVE -> {
-                        val inBounds = event.x >= 0 && event.x <= v.width &&
-                            event.y >= -v.height && event.y <= v.height * 2
-                        if (!inBounds && touchStarted) {
+                        val session = slideSession
+                        if (session != null) {
+                            // The popup owns the gesture. Route only the tracked
+                            // finger; a second pointer must not move the highlight.
+                            val idx = event.findPointerIndex(activePointerId)
+                            if (idx < 0) {
+                                cancelSlide(session)
+                                slideSession = null
+                            } else {
+                                session.onMove(
+                                    anchorScreenX + event.getX(idx),
+                                    anchorScreenY + event.getY(idx)
+                                )
+                            }
+                        } else {
+                            val inBounds = event.x >= 0 && event.x <= v.width &&
+                                event.y >= -v.height && event.y <= v.height * 2
+                            if (!inBounds && touchStarted) {
+                                touchStarted = false
+                                v.isPressed = false
+                                keyPreview?.hide()
+                                longPressRunnable?.let { longPressHandler.removeCallbacks(it) }
+                                longPressRunnable = null
+                            }
+                        }
+                        true
+                    }
+                    MotionEvent.ACTION_POINTER_UP -> {
+                        // If the tracked finger is the one lifting, end the gesture
+                        // here; a non-tracked finger lifting is ignored.
+                        if (event.getPointerId(event.actionIndex) == activePointerId) {
+                            val session = slideSession
+                            if (session != null) {
+                                commitSlide(session, anchorScreenX, anchorScreenY, event, activePointerId)
+                                slideSession = null
+                            } else {
+                                keyPreview?.hide()
+                                longPressRunnable?.let { longPressHandler.removeCallbacks(it) }
+                                longPressRunnable = null
+                                if (touchStarted && v.isPressed) {
+                                    handleKeyPress(holder.key)
+                                }
+                            }
                             touchStarted = false
                             v.isPressed = false
-                            keyPreview?.hide()
-                            longPressRunnable?.let { longPressHandler.removeCallbacks(it) }
-                            longPressRunnable = null
                         }
                         true
                     }
@@ -442,19 +502,27 @@ class QwertyKeyboard(
                         keyPreview?.hide()
                         longPressRunnable?.let { longPressHandler.removeCallbacks(it) }
                         longPressRunnable = null
-                        if (touchStarted && v.isPressed) {
+                        val session = slideSession
+                        if (session != null) {
+                            commitSlide(session, anchorScreenX, anchorScreenY, event, activePointerId)
+                            slideSession = null
+                        } else if (touchStarted && v.isPressed) {
                             handleKeyPress(holder.key)
                         }
                         touchStarted = false
                         v.isPressed = false
+                        activePointerId = MotionEvent.INVALID_POINTER_ID
                         true
                     }
                     MotionEvent.ACTION_CANCEL -> {
                         keyPreview?.hide()
                         longPressRunnable?.let { longPressHandler.removeCallbacks(it) }
                         longPressRunnable = null
+                        slideSession?.let { cancelSlide(it) }
+                        slideSession = null
                         touchStarted = false
                         v.isPressed = false
+                        activePointerId = MotionEvent.INVALID_POINTER_ID
                         true
                     }
                     else -> false
@@ -499,6 +567,37 @@ class QwertyKeyboard(
         }
 
         return button
+    }
+
+    /**
+     * Resolve the slide release at the tracked finger's position. Commits the
+     * hovered alt (if any) and dismisses the popup. Lifting outside all
+     * candidates sends nothing.
+     */
+    private fun commitSlide(
+        session: AltKeyPopup.SlideSession,
+        anchorScreenX: Int,
+        anchorScreenY: Int,
+        event: MotionEvent,
+        activePointerId: Int
+    ) {
+        val idx = event.findPointerIndex(activePointerId)
+        val selected = if (idx >= 0) {
+            session.onRelease(anchorScreenX + event.getX(idx), anchorScreenY + event.getY(idx))
+        } else {
+            null
+        }
+        if (selected != null) {
+            inputConnectionProvider()?.let { ic -> keySender.sendText(ic, selected) }
+        }
+        session.dismiss()
+        if (currentSlideSession === session) currentSlideSession = null
+    }
+
+    /** Dismiss the slide popup without committing (cancel, lost pointer). */
+    private fun cancelSlide(session: AltKeyPopup.SlideSession) {
+        session.dismiss()
+        if (currentSlideSession === session) currentSlideSession = null
     }
 
     private fun performHaptic(type: Int = HapticFeedbackConstants.KEYBOARD_TAP) {

--- a/app/src/main/java/com/keyjawn/SlashCommandPopup.kt
+++ b/app/src/main/java/com/keyjawn/SlashCommandPopup.kt
@@ -13,7 +13,8 @@ import android.widget.TextView
 class SlashCommandPopup(
     private val registry: SlashCommandRegistry,
     private val onCommandSelected: (String) -> Unit,
-    private val onDismissedEmpty: () -> Unit
+    private val onDismissedEmpty: () -> Unit,
+    private val themeManager: ThemeManager? = null
 ) {
 
     private var popup: PopupWindow? = null
@@ -24,10 +25,16 @@ class SlashCommandPopup(
         val popupView = inflater.inflate(R.layout.slash_command_popup, null)
         val commandList = popupView.findViewById<LinearLayout>(R.id.command_list)
 
+        val tm = themeManager
+        val backgroundColor = tm?.keyboardBg() ?: DEFAULT_BACKGROUND
+        val textColor = tm?.keyText() ?: DEFAULT_TEXT
+        popupView.setBackgroundColor(backgroundColor)
+
         val commands = registry.getCommands()
         for (command in commands) {
             val item = inflater.inflate(R.layout.slash_command_item, commandList, false) as TextView
             item.text = command
+            item.setTextColor(textColor)
             item.setOnClickListener {
                 registry.recordUsage(command)
                 onCommandSelected(command)
@@ -42,7 +49,7 @@ class SlashCommandPopup(
             dpToPx(context, 200),
             true
         )
-        window.setBackgroundDrawable(ColorDrawable(0xFF1E1E1E.toInt()))
+        window.setBackgroundDrawable(ColorDrawable(backgroundColor))
         window.isOutsideTouchable = true
         window.setOnDismissListener {
             onDismissedEmpty()
@@ -64,5 +71,12 @@ class SlashCommandPopup(
     private fun dpToPx(context: Context, dp: Int): Int {
         val density = context.resources.displayMetrics.density
         return (dp * density + 0.5f).toInt()
+    }
+
+    companion object {
+        // Fallback colors when no ThemeManager is supplied (lite flavor, which has
+        // no themes). Matches the previous hardcoded dark popup appearance.
+        private val DEFAULT_BACKGROUND = 0xFF1E1E1E.toInt()
+        private val DEFAULT_TEXT = 0xFFFFFFFF.toInt()
     }
 }

--- a/app/src/main/java/com/keyjawn/SpacebarCursorController.kt
+++ b/app/src/main/java/com/keyjawn/SpacebarCursorController.kt
@@ -25,16 +25,28 @@ class SpacebarCursorController(
     private var longPressRunnable: Runnable? = null
     private var touchActive = false
 
+    // px thresholds resolved once from the touched view's density (constant for
+    // the controller's lifetime) instead of re-reading resources on every move.
+    private var thresholdsResolved = false
+    private var cursorThresholdPx = 0f
+    private var stepSizePx = 0f
+
     companion object {
         private const val CURSOR_THRESHOLD_DP = 10f
         private const val STEP_SIZE_DP = 8f
         private const val LONG_PRESS_MS = 500L
     }
 
-    override fun onTouch(v: View, event: MotionEvent): Boolean {
+    private fun resolveThresholds(v: View) {
+        if (thresholdsResolved) return
         val density = v.context.resources.displayMetrics.density
-        val cursorThresholdPx = CURSOR_THRESHOLD_DP * density
-        val stepSizePx = STEP_SIZE_DP * density
+        cursorThresholdPx = CURSOR_THRESHOLD_DP * density
+        stepSizePx = STEP_SIZE_DP * density
+        thresholdsResolved = true
+    }
+
+    override fun onTouch(v: View, event: MotionEvent): Boolean {
+        resolveThresholds(v)
 
         when (event.action) {
             MotionEvent.ACTION_DOWN -> {

--- a/app/src/main/java/com/keyjawn/SwipeGestureDetector.kt
+++ b/app/src/main/java/com/keyjawn/SwipeGestureDetector.kt
@@ -20,12 +20,26 @@ class SwipeGestureDetector(
     private val minVerticalDistanceDp = 90f
     private val minVerticalVelocityDp = 300f
 
-    override fun onTouch(view: View, event: MotionEvent): Boolean {
+    // px thresholds resolved once from the touched view's density (constant for
+    // the listener's lifetime) instead of re-reading resources on every event.
+    private var thresholdsResolved = false
+    private var minDistancePx = 0f
+    private var minVelocityPx = 0f
+    private var minVerticalDistancePx = 0f
+    private var minVerticalVelocityPx = 0f
+
+    private fun resolveThresholds(view: View) {
+        if (thresholdsResolved) return
         val density = view.context.resources.displayMetrics.density
-        val minDistancePx = minDistanceDp * density
-        val minVelocityPx = minVelocityDp * density
-        val minVerticalDistancePx = minVerticalDistanceDp * density
-        val minVerticalVelocityPx = minVerticalVelocityDp * density
+        minDistancePx = minDistanceDp * density
+        minVelocityPx = minVelocityDp * density
+        minVerticalDistancePx = minVerticalDistanceDp * density
+        minVerticalVelocityPx = minVerticalVelocityDp * density
+        thresholdsResolved = true
+    }
+
+    override fun onTouch(view: View, event: MotionEvent): Boolean {
+        resolveThresholds(view)
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {

--- a/app/src/main/java/com/keyjawn/ThemeManager.kt
+++ b/app/src/main/java/com/keyjawn/ThemeManager.kt
@@ -65,6 +65,13 @@ class ThemeManager(context: Context) {
     private fun readPersistedTheme(): KeyboardTheme =
         themeForName(prefs.getString("theme", KeyboardTheme.DARK.name))
 
+    /**
+     * True when the persisted theme differs from the cached one, i.e. another
+     * instance (such as SettingsActivity) changed it. Lets the IME decide to
+     * refresh and re-apply colors on the next keyboard open.
+     */
+    fun isThemeStale(): Boolean = readPersistedTheme() != _currentTheme
+
     // -- Core colors --
 
     fun keyboardBg(): Int = palette.keyboardBg

--- a/app/src/main/java/com/keyjawn/ThemeManager.kt
+++ b/app/src/main/java/com/keyjawn/ThemeManager.kt
@@ -209,6 +209,20 @@ class ThemeManager(context: Context) {
         return RippleDrawable(rippleColor, shape, null)
     }
 
+    // -- Pure palette --
+    // Swatch colors for a given theme, with no prefs read or write and no
+    // currentTheme mutation. Used to render theme previews without touching the
+    // live selection.
+
+    data class Swatch(val keyboardBg: Int, val keyBg: Int, val keyText: Int)
+
+    fun swatch(theme: KeyboardTheme): Swatch = when (theme) {
+        KeyboardTheme.DARK -> Swatch(0xFF1B1B1F.toInt(), 0xFF2B2B30.toInt(), 0xFFE8E8EC.toInt())
+        KeyboardTheme.LIGHT -> Swatch(0xFFE8E8EC.toInt(), 0xFFFFFFFF.toInt(), 0xFF1A1A1F.toInt())
+        KeyboardTheme.OLED -> Swatch(0xFF000000.toInt(), 0xFF111114.toInt(), 0xFFE8E8EC.toInt())
+        KeyboardTheme.TERMINAL -> Swatch(0xFF0A1A0A.toInt(), 0xFF0F2B0F.toInt(), 0xFF33FF33.toInt())
+    }
+
     fun getAvailableThemes(): List<KeyboardTheme> = KeyboardTheme.entries
 
     fun themeLabel(theme: KeyboardTheme): String = when (theme) {

--- a/app/src/main/java/com/keyjawn/ThemeManager.kt
+++ b/app/src/main/java/com/keyjawn/ThemeManager.kt
@@ -23,12 +23,22 @@ class ThemeManager(context: Context) {
     private var _currentTheme: KeyboardTheme = readPersistedTheme()
     private var palette: Palette = paletteFor(_currentTheme)
 
+    // Drawable prototypes, keyed by surface color, rebuilt only on a theme
+    // change. Each call hands out a cheap copy via constantState.newDrawable()
+    // (a Drawable can back only one view) instead of rebuilding the drawable
+    // tree per key per render. The pressed ColorStateList is immutable, so a
+    // single instance is shared across every key of the active theme.
+    private var pressedColorStateList: ColorStateList = ColorStateList.valueOf(palette.keyBgPressed)
+    private val keyDrawableCache = HashMap<Int, Drawable>()
+    private val flatDrawableCache = HashMap<Int, Drawable>()
+    private val extraRowDrawableCache = HashMap<Int, Drawable>()
+
     var currentTheme: KeyboardTheme
         get() = _currentTheme
         set(value) {
             prefs.edit().putString("theme", value.name).apply()
             _currentTheme = value
-            palette = paletteFor(value)
+            applyPalette(paletteFor(value))
         }
 
     /**
@@ -38,7 +48,18 @@ class ThemeManager(context: Context) {
      */
     fun refresh() {
         _currentTheme = readPersistedTheme()
-        palette = paletteFor(_currentTheme)
+        applyPalette(paletteFor(_currentTheme))
+    }
+
+    private fun applyPalette(newPalette: Palette) {
+        palette = newPalette
+        // The pressed ripple color is theme-specific, so the drawable
+        // prototypes must be discarded even when a surface color repeats
+        // across themes.
+        pressedColorStateList = ColorStateList.valueOf(newPalette.keyBgPressed)
+        keyDrawableCache.clear()
+        flatDrawableCache.clear()
+        extraRowDrawableCache.clear()
     }
 
     private fun readPersistedTheme(): KeyboardTheme =
@@ -85,8 +106,39 @@ class ThemeManager(context: Context) {
     fun micBg(): Int = palette.micBg
 
     // -- Drawable builders --
+    // The drawable tree for a given surface color is built once per theme and
+    // cached as a prototype. Each create* call hands out a fresh, view-assignable
+    // copy via constantState.newDrawable() (a Drawable can back only one view)
+    // without reconstructing the GradientDrawable/LayerDrawable tree. Callers must
+    // not tint the returned drawable in place (the surface color is already baked
+    // in); a future per-instance tint would need a mutate() on the copy first.
 
-    fun createKeyDrawable(bgColor: Int): Drawable {
+    fun createKeyDrawable(bgColor: Int): Drawable =
+        copyOf(keyDrawablePrototype(bgColor))
+
+    fun createFlatDrawable(bgColor: Int): Drawable =
+        copyOf(flatDrawablePrototype(bgColor))
+
+    fun createExtraRowButtonDrawable(bgColor: Int): Drawable =
+        copyOf(extraRowButtonDrawablePrototype(bgColor))
+
+    // Cached prototypes. internal so tests can assert that the same prototype
+    // instance is reused for a color until the theme changes (RippleDrawable's
+    // newDrawable() does not preserve ConstantState identity, so prototype
+    // identity is the observable signal that the tree was not rebuilt).
+    internal fun keyDrawablePrototype(bgColor: Int): Drawable =
+        keyDrawableCache.getOrPut(bgColor) { buildKeyDrawable(bgColor) }
+
+    internal fun flatDrawablePrototype(bgColor: Int): Drawable =
+        flatDrawableCache.getOrPut(bgColor) { buildFlatDrawable(bgColor) }
+
+    internal fun extraRowButtonDrawablePrototype(bgColor: Int): Drawable =
+        extraRowDrawableCache.getOrPut(bgColor) { buildExtraRowButtonDrawable(bgColor) }
+
+    private fun copyOf(prototype: Drawable): Drawable =
+        prototype.constantState?.newDrawable() ?: prototype
+
+    private fun buildKeyDrawable(bgColor: Int): Drawable {
         val cornerRadius = 6f * density
 
         // Shadow layer (darker, offset down 1dp)
@@ -108,29 +160,26 @@ class ThemeManager(context: Context) {
         layers.setLayerInset(0, 0, insetPx, 0, 0) // shadow offset down
         layers.setLayerInset(1, 0, 0, 0, insetPx) // surface offset up
 
-        val rippleColor = ColorStateList.valueOf(keyBgPressed())
-        return RippleDrawable(rippleColor, layers, null)
+        return RippleDrawable(pressedColorStateList, layers, null)
     }
 
-    fun createFlatDrawable(bgColor: Int): Drawable {
+    private fun buildFlatDrawable(bgColor: Int): Drawable {
+        val cornerRadius = 6f * density
+        return GradientDrawable().apply {
+            this.shape = GradientDrawable.RECTANGLE
+            setColor(bgColor)
+            this.cornerRadius = cornerRadius
+        }
+    }
+
+    private fun buildExtraRowButtonDrawable(bgColor: Int): Drawable {
         val cornerRadius = 6f * density
         val shape = GradientDrawable().apply {
             this.shape = GradientDrawable.RECTANGLE
             setColor(bgColor)
             this.cornerRadius = cornerRadius
         }
-        return shape
-    }
-
-    fun createExtraRowButtonDrawable(bgColor: Int): Drawable {
-        val cornerRadius = 6f * density
-        val shape = GradientDrawable().apply {
-            this.shape = GradientDrawable.RECTANGLE
-            setColor(bgColor)
-            this.cornerRadius = cornerRadius
-        }
-        val rippleColor = ColorStateList.valueOf(keyBgPressed())
-        return RippleDrawable(rippleColor, shape, null)
+        return RippleDrawable(pressedColorStateList, shape, null)
     }
 
     // -- Pure palette --

--- a/app/src/main/java/com/keyjawn/ThemeManager.kt
+++ b/app/src/main/java/com/keyjawn/ThemeManager.kt
@@ -17,148 +17,72 @@ class ThemeManager(context: Context) {
     private val prefs = context.getSharedPreferences("keyjawn_theme", Context.MODE_PRIVATE)
     private val density = context.resources.displayMetrics.density
 
+    // Resolved once at construction and refreshed only through the setter or
+    // refresh(): every color lookup reads these cached fields instead of
+    // re-reading prefs and re-parsing the theme enum on the hot render path.
+    private var _currentTheme: KeyboardTheme = readPersistedTheme()
+    private var palette: Palette = paletteFor(_currentTheme)
+
     var currentTheme: KeyboardTheme
-        get() {
-            val name = prefs.getString("theme", KeyboardTheme.DARK.name) ?: KeyboardTheme.DARK.name
-            return try {
-                KeyboardTheme.valueOf(name)
-            } catch (_: IllegalArgumentException) {
-                KeyboardTheme.DARK
-            }
-        }
+        get() = _currentTheme
         set(value) {
             prefs.edit().putString("theme", value.name).apply()
+            _currentTheme = value
+            palette = paletteFor(value)
         }
+
+    /**
+     * Re-resolve the cached theme and palette from prefs. Needed only when the
+     * persisted value can change without going through the setter on this
+     * instance (the setter is the normal single refresh point).
+     */
+    fun refresh() {
+        _currentTheme = readPersistedTheme()
+        palette = paletteFor(_currentTheme)
+    }
+
+    private fun readPersistedTheme(): KeyboardTheme =
+        themeForName(prefs.getString("theme", KeyboardTheme.DARK.name))
 
     // -- Core colors --
 
-    fun keyboardBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF1B1B1F.toInt()
-        KeyboardTheme.LIGHT -> 0xFFE8E8EC.toInt()
-        KeyboardTheme.OLED -> 0xFF000000.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF0A1A0A.toInt()
-    }
+    fun keyboardBg(): Int = palette.keyboardBg
 
-    fun keyBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF2B2B30.toInt()
-        KeyboardTheme.LIGHT -> 0xFFFFFFFF.toInt()
-        KeyboardTheme.OLED -> 0xFF111114.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF0F2B0F.toInt()
-    }
+    fun keyBg(): Int = palette.keyBg
 
-    fun keyText(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFFE8E8EC.toInt()
-        KeyboardTheme.LIGHT -> 0xFF1A1A1F.toInt()
-        KeyboardTheme.OLED -> 0xFFE8E8EC.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF33FF33.toInt()
-    }
+    fun keyText(): Int = palette.keyText
 
-    fun keySpecialBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF333338.toInt()
-        KeyboardTheme.LIGHT -> 0xFFD8D8E0.toInt()
-        KeyboardTheme.OLED -> 0xFF1A1A1E.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A3A1A.toInt()
-    }
+    fun keySpecialBg(): Int = palette.keySpecialBg
 
-    fun quickKeyBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF2A3A4A.toInt()
-        KeyboardTheme.LIGHT -> 0xFFC0D0E0.toInt()
-        KeyboardTheme.OLED -> 0xFF1A2A3A.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A3A2A.toInt()
-    }
+    fun quickKeyBg(): Int = palette.quickKeyBg
 
-    fun accent(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF6C9BF2.toInt()
-        KeyboardTheme.LIGHT -> 0xFF2563EB.toInt()
-        KeyboardTheme.OLED -> 0xFF6C9BF2.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF33FF33.toInt()
-    }
+    fun accent(): Int = palette.accent
 
-    fun accentLocked(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFFE86C5A.toInt()
-        KeyboardTheme.LIGHT -> 0xFFDC2626.toInt()
-        KeyboardTheme.OLED -> 0xFFE86C5A.toInt()
-        KeyboardTheme.TERMINAL -> 0xFFFF6633.toInt()
-    }
+    fun accentLocked(): Int = palette.accentLocked
 
-    fun extraRowBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF161619.toInt()
-        KeyboardTheme.LIGHT -> 0xFFD0D0D8.toInt()
-        KeyboardTheme.OLED -> 0xFF000000.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF081808.toInt()
-    }
+    fun extraRowBg(): Int = palette.extraRowBg
 
-    fun qwertyBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF222226.toInt()
-        KeyboardTheme.LIGHT -> 0xFFE0E0E6.toInt()
-        KeyboardTheme.OLED -> 0xFF080810.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF0D220D.toInt()
-    }
+    fun qwertyBg(): Int = palette.qwertyBg
 
-    fun keyHint(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF6E6E78.toInt()
-        KeyboardTheme.LIGHT -> 0xFF8888A0.toInt()
-        KeyboardTheme.OLED -> 0xFF555560.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF227722.toInt()
-    }
+    fun keyHint(): Int = palette.keyHint
 
-    fun keyBgPressed(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF3A3A40.toInt()
-        KeyboardTheme.LIGHT -> 0xFFD0D0D8.toInt()
-        KeyboardTheme.OLED -> 0xFF222228.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A4A1A.toInt()
-    }
+    fun keyBgPressed(): Int = palette.keyBgPressed
 
-    fun divider(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF38383E.toInt()
-        KeyboardTheme.LIGHT -> 0xFFC0C0CC.toInt()
-        KeyboardTheme.OLED -> 0xFF222228.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A3A1A.toInt()
-    }
+    fun divider(): Int = palette.divider
 
     // -- Extra row per-button colors --
 
-    fun escBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF1A1A1A.toInt()
-        KeyboardTheme.LIGHT -> 0xFFBBBBC8.toInt()
-        KeyboardTheme.OLED -> 0xFF0A0A0E.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF0A1A0A.toInt()
-    }
+    fun escBg(): Int = palette.escBg
 
-    fun tabBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF2A4A35.toInt()
-        KeyboardTheme.LIGHT -> 0xFFA8D4B8.toInt()
-        KeyboardTheme.OLED -> 0xFF1A3A25.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A3A1A.toInt()
-    }
+    fun tabBg(): Int = palette.tabBg
 
-    fun clipboardBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF4A3D20.toInt()
-        KeyboardTheme.LIGHT -> 0xFFD4C898.toInt()
-        KeyboardTheme.OLED -> 0xFF3A2D10.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF2A3A1A.toInt()
-    }
+    fun clipboardBg(): Int = palette.clipboardBg
 
-    fun arrowBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF3A3A3F.toInt()
-        KeyboardTheme.LIGHT -> 0xFFC0C0CC.toInt()
-        KeyboardTheme.OLED -> 0xFF1A1A22.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A2A1A.toInt()
-    }
+    fun arrowBg(): Int = palette.arrowBg
 
-    fun uploadBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF253050.toInt()
-        KeyboardTheme.LIGHT -> 0xFF98B4D4.toInt()
-        KeyboardTheme.OLED -> 0xFF152040.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF1A2A3A.toInt()
-    }
+    fun uploadBg(): Int = palette.uploadBg
 
-    fun micBg(): Int = when (currentTheme) {
-        KeyboardTheme.DARK -> 0xFF4A2525.toInt()
-        KeyboardTheme.LIGHT -> 0xFFD4A0A0.toInt()
-        KeyboardTheme.OLED -> 0xFF3A1515.toInt()
-        KeyboardTheme.TERMINAL -> 0xFF3A1A1A.toInt()
-    }
+    fun micBg(): Int = palette.micBg
 
     // -- Drawable builders --
 
@@ -216,11 +140,8 @@ class ThemeManager(context: Context) {
 
     data class Swatch(val keyboardBg: Int, val keyBg: Int, val keyText: Int)
 
-    fun swatch(theme: KeyboardTheme): Swatch = when (theme) {
-        KeyboardTheme.DARK -> Swatch(0xFF1B1B1F.toInt(), 0xFF2B2B30.toInt(), 0xFFE8E8EC.toInt())
-        KeyboardTheme.LIGHT -> Swatch(0xFFE8E8EC.toInt(), 0xFFFFFFFF.toInt(), 0xFF1A1A1F.toInt())
-        KeyboardTheme.OLED -> Swatch(0xFF000000.toInt(), 0xFF111114.toInt(), 0xFFE8E8EC.toInt())
-        KeyboardTheme.TERMINAL -> Swatch(0xFF0A1A0A.toInt(), 0xFF0F2B0F.toInt(), 0xFF33FF33.toInt())
+    fun swatch(theme: KeyboardTheme): Swatch = paletteFor(theme).let {
+        Swatch(it.keyboardBg, it.keyBg, it.keyText)
     }
 
     fun getAvailableThemes(): List<KeyboardTheme> = KeyboardTheme.entries
@@ -230,5 +151,124 @@ class ThemeManager(context: Context) {
         KeyboardTheme.LIGHT -> "Light"
         KeyboardTheme.OLED -> "OLED black"
         KeyboardTheme.TERMINAL -> "Terminal"
+    }
+
+    /**
+     * Every theme color resolved once into plain Int fields. Pure function of
+     * the theme, so it carries no prefs access and can back both the live
+     * cached palette and the preview swatches.
+     */
+    class Palette(
+        val keyboardBg: Int,
+        val keyBg: Int,
+        val keyText: Int,
+        val keySpecialBg: Int,
+        val quickKeyBg: Int,
+        val accent: Int,
+        val accentLocked: Int,
+        val extraRowBg: Int,
+        val qwertyBg: Int,
+        val keyHint: Int,
+        val keyBgPressed: Int,
+        val divider: Int,
+        val escBg: Int,
+        val tabBg: Int,
+        val clipboardBg: Int,
+        val arrowBg: Int,
+        val uploadBg: Int,
+        val micBg: Int
+    )
+
+    companion object {
+        // Precomputed name -> enum lookup. Replaces KeyboardTheme.valueOf(),
+        // which throws and catches on an unknown value, with a single map read.
+        private val THEMES_BY_NAME: Map<String, KeyboardTheme> =
+            KeyboardTheme.entries.associateBy { it.name }
+
+        fun themeForName(name: String?): KeyboardTheme =
+            THEMES_BY_NAME[name] ?: KeyboardTheme.DARK
+
+        fun paletteFor(theme: KeyboardTheme): Palette = when (theme) {
+            KeyboardTheme.DARK -> Palette(
+                keyboardBg = 0xFF1B1B1F.toInt(),
+                keyBg = 0xFF2B2B30.toInt(),
+                keyText = 0xFFE8E8EC.toInt(),
+                keySpecialBg = 0xFF333338.toInt(),
+                quickKeyBg = 0xFF2A3A4A.toInt(),
+                accent = 0xFF6C9BF2.toInt(),
+                accentLocked = 0xFFE86C5A.toInt(),
+                extraRowBg = 0xFF161619.toInt(),
+                qwertyBg = 0xFF222226.toInt(),
+                keyHint = 0xFF6E6E78.toInt(),
+                keyBgPressed = 0xFF3A3A40.toInt(),
+                divider = 0xFF38383E.toInt(),
+                escBg = 0xFF1A1A1A.toInt(),
+                tabBg = 0xFF2A4A35.toInt(),
+                clipboardBg = 0xFF4A3D20.toInt(),
+                arrowBg = 0xFF3A3A3F.toInt(),
+                uploadBg = 0xFF253050.toInt(),
+                micBg = 0xFF4A2525.toInt()
+            )
+            KeyboardTheme.LIGHT -> Palette(
+                keyboardBg = 0xFFE8E8EC.toInt(),
+                keyBg = 0xFFFFFFFF.toInt(),
+                keyText = 0xFF1A1A1F.toInt(),
+                keySpecialBg = 0xFFD8D8E0.toInt(),
+                quickKeyBg = 0xFFC0D0E0.toInt(),
+                accent = 0xFF2563EB.toInt(),
+                accentLocked = 0xFFDC2626.toInt(),
+                extraRowBg = 0xFFD0D0D8.toInt(),
+                qwertyBg = 0xFFE0E0E6.toInt(),
+                keyHint = 0xFF8888A0.toInt(),
+                keyBgPressed = 0xFFD0D0D8.toInt(),
+                divider = 0xFFC0C0CC.toInt(),
+                escBg = 0xFFBBBBC8.toInt(),
+                tabBg = 0xFFA8D4B8.toInt(),
+                clipboardBg = 0xFFD4C898.toInt(),
+                arrowBg = 0xFFC0C0CC.toInt(),
+                uploadBg = 0xFF98B4D4.toInt(),
+                micBg = 0xFFD4A0A0.toInt()
+            )
+            KeyboardTheme.OLED -> Palette(
+                keyboardBg = 0xFF000000.toInt(),
+                keyBg = 0xFF111114.toInt(),
+                keyText = 0xFFE8E8EC.toInt(),
+                keySpecialBg = 0xFF1A1A1E.toInt(),
+                quickKeyBg = 0xFF1A2A3A.toInt(),
+                accent = 0xFF6C9BF2.toInt(),
+                accentLocked = 0xFFE86C5A.toInt(),
+                extraRowBg = 0xFF000000.toInt(),
+                qwertyBg = 0xFF080810.toInt(),
+                keyHint = 0xFF555560.toInt(),
+                keyBgPressed = 0xFF222228.toInt(),
+                divider = 0xFF222228.toInt(),
+                escBg = 0xFF0A0A0E.toInt(),
+                tabBg = 0xFF1A3A25.toInt(),
+                clipboardBg = 0xFF3A2D10.toInt(),
+                arrowBg = 0xFF1A1A22.toInt(),
+                uploadBg = 0xFF152040.toInt(),
+                micBg = 0xFF3A1515.toInt()
+            )
+            KeyboardTheme.TERMINAL -> Palette(
+                keyboardBg = 0xFF0A1A0A.toInt(),
+                keyBg = 0xFF0F2B0F.toInt(),
+                keyText = 0xFF33FF33.toInt(),
+                keySpecialBg = 0xFF1A3A1A.toInt(),
+                quickKeyBg = 0xFF1A3A2A.toInt(),
+                accent = 0xFF33FF33.toInt(),
+                accentLocked = 0xFFFF6633.toInt(),
+                extraRowBg = 0xFF081808.toInt(),
+                qwertyBg = 0xFF0D220D.toInt(),
+                keyHint = 0xFF227722.toInt(),
+                keyBgPressed = 0xFF1A4A1A.toInt(),
+                divider = 0xFF1A3A1A.toInt(),
+                escBg = 0xFF0A1A0A.toInt(),
+                tabBg = 0xFF1A3A1A.toInt(),
+                clipboardBg = 0xFF2A3A1A.toInt(),
+                arrowBg = 0xFF1A2A1A.toInt(),
+                uploadBg = 0xFF1A2A3A.toInt(),
+                micBg = 0xFF3A1A1A.toInt()
+            )
+        }
     }
 }

--- a/app/src/main/java/com/keyjawn/VoiceInputHandler.kt
+++ b/app/src/main/java/com/keyjawn/VoiceInputHandler.kt
@@ -20,7 +20,17 @@ interface VoiceInputListener {
     fun onPartialResult(text: String)
     fun onFinalResult(text: String)
     fun onRmsChanged(rmsdB: Float)
-    fun onError()
+    fun onError(error: Int)
+}
+
+/** Maps a [SpeechRecognizer] error code to a short user-facing message. */
+fun voiceErrorMessage(error: Int): String = when (error) {
+    SpeechRecognizer.ERROR_NO_MATCH,
+    SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "Didn't catch that"
+    SpeechRecognizer.ERROR_NETWORK,
+    SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "No network"
+    SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Busy, try again"
+    else -> "Voice input failed"
 }
 
 class VoiceInputHandler(private val context: Context) {
@@ -110,7 +120,7 @@ class VoiceInputHandler(private val context: Context) {
 
             override fun onError(error: Int) {
                 listening = false
-                listener?.onError()
+                listener?.onError(error)
                 listener?.onVoiceStop()
             }
 

--- a/app/src/main/res/layout/slash_command_item.xml
+++ b/app/src/main/res/layout/slash_command_item.xml
@@ -5,6 +5,5 @@
     android:gravity="center_vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
-    android:textColor="#FFFFFF"
     android:textSize="16sp"
     android:background="?android:attr/selectableItemBackground" />

--- a/app/src/main/res/layout/slash_command_popup.xml
+++ b/app/src/main/res/layout/slash_command_popup.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="200dp"
-    android:background="#1E1E1E">
+    android:layout_height="200dp">
     <LinearLayout
         android:id="@+id/command_list"
         android:layout_width="match_parent"

--- a/app/src/test/java/com/keyjawn/AltKeyMappingsTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeyMappingsTest.kt
@@ -135,4 +135,38 @@ class AltKeyMappingsTest {
         assertNull(AltKeyMappings.getAlts("Z"))
         assertNull(AltKeyMappings.getAlts("Q"))
     }
+
+    @Test
+    fun `getAlts returns the same precomputed list instance across calls for lowercase`() {
+        val first = AltKeyMappings.getAlts("a")
+        val second = AltKeyMappings.getAlts("a")
+        // Precomputed lookup: no per-call list allocation.
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `getAlts returns the same precomputed list instance across calls for uppercase`() {
+        val first = AltKeyMappings.getAlts("A")
+        val second = AltKeyMappings.getAlts("A")
+        // Uppercase variant is precomputed once, not rebuilt per call.
+        assertSame(first, second)
+    }
+
+    @Test
+    fun `uppercase variants are uppercased element by element`() {
+        val lower = AltKeyMappings.getAlts("e")!!
+        val upper = AltKeyMappings.getAlts("E")!!
+        assertEquals(lower.size, upper.size)
+        for (i in lower.indices) {
+            assertEquals(lower[i].uppercase(), upper[i])
+        }
+    }
+
+    @Test
+    fun `uppercase digit and punctuation keys keep their alts unchanged`() {
+        // Digits and punctuation have no case, so the lower and upper lookups
+        // (label == label.lowercase()) resolve to the same precomputed list.
+        assertEquals(listOf("!"), AltKeyMappings.getAlts("1"))
+        assertEquals(listOf("—", "–"), AltKeyMappings.getAlts("-"))
+    }
 }

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -1,0 +1,339 @@
+package com.keyjawn
+
+import android.app.Activity
+import android.graphics.Rect
+import android.os.Looper
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import android.view.inputmethod.InputConnection
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.mockito.kotlin.*
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AltKeySlideTest {
+
+    private lateinit var container: LinearLayout
+    private lateinit var keySender: KeySender
+    private lateinit var extraRowManager: ExtraRowManager
+    private lateinit var ic: InputConnection
+    private lateinit var keyboard: QwertyKeyboard
+    private lateinit var activityController: ActivityController<Activity>
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        container = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        keySender = mock()
+        ic = mock()
+        whenever(ic.commitText(any(), any())).thenReturn(true)
+        whenever(ic.sendKeyEvent(any())).thenReturn(true)
+
+        val extraRowView = LinearLayout(context).apply { id = R.id.extra_row }
+        addExtraRowButtons(extraRowView, context)
+        val parentView = LinearLayout(context).apply { addView(extraRowView) }
+        extraRowManager = ExtraRowManager(parentView, keySender, { ic })
+
+        val root = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(parentView)
+            addView(container)
+        }
+        activityController = Robolectric.buildActivity(Activity::class.java).setup()
+        activityController.get().setContentView(root)
+
+        keyboard = QwertyKeyboard(container, keySender, extraRowManager, { ic })
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+
+        // Robolectric does not lay out the view tree automatically, so key views
+        // report a 0x0 size and the listener's in-bounds check degenerates. Force
+        // a measure/layout pass so the drag-off bounds test exercises real sizes.
+        val widthSpec = View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY)
+        val heightSpec = View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY)
+        root.measure(widthSpec, heightSpec)
+        root.layout(0, 0, 1080, 1920)
+    }
+
+    private fun addExtraRowButtons(parent: LinearLayout, context: android.content.Context) {
+        val ids = listOf(
+            R.id.key_esc, R.id.key_tab, R.id.key_clipboard, R.id.key_ctrl,
+            R.id.key_left, R.id.key_down, R.id.key_up, R.id.key_right,
+            R.id.key_upload, R.id.key_mic
+        )
+        for (id in ids) {
+            val btn = Button(context)
+            btn.id = id
+            parent.addView(btn)
+        }
+    }
+
+    private fun findButton(view: View): Button =
+        if (view is FrameLayout) view.getChildAt(0) as Button else view as Button
+
+    private fun charButtonAt(rowIndex: Int, colIndex: Int): Button {
+        val row = container.getChildAt(rowIndex) as LinearLayout
+        return findButton(row.getChildAt(colIndex))
+    }
+
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun obtain(action: Int, x: Float, y: Float): MotionEvent {
+        val now = SystemClock.uptimeMillis()
+        return MotionEvent.obtain(now, now, action, x, y, 0)
+    }
+
+    /** Fire the pending long-press runnable on a multi-alt key by advancing the looper. */
+    private fun openSlideOn(button: Button) {
+        val down = obtain(MotionEvent.ACTION_DOWN, button.width / 2f, button.height / 2f)
+        button.dispatchTouchEvent(down)
+        down.recycle()
+        // The long-press runnable is posted with a 500ms delay; advance time so it runs.
+        shadowOf(Looper.getMainLooper()).idleFor(600, java.util.concurrent.TimeUnit.MILLISECONDS)
+    }
+
+    /**
+     * Local-x within the anchor key that maps to candidate index [i]'s center in
+     * screen space. The listener converts via anchorScreenX + event.getX, so the
+     * inverse is candidateRect.centerX - anchorScreenX.
+     */
+    private fun localXForCandidate(anchor: View, rect: Rect): Float {
+        val loc = IntArray(2)
+        anchor.getLocationOnScreen(loc)
+        return rect.centerX().toFloat() - loc[0]
+    }
+
+    private fun localYForCandidate(anchor: View, rect: Rect): Float {
+        val loc = IntArray(2)
+        anchor.getLocationOnScreen(loc)
+        return rect.centerY().toFloat() - loc[1]
+    }
+
+    // ---- End-to-end gesture tests ----
+
+    @Test
+    fun `slide onto candidate index 1 and release sends that alt`() {
+        // "a" (row 2 index 0) is a multi-alt key.
+        val aButton = charButtonAt(1, 0)
+        val alts = AltKeyMappings.getAlts("a")!!
+        assertTrue("test needs a multi-alt key", alts.size > 1)
+
+        openSlideOn(aButton)
+        val session = keyboard.currentSlideSession
+        assertNotNull("long-press on a multi-alt key opens a slide session", session)
+        assertTrue(session!!.isShowing())
+
+        val rect1 = session.candidateRectsForTest()[1]
+        val moveX = localXForCandidate(aButton, rect1)
+        val moveY = localYForCandidate(aButton, rect1)
+
+        val move = obtain(MotionEvent.ACTION_MOVE, moveX, moveY)
+        aButton.dispatchTouchEvent(move)
+        move.recycle()
+        assertEquals(1, session.hoveredIndex)
+
+        val up = obtain(MotionEvent.ACTION_UP, moveX, moveY)
+        aButton.dispatchTouchEvent(up)
+        up.recycle()
+
+        verify(keySender).sendText(any(), eq(alts[1]))
+        assertFalse("popup dismissed after release", session.isShowing())
+        assertNull(keyboard.currentSlideSession)
+    }
+
+    @Test
+    fun `release outside all candidates sends nothing`() {
+        val aButton = charButtonAt(1, 0)
+        openSlideOn(aButton)
+        val session = keyboard.currentSlideSession
+        assertNotNull(session)
+
+        // Move far away from any candidate, then lift.
+        val move = obtain(MotionEvent.ACTION_MOVE, -10000f, -10000f)
+        aButton.dispatchTouchEvent(move)
+        move.recycle()
+        assertEquals(-1, session!!.hoveredIndex)
+
+        val up = obtain(MotionEvent.ACTION_UP, -10000f, -10000f)
+        aButton.dispatchTouchEvent(up)
+        up.recycle()
+
+        verify(keySender, never()).sendText(any(), any())
+        assertFalse(session.isShowing())
+        assertNull(keyboard.currentSlideSession)
+    }
+
+    @Test
+    fun `quick tap before long-press sends the primary character`() {
+        val aButton = charButtonAt(1, 0)
+        val down = obtain(MotionEvent.ACTION_DOWN, aButton.width / 2f, aButton.height / 2f)
+        val up = obtain(MotionEvent.ACTION_UP, aButton.width / 2f, aButton.height / 2f)
+        aButton.dispatchTouchEvent(down)
+        aButton.dispatchTouchEvent(up)
+        down.recycle()
+        up.recycle()
+
+        verify(keySender).sendChar(any(), eq("a"), any())
+        assertNull("no popup on a quick tap", keyboard.currentSlideSession)
+    }
+
+    @Test
+    fun `drag off the key before long-press opens no popup and sends nothing`() {
+        val aButton = charButtonAt(1, 0)
+        val down = obtain(MotionEvent.ACTION_DOWN, aButton.width / 2f, aButton.height / 2f)
+        aButton.dispatchTouchEvent(down)
+        down.recycle()
+
+        // Drag far below the key (out of the listener's vertical bounds) BEFORE
+        // the long-press timer fires.
+        val move = obtain(MotionEvent.ACTION_MOVE, aButton.width / 2f, aButton.height * 5f)
+        aButton.dispatchTouchEvent(move)
+        move.recycle()
+
+        // Advance past the long-press delay; the runnable was cancelled on drag-off.
+        shadowOf(Looper.getMainLooper()).idleFor(600, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        assertNull("drag-off before long-press opens no popup", keyboard.currentSlideSession)
+
+        val up = obtain(MotionEvent.ACTION_UP, aButton.width / 2f, aButton.height * 5f)
+        aButton.dispatchTouchEvent(up)
+        up.recycle()
+
+        verify(keySender, never()).sendChar(any(), any(), any())
+        verify(keySender, never()).sendText(any(), any())
+    }
+
+    @Test
+    fun `single-alt key long-press sends the single alt with no popup`() {
+        // Row 3 is [Shift, z, x, c, v, b, n, m, Del]; "n" (index 6) has exactly
+        // one alt, so the long-press sends it directly without opening a popup.
+        val nButton = charButtonAt(2, 6)
+        assertEquals("n", nButton.text.toString())
+        val alts = AltKeyMappings.getAlts("n")!!
+        assertEquals(1, alts.size)
+
+        openSlideOn(nButton)
+
+        assertNull("single-alt key opens no slide popup", keyboard.currentSlideSession)
+        verify(keySender).sendText(any(), eq(alts[0]))
+    }
+
+    @Test
+    fun `a second pointer mid-slide does not change the committed candidate`() {
+        val aButton = charButtonAt(1, 0)
+        val alts = AltKeyMappings.getAlts("a")!!
+        openSlideOn(aButton)
+        val session = keyboard.currentSlideSession!!
+
+        val rect1 = session.candidateRectsForTest()[1]
+        val x1 = localXForCandidate(aButton, rect1)
+        val y1 = localYForCandidate(aButton, rect1)
+
+        // Tracked finger hovers candidate 1.
+        val move = obtain(MotionEvent.ACTION_MOVE, x1, y1)
+        aButton.dispatchTouchEvent(move)
+        move.recycle()
+        assertEquals(1, session.hoveredIndex)
+
+        // A second finger arrives over candidate 0 via ACTION_POINTER_DOWN. It
+        // must not hijack the hovered candidate.
+        val rect0 = session.candidateRectsForTest()[0]
+        val x0 = localXForCandidate(aButton, rect0)
+        val y0 = localYForCandidate(aButton, rect0)
+        val pointerDown = MotionEvent.obtain(
+            SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
+            MotionEvent.ACTION_POINTER_DOWN, x0, y0, 0
+        )
+        aButton.dispatchTouchEvent(pointerDown)
+        pointerDown.recycle()
+        assertEquals("second pointer must not move the highlight", 1, session.hoveredIndex)
+
+        // The tracked finger lifts, still over candidate 1.
+        val up = obtain(MotionEvent.ACTION_UP, x1, y1)
+        aButton.dispatchTouchEvent(up)
+        up.recycle()
+
+        verify(keySender).sendText(any(), eq(alts[1]))
+    }
+
+    // ---- SlideSession unit tests (pure hit-testing) ----
+
+    private fun synthSession(rects: List<Rect>): AltKeyPopup.SlideSession {
+        val context = RuntimeEnvironment.getApplication()
+        val buttons = rects.indices.map { Button(context).apply { text = "x$it" } }
+        return AltKeyPopup.SlideSession(buttons, rects, null) { }
+    }
+
+    @Test
+    fun `indexAt returns the candidate containing the point`() {
+        val rects = listOf(
+            Rect(0, 0, 40, 44),
+            Rect(50, 0, 90, 44),
+            Rect(100, 0, 140, 44)
+        )
+        val s = synthSession(rects)
+        assertEquals(0, s.indexAt(20f, 22f))
+        assertEquals(1, s.indexAt(70f, 22f))
+        assertEquals(2, s.indexAt(120f, 22f))
+    }
+
+    @Test
+    fun `indexAt returns -1 outside all candidates`() {
+        val rects = listOf(Rect(0, 0, 40, 44), Rect(50, 0, 90, 44))
+        val s = synthSession(rects)
+        assertEquals(-1, s.indexAt(45f, 22f)) // in the gap
+        assertEquals(-1, s.indexAt(-5f, 22f)) // left of all
+        assertEquals(-1, s.indexAt(200f, 22f)) // right of all
+        assertEquals(-1, s.indexAt(20f, 100f)) // below
+    }
+
+    @Test
+    fun `onMove updates hoveredIndex and onRelease returns the alt`() {
+        val rects = listOf(Rect(0, 0, 40, 44), Rect(50, 0, 90, 44))
+        val s = synthSession(rects)
+        s.onMove(70f, 22f)
+        assertEquals(1, s.hoveredIndex)
+        assertEquals("x1", s.onRelease(70f, 22f))
+    }
+
+    @Test
+    fun `onRelease outside all candidates returns null`() {
+        val rects = listOf(Rect(0, 0, 40, 44), Rect(50, 0, 90, 44))
+        val s = synthSession(rects)
+        s.onMove(20f, 22f)
+        assertEquals(0, s.hoveredIndex)
+        assertNull(s.onRelease(45f, 22f))
+    }
+
+    @Test
+    fun `dismiss makes the session stop showing and reports no hover`() {
+        val rects = listOf(Rect(0, 0, 40, 44))
+        val s = synthSession(rects)
+        s.onMove(20f, 22f)
+        assertTrue(s.isShowing())
+        s.dismiss()
+        assertFalse(s.isShowing())
+        assertEquals(-1, s.hoveredIndex)
+        // After dismissal, further moves are inert.
+        s.onMove(20f, 22f)
+        assertEquals(-1, s.hoveredIndex)
+        assertNull(s.onRelease(20f, 22f))
+    }
+}

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -100,6 +100,41 @@ class AltKeySlideTest {
         return MotionEvent.obtain(now, now, action, x, y, 0)
     }
 
+    private data class Pointer(val id: Int, val x: Float, val y: Float)
+
+    /**
+     * Build a genuine multi-pointer [MotionEvent] from the given pointers, with
+     * [action] (already packed with its actionIndex for pointer up/down events).
+     * Single-pointer MotionEvent.obtain calls can never exercise the pointer-id
+     * routing, so the hijack and tracked-pointer-up tests must drive real
+     * PointerProperties/PointerCoords arrays.
+     */
+    private fun obtainMulti(action: Int, vararg pointers: Pointer): MotionEvent {
+        val now = SystemClock.uptimeMillis()
+        val props = Array(pointers.size) { i ->
+            MotionEvent.PointerProperties().apply {
+                id = pointers[i].id
+                toolType = MotionEvent.TOOL_TYPE_FINGER
+            }
+        }
+        val coords = Array(pointers.size) { i ->
+            MotionEvent.PointerCoords().apply {
+                x = pointers[i].x
+                y = pointers[i].y
+                pressure = 1f
+                size = 1f
+            }
+        }
+        return MotionEvent.obtain(
+            now, now, action, pointers.size, props, coords,
+            0, 0, 1f, 1f, 0, 0, 0, 0
+        )
+    }
+
+    /** Pack an ACTION_POINTER_DOWN/UP action with the pointer slot index that moved. */
+    private fun pointerAction(maskedAction: Int, pointerIndex: Int): Int =
+        maskedAction or (pointerIndex shl MotionEvent.ACTION_POINTER_INDEX_SHIFT)
+
     /** Fire the pending long-press runnable on a multi-alt key by advancing the looper. */
     private fun openSlideOn(button: Button) {
         val down = obtain(MotionEvent.ACTION_DOWN, button.width / 2f, button.height / 2f)
@@ -236,7 +271,87 @@ class AltKeySlideTest {
     }
 
     @Test
-    fun `a second pointer mid-slide does not change the committed candidate`() {
+    fun `a second pointer mid-slide does not move or commit the tracked candidate`() {
+        // Genuine multi-pointer gesture: pointer 0 (tracked) drives candidate 1; a
+        // second pointer goes down over candidate 3 and then MOVES across the row.
+        // The activePointerId gate must keep the highlight on pointer 0's candidate.
+        // The mutation `findPointerIndex(activePointerId) -> 0` (or dropping the
+        // gate) makes this fail, because the second pointer would hijack the hover.
+        val aButton = charButtonAt(1, 0)
+        val alts = AltKeyMappings.getAlts("a")!!
+        assertTrue("test needs at least four alts", alts.size >= 4)
+        openSlideOn(aButton)
+        val session = keyboard.currentSlideSession!!
+
+        val rect1 = session.candidateRectsForTest()[1]
+        val x1 = localXForCandidate(aButton, rect1)
+        val y1 = localYForCandidate(aButton, rect1)
+        val rect3 = session.candidateRectsForTest()[3]
+        val x3 = localXForCandidate(aButton, rect3)
+        val y3 = localYForCandidate(aButton, rect3)
+
+        // Tracked finger (pointer 0) hovers candidate 1.
+        val move0 = obtain(MotionEvent.ACTION_MOVE, x1, y1)
+        aButton.dispatchTouchEvent(move0)
+        move0.recycle()
+        assertEquals(1, session.hoveredIndex)
+
+        // A second finger (pointer id 1) goes down over candidate 3.
+        val pointerDown = obtainMulti(
+            pointerAction(MotionEvent.ACTION_POINTER_DOWN, 1),
+            Pointer(0, x1, y1), Pointer(1, x3, y3)
+        )
+        aButton.dispatchTouchEvent(pointerDown)
+        pointerDown.recycle()
+        assertEquals("second pointer down must not move the highlight", 1, session.hoveredIndex)
+
+        // The second finger MOVES to candidate 0 while pointer 0 holds at candidate
+        // 1. The hijacker is placed at slot index 0 and the tracked finger at slot
+        // index 1, so a naive `idx = 0` (instead of findPointerIndex(activePointerId))
+        // would read the hijacker's coords and move the highlight to candidate 0.
+        // The activePointerId gate must keep it on candidate 1.
+        val rect0 = session.candidateRectsForTest()[0]
+        val x0 = localXForCandidate(aButton, rect0)
+        val y0 = localYForCandidate(aButton, rect0)
+        val twoFingerMove = obtainMulti(
+            MotionEvent.ACTION_MOVE,
+            Pointer(1, x0, y0), Pointer(0, x1, y1)
+        )
+        aButton.dispatchTouchEvent(twoFingerMove)
+        twoFingerMove.recycle()
+        assertEquals("second pointer move must not hijack the highlight", 1, session.hoveredIndex)
+
+        // The tracked finger lifts, still over candidate 1, as the last pointer.
+        val up = obtain(MotionEvent.ACTION_UP, x1, y1)
+        aButton.dispatchTouchEvent(up)
+        up.recycle()
+
+        verify(keySender).sendText(any(), eq(alts[1]))
+    }
+
+    @Test
+    fun `ACTION_CANCEL during a slide dismisses without sending`() {
+        val aButton = charButtonAt(1, 0)
+        openSlideOn(aButton)
+        val session = keyboard.currentSlideSession
+        assertNotNull(session)
+        assertTrue(session!!.isShowing())
+
+        val cancel = obtain(MotionEvent.ACTION_CANCEL, aButton.width / 2f, aButton.height / 2f)
+        aButton.dispatchTouchEvent(cancel)
+        cancel.recycle()
+
+        verify(keySender, never()).sendText(any(), any())
+        assertFalse("cancel dismisses the slide popup", session.isShowing())
+        assertNull(keyboard.currentSlideSession)
+    }
+
+    @Test
+    fun `tracked finger lifting as a non-primary pointer commits its candidate`() {
+        // Gates the commit-via-ACTION_POINTER_UP branch: a second finger is down, so
+        // the tracked finger lifts as a non-primary pointer (ACTION_POINTER_UP whose
+        // actionIndex is the tracked slot). The slide must commit the tracked
+        // finger's hovered candidate, not ignore the lift.
         val aButton = charButtonAt(1, 0)
         val alts = AltKeyMappings.getAlts("a")!!
         openSlideOn(aButton)
@@ -245,32 +360,36 @@ class AltKeySlideTest {
         val rect1 = session.candidateRectsForTest()[1]
         val x1 = localXForCandidate(aButton, rect1)
         val y1 = localYForCandidate(aButton, rect1)
+        val rect2 = session.candidateRectsForTest()[2]
+        val x2 = localXForCandidate(aButton, rect2)
+        val y2 = localYForCandidate(aButton, rect2)
 
-        // Tracked finger hovers candidate 1.
-        val move = obtain(MotionEvent.ACTION_MOVE, x1, y1)
-        aButton.dispatchTouchEvent(move)
-        move.recycle()
+        // Tracked finger (pointer 0) hovers candidate 1.
+        val move0 = obtain(MotionEvent.ACTION_MOVE, x1, y1)
+        aButton.dispatchTouchEvent(move0)
+        move0.recycle()
         assertEquals(1, session.hoveredIndex)
 
-        // A second finger arrives over candidate 0 via ACTION_POINTER_DOWN. It
-        // must not hijack the hovered candidate.
-        val rect0 = session.candidateRectsForTest()[0]
-        val x0 = localXForCandidate(aButton, rect0)
-        val y0 = localYForCandidate(aButton, rect0)
-        val pointerDown = MotionEvent.obtain(
-            SystemClock.uptimeMillis(), SystemClock.uptimeMillis(),
-            MotionEvent.ACTION_POINTER_DOWN, x0, y0, 0
+        // A second finger (id 1) goes down over candidate 2.
+        val pointerDown = obtainMulti(
+            pointerAction(MotionEvent.ACTION_POINTER_DOWN, 1),
+            Pointer(0, x1, y1), Pointer(1, x2, y2)
         )
         aButton.dispatchTouchEvent(pointerDown)
         pointerDown.recycle()
-        assertEquals("second pointer must not move the highlight", 1, session.hoveredIndex)
 
-        // The tracked finger lifts, still over candidate 1.
-        val up = obtain(MotionEvent.ACTION_UP, x1, y1)
-        aButton.dispatchTouchEvent(up)
-        up.recycle()
+        // The tracked finger (pointer 0, slot index 0) lifts as a NON-primary
+        // pointer while pointer 1 is still down, still over candidate 1.
+        val pointerUp = obtainMulti(
+            pointerAction(MotionEvent.ACTION_POINTER_UP, 0),
+            Pointer(0, x1, y1), Pointer(1, x2, y2)
+        )
+        aButton.dispatchTouchEvent(pointerUp)
+        pointerUp.recycle()
 
         verify(keySender).sendText(any(), eq(alts[1]))
+        assertFalse(session.isShowing())
+        assertNull(keyboard.currentSlideSession)
     }
 
     // ---- Fix A: popup clamping keeps hit-test rects on the visible buttons ----

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -395,27 +395,51 @@ class AltKeySlideTest {
     // ---- Fix A: popup clamping keeps hit-test rects on the visible buttons ----
 
     @Test
-    fun `clampPopupLeft pins a negative requested left to zero`() {
+    fun `clampPopupLeft pins a negative requested left to the frame left`() {
         // A wide candidate row centered over a narrow edge key requests a negative
-        // left; the clamp must pin it to 0 so the visible popup and the rects agree.
-        assertEquals(0, AltKeyPopup.clampPopupLeft(requestedLeft = -120, popupWidth = 300, screenWidth = 1080))
+        // left; the clamp must pin it to the frame left so the visible popup and the
+        // rects agree. Portrait full-width IME: frame is [0, 1080].
+        assertEquals(0, AltKeyPopup.clampPopupLeft(requestedLeft = -120, popupWidth = 300, frameLeft = 0, frameRight = 1080))
     }
 
     @Test
-    fun `clampPopupLeft slides an overflowing-right popup back on screen`() {
-        // Requested right edge (1000 + 300 = 1300) overflows the 1080 screen, so the
-        // left clamps to screenWidth - popupWidth = 780.
-        assertEquals(780, AltKeyPopup.clampPopupLeft(requestedLeft = 1000, popupWidth = 300, screenWidth = 1080))
+    fun `clampPopupLeft slides an overflowing-right popup back inside the frame`() {
+        // Requested right edge (1000 + 300 = 1300) overflows the [0, 1080] frame, so
+        // the left clamps to frameRight - popupWidth = 780.
+        assertEquals(780, AltKeyPopup.clampPopupLeft(requestedLeft = 1000, popupWidth = 300, frameLeft = 0, frameRight = 1080))
     }
 
     @Test
     fun `clampPopupLeft leaves a popup that already fits unchanged`() {
-        assertEquals(400, AltKeyPopup.clampPopupLeft(requestedLeft = 400, popupWidth = 300, screenWidth = 1080))
+        assertEquals(400, AltKeyPopup.clampPopupLeft(requestedLeft = 400, popupWidth = 300, frameLeft = 0, frameRight = 1080))
     }
 
     @Test
-    fun `clampPopupLeft pins a popup wider than the screen to zero`() {
-        assertEquals(0, AltKeyPopup.clampPopupLeft(requestedLeft = -50, popupWidth = 1200, screenWidth = 1080))
+    fun `clampPopupLeft pins a popup wider than the frame to the frame left`() {
+        assertEquals(0, AltKeyPopup.clampPopupLeft(requestedLeft = -50, popupWidth = 1200, frameLeft = 0, frameRight = 1080))
+    }
+
+    @Test
+    fun `clampPopupLeft pins a left-overflowing popup to a non-zero frame left`() {
+        // Split-screen/freeform: the anchor window's visible frame is [200, 1000].
+        // A requested left of 150 falls left of the frame, so it pins to frameLeft.
+        // The old [0, screenWidth - popupWidth] clamp ignored frameLeft and returned
+        // 150 unchanged, leaving the rects off the left edge of the window.
+        assertEquals(200, AltKeyPopup.clampPopupLeft(requestedLeft = 150, popupWidth = 300, frameLeft = 200, frameRight = 1000))
+    }
+
+    @Test
+    fun `clampPopupLeft slides a right-overflowing popup to the non-zero frame right`() {
+        // Frame [200, 1000], popupWidth 300: requested left 850 would push the right
+        // edge to 1150, past frameRight, so it clamps to frameRight - popupWidth = 700.
+        assertEquals(700, AltKeyPopup.clampPopupLeft(requestedLeft = 850, popupWidth = 300, frameLeft = 200, frameRight = 1000))
+    }
+
+    @Test
+    fun `clampPopupLeft pins a popup wider than a non-zero frame to the frame left`() {
+        // Frame [200, 1000] is 800 wide; a 900-wide popup cannot fit, so it pins to
+        // frameLeft (200), not 0.
+        assertEquals(200, AltKeyPopup.clampPopupLeft(requestedLeft = 250, popupWidth = 900, frameLeft = 200, frameRight = 1000))
     }
 
     @Test
@@ -432,14 +456,18 @@ class AltKeySlideTest {
         val session = keyboard.currentSlideSession
         assertNotNull("long-press on a multi-alt key opens a slide session", session)
 
-        val screenWidth = aButton.context.resources.displayMetrics.widthPixels
+        // Assert against the anchor window's visible display frame -- the same Rect
+        // showAsDropDown clips against -- not raw displayMetrics.widthPixels, so the
+        // bounds match what the popup is actually clamped to in any window mode.
+        val displayFrame = Rect()
+        aButton.getWindowVisibleDisplayFrame(displayFrame)
         val rects = session!!.candidateRectsForTest()
         assertEquals(alts.size, rects.size)
 
         var previousRight = Int.MIN_VALUE
         for ((i, rect) in rects.withIndex()) {
-            assertTrue("rect $i must not start off the left edge: ${rect.left}", rect.left >= 0)
-            assertTrue("rect $i must not run off the right edge: ${rect.right} > $screenWidth", rect.right <= screenWidth)
+            assertTrue("rect $i must not start off the left edge: ${rect.left} < ${displayFrame.left}", rect.left >= displayFrame.left)
+            assertTrue("rect $i must not run off the right edge: ${rect.right} > ${displayFrame.right}", rect.right <= displayFrame.right)
             assertTrue("rects must be left-to-right ordered", rect.left > previousRight)
             previousRight = rect.right
         }

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -443,6 +443,31 @@ class AltKeySlideTest {
     }
 
     @Test
+    fun `popupScreenTop lands the row popupHeight above the anchor top`() {
+        // openForSlide picks yOffset = -(anchorHeight + popupHeight) to lift the
+        // candidate row above the key. Because showAsDropDown anchors to the anchor
+        // BOTTOM, the row's real top must be popupHeight above the anchor TOP. The
+        // naive anchorScreenY + yOffset lands a full anchor height too high, which
+        // is the regression this guards.
+        val anchorScreenY = 1200
+        val anchorHeight = 132
+        val popupHeight = 154
+        val yOffset = -(anchorHeight + popupHeight)
+        assertEquals(
+            anchorScreenY - popupHeight,
+            AltKeyPopup.popupScreenTop(anchorScreenY, anchorHeight, yOffset)
+        )
+    }
+
+    @Test
+    fun `popupScreenTop adds the anchor height to the bottom-anchored offset`() {
+        // General contract: top = anchorBottom + yOffset = anchorScreenY +
+        // anchorHeight + yOffset. A positive yOffset (drop-down below the key)
+        // exercises the same arithmetic the buggy form got wrong.
+        assertEquals(560, AltKeyPopup.popupScreenTop(anchorScreenY = 500, anchorHeight = 40, yOffset = 20))
+    }
+
+    @Test
     fun `slide popup on a far-left wide-alt key keeps every rect on screen and ordered`() {
         // "a" sits at the far-left column and carries ~6 accented alts, so the
         // centered candidate row is far wider than the key and its requested left

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -273,6 +273,63 @@ class AltKeySlideTest {
         verify(keySender).sendText(any(), eq(alts[1]))
     }
 
+    // ---- Fix A: popup clamping keeps hit-test rects on the visible buttons ----
+
+    @Test
+    fun `clampPopupLeft pins a negative requested left to zero`() {
+        // A wide candidate row centered over a narrow edge key requests a negative
+        // left; the clamp must pin it to 0 so the visible popup and the rects agree.
+        assertEquals(0, AltKeyPopup.clampPopupLeft(requestedLeft = -120, popupWidth = 300, screenWidth = 1080))
+    }
+
+    @Test
+    fun `clampPopupLeft slides an overflowing-right popup back on screen`() {
+        // Requested right edge (1000 + 300 = 1300) overflows the 1080 screen, so the
+        // left clamps to screenWidth - popupWidth = 780.
+        assertEquals(780, AltKeyPopup.clampPopupLeft(requestedLeft = 1000, popupWidth = 300, screenWidth = 1080))
+    }
+
+    @Test
+    fun `clampPopupLeft leaves a popup that already fits unchanged`() {
+        assertEquals(400, AltKeyPopup.clampPopupLeft(requestedLeft = 400, popupWidth = 300, screenWidth = 1080))
+    }
+
+    @Test
+    fun `clampPopupLeft pins a popup wider than the screen to zero`() {
+        assertEquals(0, AltKeyPopup.clampPopupLeft(requestedLeft = -50, popupWidth = 1200, screenWidth = 1080))
+    }
+
+    @Test
+    fun `slide popup on a far-left wide-alt key keeps every rect on screen and ordered`() {
+        // "a" sits at the far-left column and carries ~6 accented alts, so the
+        // centered candidate row is far wider than the key and its requested left
+        // goes negative. Before clamping, the rects started off screen and a slide
+        // onto the leftmost visible candidate hit-tested the wrong index or -1.
+        val aButton = charButtonAt(1, 0)
+        val alts = AltKeyMappings.getAlts("a")!!
+        assertTrue("test needs a wide-alt key", alts.size >= 4)
+
+        openSlideOn(aButton)
+        val session = keyboard.currentSlideSession
+        assertNotNull("long-press on a multi-alt key opens a slide session", session)
+
+        val screenWidth = aButton.context.resources.displayMetrics.widthPixels
+        val rects = session!!.candidateRectsForTest()
+        assertEquals(alts.size, rects.size)
+
+        var previousRight = Int.MIN_VALUE
+        for ((i, rect) in rects.withIndex()) {
+            assertTrue("rect $i must not start off the left edge: ${rect.left}", rect.left >= 0)
+            assertTrue("rect $i must not run off the right edge: ${rect.right} > $screenWidth", rect.right <= screenWidth)
+            assertTrue("rects must be left-to-right ordered", rect.left > previousRight)
+            previousRight = rect.right
+        }
+
+        // The leftmost visible candidate must map to alts[0]. Against the old code
+        // the first rect started negative, so its center hit-tested to -1.
+        assertEquals(0, session.indexAt(rects[0].centerX().toFloat(), rects[0].centerY().toFloat()))
+    }
+
     // ---- SlideSession unit tests (pure hit-testing) ----
 
     private fun synthSession(rects: List<Rect>): AltKeyPopup.SlideSession {

--- a/app/src/test/java/com/keyjawn/ClipboardHistoryManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ClipboardHistoryManagerTest.kt
@@ -162,6 +162,29 @@ class ClipboardHistoryManagerTest {
     }
 
     @Test
+    fun `destroy is idempotent`() {
+        // Tearing down twice must not throw (a rebuild may destroy an already
+        // destroyed manager).
+        manager.destroy()
+        manager.destroy()
+    }
+
+    @Test
+    fun `destroy unregisters the clipboard listener so later clips are ignored`() {
+        val context = RuntimeEnvironment.getApplication()
+        val clipboard =
+            context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+
+        manager.destroy()
+
+        // A clipboard change after destroy must not feed the torn-down manager.
+        clipboard.setPrimaryClip(
+            android.content.ClipData.newPlainText("label", "after destroy")
+        )
+        assertFalse(manager.getHistory().contains("after destroy"))
+    }
+
+    @Test
     fun `pinned items persist across instances`() {
         manager.addToHistory("persist me")
         manager.pin("persist me")

--- a/app/src/test/java/com/keyjawn/ClipboardHistoryManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ClipboardHistoryManagerTest.kt
@@ -194,4 +194,24 @@ class ClipboardHistoryManagerTest {
         assertTrue(manager2.isPinned("persist me"))
         manager2.destroy()
     }
+
+    @Test
+    fun `reusing the same instance keeps unpinned history but a new instance does not`() {
+        // Unpinned history lives only in memory on the instance (unlike pins, which
+        // round-trip through prefs). This is why KeyJawnService hoists one manager
+        // and reuses it across input-view rebuilds: reusing the same instance keeps
+        // the user's unpinned clips, while constructing a fresh one on every theme
+        // change (the pre-#37-follow-up behavior) silently drops them.
+        manager.addToHistory("unpinned clip")
+        assertEquals(listOf("unpinned clip"), manager.getHistory())
+
+        // Reuse: same instance still has the history.
+        assertEquals(listOf("unpinned clip"), manager.getHistory())
+
+        // Reconstruct: a brand-new instance starts empty (no inherited unpinned
+        // history), which is the data loss the hoist avoids.
+        val rebuilt = ClipboardHistoryManager(RuntimeEnvironment.getApplication())
+        assertFalse(rebuilt.getHistory().contains("unpinned clip"))
+        rebuilt.destroy()
+    }
 }

--- a/app/src/test/java/com/keyjawn/CtrlTransitionMessageTest.kt
+++ b/app/src/test/java/com/keyjawn/CtrlTransitionMessageTest.kt
@@ -1,0 +1,23 @@
+package com.keyjawn
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class CtrlTransitionMessageTest {
+
+    @Test
+    fun `armed maps to ctrl armed`() {
+        assertEquals("Ctrl armed", ctrlTransitionMessage(CtrlMode.ARMED))
+    }
+
+    @Test
+    fun `locked maps to ctrl locked`() {
+        assertEquals("Ctrl locked", ctrlTransitionMessage(CtrlMode.LOCKED))
+    }
+
+    @Test
+    fun `off has no transition tooltip`() {
+        // OFF fires on every armed-key consumption, so it must not pop a tooltip.
+        assertNull(ctrlTransitionMessage(CtrlMode.OFF))
+    }
+}

--- a/app/src/test/java/com/keyjawn/ExtraRowManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ExtraRowManagerTest.kt
@@ -2,7 +2,9 @@ package com.keyjawn
 
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.View
 import android.view.inputmethod.InputConnection
+import android.widget.TextView
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.*
@@ -135,5 +137,94 @@ class ExtraRowManagerTest {
         val captor = argumentCaptor<KeyEvent>()
         verify(ic, atLeast(1)).sendKeyEvent(captor.capture())
         assertTrue(captor.allValues.any { it.keyCode == KeyEvent.KEYCODE_TAB })
+    }
+
+    // --- Critical tooltips bypass the tooltips-disabled preference (Codex 5.4 finding) ---
+    // The tooltips toggle is meant to silence transient hints, not operation
+    // results and errors. These gate that distinction.
+
+    private fun managerWith(
+        prefs: AppPrefs,
+        voice: VoiceInputHandler? = null
+    ): Pair<View, ExtraRowManager> {
+        val context = RuntimeEnvironment.getApplication()
+        val view = LayoutInflater.from(context).inflate(R.layout.keyboard_view, null)
+        val ic: InputConnection = mock()
+        whenever(ic.sendKeyEvent(any())).thenReturn(true)
+        val erm = ExtraRowManager(
+            view = view,
+            keySender = KeySender(),
+            inputConnectionProvider = { ic },
+            voiceInputHandler = voice,
+            appPrefs = prefs
+        )
+        return view to erm
+    }
+
+    @Test
+    fun `critical tooltip shows even when tooltips disabled`() {
+        val prefs = AppPrefs(RuntimeEnvironment.getApplication())
+        prefs.setTooltipsEnabled(false)
+        val (view, erm) = managerWith(prefs)
+
+        erm.showTooltip("Uploaded photo.jpg", critical = true)
+
+        val bar = view.findViewById<TextView>(R.id.tooltip_bar)
+        assertEquals(View.VISIBLE, bar.visibility)
+        assertEquals("Uploaded photo.jpg", bar.text.toString())
+    }
+
+    @Test
+    fun `non-critical tooltip is suppressed when tooltips disabled`() {
+        val prefs = AppPrefs(RuntimeEnvironment.getApplication())
+        prefs.setTooltipsEnabled(false)
+        val (view, erm) = managerWith(prefs)
+
+        erm.showTooltip("press and hold for options")
+
+        val bar = view.findViewById<TextView>(R.id.tooltip_bar)
+        assertEquals(View.GONE, bar.visibility)
+    }
+
+    @Test
+    fun `non-critical tooltip shows when tooltips enabled`() {
+        val prefs = AppPrefs(RuntimeEnvironment.getApplication())
+        prefs.setTooltipsEnabled(true)
+        val (view, erm) = managerWith(prefs)
+
+        erm.showTooltip("press and hold for options")
+
+        val bar = view.findViewById<TextView>(R.id.tooltip_bar)
+        assertEquals(View.VISIBLE, bar.visibility)
+    }
+
+    @Test
+    fun `voice unavailable tap shows tooltip when tooltips disabled`() {
+        val prefs = AppPrefs(RuntimeEnvironment.getApplication())
+        prefs.setTooltipsEnabled(false)
+        val (view, _) = managerWith(prefs, voice = null)
+
+        view.findViewById<View>(R.id.key_mic).performClick()
+
+        val bar = view.findViewById<TextView>(R.id.tooltip_bar)
+        assertEquals(View.VISIBLE, bar.visibility)
+        assertEquals("Voice input not available", bar.text.toString())
+    }
+
+    @Test
+    fun `voice recognition error shows tooltip when tooltips disabled`() {
+        val prefs = AppPrefs(RuntimeEnvironment.getApplication())
+        prefs.setTooltipsEnabled(false)
+        val voice: VoiceInputHandler = mock()
+        val (view, _) = managerWith(prefs, voice = voice)
+
+        // The manager registers an anonymous VoiceInputListener on the handler;
+        // capture it and drive an error through the real onError path.
+        val captor = argumentCaptor<VoiceInputListener>()
+        verify(voice).listener = captor.capture()
+        captor.lastValue.onError(2)
+
+        val bar = view.findViewById<TextView>(R.id.tooltip_bar)
+        assertEquals(View.VISIBLE, bar.visibility)
     }
 }

--- a/app/src/test/java/com/keyjawn/KeyPreviewTest.kt
+++ b/app/src/test/java/com/keyjawn/KeyPreviewTest.kt
@@ -74,4 +74,20 @@ class KeyPreviewTest {
         assertSame(view1, view2)
         assertEquals("B", (view2 as TextView).text.toString())
     }
+
+    @Test
+    fun `multiple shows reuse the same background drawable`() {
+        // The background depends only on the theme, which does not change between
+        // presses, so it is built once in init and reused. The pre-#35 code rebuilt
+        // a fresh GradientDrawable on every show(); against that code these two
+        // references would differ.
+        val anchor = Button(RuntimeEnvironment.getApplication())
+        anchor.layout(100, 200, 200, 260)
+        container.addView(anchor)
+        keyPreview.show(anchor, "A")
+        val background1 = keyPreview.previewView.background
+        keyPreview.show(anchor, "B")
+        val background2 = keyPreview.previewView.background
+        assertSame(background1, background2)
+    }
 }

--- a/app/src/test/java/com/keyjawn/MenuPanelTest.kt
+++ b/app/src/test/java/com/keyjawn/MenuPanelTest.kt
@@ -219,6 +219,42 @@ class MenuPanelTest {
     }
 
     @Test
+    fun `building theme swatches does not write the live theme pref`() {
+        val context = RuntimeEnvironment.getApplication()
+        val prefs = context.getSharedPreferences("keyjawn_theme", 0)
+        // Establish a known selected theme before opening the menu.
+        themeManager.currentTheme = KeyboardTheme.TERMINAL
+        prefs.edit().putString("theme", KeyboardTheme.TERMINAL.name).commit()
+
+        // Count any write to the persisted "theme" pref while the menu is built.
+        var themeWrites = 0
+        val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == "theme") themeWrites++
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+
+        try {
+            // Opening the menu builds the theme swatch strip. Building swatches is a
+            // pure render and must not touch the persisted "theme" pref at all.
+            menuPanel.show()
+        } finally {
+            prefs.unregisterOnSharedPreferenceChangeListener(listener)
+        }
+
+        assertEquals(
+            "Building theme swatches must not write the persisted theme pref",
+            0,
+            themeWrites
+        )
+        assertEquals(
+            "Persisted theme must still be the originally selected theme",
+            KeyboardTheme.TERMINAL.name,
+            prefs.getString("theme", KeyboardTheme.DARK.name)
+        )
+        assertEquals(KeyboardTheme.TERMINAL, themeManager.currentTheme)
+    }
+
+    @Test
     fun `bottom padding slider fires callback and updates pref`() {
         menuPanel.show()
         // Find the SeekBar

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -384,6 +384,21 @@ class QwertyKeyboardTest {
     }
 
     @Test
+    fun `alt-key buttons have no background so the themed frame shows through`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        val row2 = container.getChildAt(1) as LinearLayout
+        // Row 2 starts with "a", which has accented alt characters and is wrapped
+        // in a FrameLayout carrying the key background.
+        val aView = row2.getChildAt(0)
+        assertTrue("alt key should be wrapped in a FrameLayout", aView is FrameLayout)
+        val frame = aView as FrameLayout
+        assertNotNull("the wrapping frame carries the key background", frame.background)
+        val innerButton = frame.getChildAt(0) as Button
+        assertEquals("a", innerButton.text.toString())
+        assertNull("the wrapped button must not paint its own background", innerButton.background)
+    }
+
+    @Test
     fun `autocorrect flag is cached and not re-read from prefs on every call`() {
         val context = RuntimeEnvironment.getApplication()
         context.getSharedPreferences("keyjawn_app_prefs", 0).edit().clear().commit()

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -339,4 +339,28 @@ class QwertyKeyboardTest {
         val firstKey = findButton(row2.getChildAt(0))
         assertEquals("*", firstKey.text.toString())
     }
+
+    @Test
+    fun `updatePackage with same package does not rebuild the grid`() {
+        keyboard.updatePackage("com.example.app")
+        val rowBefore = container.getChildAt(0)
+
+        keyboard.updatePackage("com.example.app")
+        val rowAfter = container.getChildAt(0)
+
+        // A rebuild calls removeAllViews() and re-inflates, producing new view
+        // instances. Unchanged package must reuse the existing grid.
+        assertSame(rowBefore, rowAfter)
+    }
+
+    @Test
+    fun `updatePackage with a different package rebuilds the grid`() {
+        keyboard.updatePackage("com.example.app")
+        val rowBefore = container.getChildAt(0)
+
+        keyboard.updatePackage("com.other.app")
+        val rowAfter = container.getChildAt(0)
+
+        assertNotSame(rowBefore, rowAfter)
+    }
 }

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -363,4 +363,23 @@ class QwertyKeyboardTest {
 
         assertNotSame(rowBefore, rowAfter)
     }
+
+    @Test
+    fun `ctrlKeyCode maps lowercase letters to their keycodes`() {
+        assertEquals(KeyEvent.KEYCODE_A, QwertyKeyboard.ctrlKeyCode('a'))
+        assertEquals(KeyEvent.KEYCODE_Z, QwertyKeyboard.ctrlKeyCode('z'))
+    }
+
+    @Test
+    fun `ctrlKeyCode maps uppercase letters to their keycodes`() {
+        assertEquals(KeyEvent.KEYCODE_A, QwertyKeyboard.ctrlKeyCode('A'))
+        assertEquals(KeyEvent.KEYCODE_Z, QwertyKeyboard.ctrlKeyCode('Z'))
+    }
+
+    @Test
+    fun `ctrlKeyCode returns unknown for non-letters`() {
+        assertEquals(KeyEvent.KEYCODE_UNKNOWN, QwertyKeyboard.ctrlKeyCode('1'))
+        assertEquals(KeyEvent.KEYCODE_UNKNOWN, QwertyKeyboard.ctrlKeyCode('/'))
+        assertEquals(KeyEvent.KEYCODE_UNKNOWN, QwertyKeyboard.ctrlKeyCode('@'))
+    }
 }

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -1,5 +1,7 @@
 package com.keyjawn
 
+import android.app.Activity
+import android.os.Looper
 import android.os.SystemClock
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -8,13 +10,17 @@ import android.view.inputmethod.InputConnection
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.TextView
 import org.junit.Before
 import org.junit.Test
 import org.junit.Assert.*
 import org.junit.runner.RunWith
 import org.mockito.kotlin.*
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -26,6 +32,7 @@ class QwertyKeyboardTest {
     private lateinit var extraRowManager: ExtraRowManager
     private lateinit var ic: InputConnection
     private lateinit var keyboard: QwertyKeyboard
+    private lateinit var activityController: ActivityController<Activity>
 
     @Before
     fun setUp() {
@@ -47,6 +54,20 @@ class QwertyKeyboardTest {
             addView(extraRowView)
         }
         extraRowManager = ExtraRowManager(parentView, keySender, { ic })
+
+        // Host the keyboard container in an attached Activity window so the
+        // one-shot shift reset and auto-capitalize relabel -- which the keyboard
+        // schedules via container.post {} -- route to the main looper. On a
+        // detached view those runnables sit in the view's run queue and never
+        // fire, so idleMainLooper() could not drain them. Attaching makes the
+        // posted work deterministically drainable.
+        val root = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            addView(parentView)
+            addView(container)
+        }
+        activityController = Robolectric.buildActivity(Activity::class.java).setup()
+        activityController.get().setContentView(root)
 
         keyboard = QwertyKeyboard(container, keySender, extraRowManager, { ic })
         keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
@@ -85,6 +106,23 @@ class QwertyKeyboardTest {
         button.dispatchTouchEvent(up)
         down.recycle()
         up.recycle()
+    }
+
+    /**
+     * Drain the main looper so any container.post {} runnables (the one-shot
+     * shift auto-reset and the auto-capitalize relabel) run synchronously before
+     * assertions. Robolectric defaults to LooperMode.PAUSED, so without this the
+     * posted setLayer() never executes and a label/state assertion races against
+     * the scheduler -- the source of the prior attempt's non-deterministic flake.
+     */
+    private fun idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    /** The clickable Button for the character at (rowIndex, colIndex). */
+    private fun charButtonAt(rowIndex: Int, colIndex: Int): Button {
+        val row = container.getChildAt(rowIndex) as LinearLayout
+        return findButton(row.getChildAt(colIndex))
     }
 
     @Test
@@ -444,5 +482,213 @@ class QwertyKeyboardTest {
         prefs.toggleAutocorrect("com.example.app")
         kb.refreshAutocorrect()
         assertTrue(kb.isAutocorrectOn())
+    }
+
+    // ---- Render guard (#29 / #28 part 1) ----
+
+    @Test
+    fun `setLayer to the same layer does not rebuild the grid`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        val rowBefore = container.getChildAt(0)
+
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        val rowAfter = container.getChildAt(0)
+
+        // A rebuild calls removeAllViews() and re-inflates, producing a new row
+        // instance. The same-layer guard must reuse the existing grid.
+        assertSame(rowBefore, rowAfter)
+    }
+
+    @Test
+    fun `refreshRender rebuilds even on the same layer`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        val rowBefore = container.getChildAt(0)
+
+        keyboard.refreshRender()
+        val rowAfter = container.getChildAt(0)
+
+        // The force path must tear down and rebuild so callers that change a
+        // keycap without a layer change (spacebar, quick key) see the update.
+        assertNotSame(rowBefore, rowAfter)
+    }
+
+    @Test
+    fun `switching to a different layer rebuilds the grid`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        val rowBefore = container.getChildAt(0)
+
+        keyboard.setLayer(KeyboardLayouts.LAYER_SYMBOLS)
+        val rowAfter = container.getChildAt(0)
+
+        assertNotSame(rowBefore, rowAfter)
+    }
+
+    // ---- In-place shift relabel (#29 / #28 part 2) ----
+
+    @Test
+    fun `shift toggle relabels letter keys in place without tearing down the grid`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        val row1Before = container.getChildAt(0) as LinearLayout
+        val qButtonBefore = charButtonAt(0, 0)
+        val row3Before = container.getChildAt(2) as LinearLayout
+        val shiftBefore = findButton(row3Before.getChildAt(0))
+        assertEquals("q", qButtonBefore.text.toString())
+
+        keyboard.setLayer(KeyboardLayouts.LAYER_UPPER)
+
+        val row1After = container.getChildAt(0) as LinearLayout
+        val qButtonAfter = charButtonAt(0, 0)
+        val row3After = container.getChildAt(2) as LinearLayout
+        val shiftAfter = findButton(row3After.getChildAt(0))
+
+        // No teardown: every View instance survives the toggle.
+        assertSame("row view must be reused", row1Before, row1After)
+        assertSame("letter button must be reused", qButtonBefore, qButtonAfter)
+        assertSame("shift button must be reused", shiftBefore, shiftAfter)
+        // The reused button is relabeled to the upper case.
+        assertEquals("Q", qButtonAfter.text.toString())
+
+        // And back the other way, still in place.
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        assertSame(qButtonBefore, charButtonAt(0, 0))
+        assertEquals("q", charButtonAt(0, 0).text.toString())
+    }
+
+    @Test
+    fun `alt hint updates case in place on a shift toggle`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        // Row 2 index 0 is "a", which carries accented alt characters and is
+        // wrapped in a FrameLayout with a hint TextView.
+        val row2 = container.getChildAt(1) as LinearLayout
+        val aFrame = row2.getChildAt(0) as FrameLayout
+        val hint = aFrame.getChildAt(1) as TextView
+        val lowerHint = hint.text.toString()
+
+        keyboard.setLayer(KeyboardLayouts.LAYER_UPPER)
+
+        // Same TextView instance, relabeled to the uppercase alt.
+        val row2After = container.getChildAt(1) as LinearLayout
+        val aFrameAfter = row2After.getChildAt(0) as FrameLayout
+        assertSame("hint TextView must be reused", hint, aFrameAfter.getChildAt(1))
+        assertEquals(lowerHint.uppercase(), hint.text.toString())
+        assertNotEquals(lowerHint, hint.text.toString())
+    }
+
+    // ---- Emitted case correct after every shift transition ----
+
+    @Test
+    fun `one-shot shift emits uppercase then resets and emits lowercase`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        // OFF -> SINGLE
+        val shiftButton = charButtonAt(2, 0)
+        shiftButton.performClick()
+        assertEquals(KeyboardLayouts.LAYER_UPPER, keyboard.currentLayer)
+
+        // Type a character: emits uppercase synchronously.
+        simulateTap(charButtonAt(0, 0))
+        verify(keySender).sendChar(any(), eq("Q"), any())
+        assertEquals(ShiftState.OFF, keyboard.shiftState)
+
+        // The auto-reset is posted; drive the looper so the relabel runs.
+        idleMainLooper()
+        assertEquals(KeyboardLayouts.LAYER_LOWER, keyboard.currentLayer)
+        assertEquals("q", charButtonAt(0, 0).text.toString())
+
+        // The next tap emits lowercase -- label and output stay in sync.
+        clearInvocations(keySender)
+        simulateTap(charButtonAt(0, 0))
+        verify(keySender).sendChar(any(), eq("q"), any())
+    }
+
+    @Test
+    fun `caps lock keeps emitting uppercase across taps`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        // OFF -> SINGLE -> CAPS_LOCK (two quick taps on the reused shift button).
+        charButtonAt(2, 0).performClick()
+        charButtonAt(2, 0).performClick()
+        assertEquals(ShiftState.CAPS_LOCK, keyboard.shiftState)
+        assertEquals(KeyboardLayouts.LAYER_UPPER, keyboard.currentLayer)
+
+        simulateTap(charButtonAt(0, 0))
+        verify(keySender).sendChar(any(), eq("Q"), any())
+        idleMainLooper()
+        // Still uppercase: caps lock does not reset.
+        assertEquals(ShiftState.CAPS_LOCK, keyboard.shiftState)
+        assertEquals("Q", charButtonAt(0, 0).text.toString())
+
+        clearInvocations(keySender)
+        simulateTap(charButtonAt(0, 0))
+        verify(keySender).sendChar(any(), eq("Q"), any())
+    }
+
+    @Test
+    fun `caps lock to OFF returns to lowercase and emits lowercase`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        // OFF -> SINGLE -> CAPS_LOCK -> OFF (three taps).
+        charButtonAt(2, 0).performClick()
+        charButtonAt(2, 0).performClick()
+        charButtonAt(2, 0).performClick()
+        assertEquals(ShiftState.OFF, keyboard.shiftState)
+        assertEquals(KeyboardLayouts.LAYER_LOWER, keyboard.currentLayer)
+
+        simulateTap(charButtonAt(0, 0))
+        verify(keySender).sendChar(any(), eq("q"), any())
+    }
+
+    @Test
+    fun `label and output stay in sync across repeated shift toggles`() {
+        keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+        repeat(5) {
+            keyboard.setLayer(KeyboardLayouts.LAYER_UPPER)
+            assertEquals("Q", charButtonAt(0, 0).text.toString())
+            clearInvocations(keySender)
+            simulateTap(charButtonAt(0, 0))
+            verify(keySender).sendChar(any(), eq("Q"), any())
+            idleMainLooper()
+
+            keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
+            assertEquals("q", charButtonAt(0, 0).text.toString())
+            clearInvocations(keySender)
+            simulateTap(charButtonAt(0, 0))
+            verify(keySender).sendChar(any(), eq("q"), any())
+            idleMainLooper()
+        }
+    }
+
+    // ---- Auto-capitalize coverage (non-blocking gap from the prior attempt) ----
+
+    @Test
+    fun `auto-capitalize relabels to upper in place and the next key emits uppercase`() {
+        val context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("keyjawn_app_prefs", 0).edit().clear().commit()
+        val prefs = AppPrefs(context)
+        prefs.setAutocorrect("com.example.app", true)
+        val kb = QwertyKeyboard(container, keySender, extraRowManager, { ic }, prefs)
+        kb.updatePackage("com.example.app")
+        assertTrue(kb.isAutocorrectOn())
+        assertEquals(KeyboardLayouts.LAYER_LOWER, kb.currentLayer)
+
+        val qButton = charButtonAt(0, 0)
+
+        // Sentence-ending punctuation before the cursor triggers auto-capitalize
+        // on the next space (item 10 path in handleKeyPress).
+        whenever(ic.getTextBeforeCursor(2, 0)).thenReturn(". ")
+        val row4 = container.getChildAt(3) as LinearLayout
+        val spaceButton = findButton(row4.getChildAt(2))
+        spaceButton.performClick()
+
+        assertEquals(ShiftState.SINGLE, kb.shiftState)
+
+        // setLayer(LAYER_UPPER) is posted; drive the looper to apply the relabel.
+        idleMainLooper()
+        assertEquals(KeyboardLayouts.LAYER_UPPER, kb.currentLayer)
+        // Relabeled in place -- same button instance, now uppercase.
+        assertSame(qButton, charButtonAt(0, 0))
+        assertEquals("Q", charButtonAt(0, 0).text.toString())
+
+        // The next character is emitted uppercase.
+        clearInvocations(keySender)
+        simulateTap(charButtonAt(0, 0))
+        verify(keySender).sendChar(any(), eq("Q"), any())
     }
 }

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -382,4 +382,52 @@ class QwertyKeyboardTest {
         assertEquals(KeyEvent.KEYCODE_UNKNOWN, QwertyKeyboard.ctrlKeyCode('/'))
         assertEquals(KeyEvent.KEYCODE_UNKNOWN, QwertyKeyboard.ctrlKeyCode('@'))
     }
+
+    @Test
+    fun `autocorrect flag is cached and not re-read from prefs on every call`() {
+        val context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("keyjawn_app_prefs", 0).edit().clear().commit()
+        val prefs = AppPrefs(context)
+        val kb = QwertyKeyboard(container, keySender, extraRowManager, { ic }, prefs)
+
+        prefs.setAutocorrect("com.example.app", true)
+        kb.updatePackage("com.example.app")
+        assertTrue(kb.isAutocorrectOn())
+
+        // Flip the pref directly, bypassing the keyboard's boundary events. The
+        // cached flag must not observe the change on a plain read.
+        prefs.setAutocorrect("com.example.app", false)
+        assertTrue("autocorrect read must come from the cache, not prefs", kb.isAutocorrectOn())
+    }
+
+    @Test
+    fun `updatePackage refreshes the cached autocorrect flag`() {
+        val context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("keyjawn_app_prefs", 0).edit().clear().commit()
+        val prefs = AppPrefs(context)
+        prefs.setAutocorrect("com.app.on", true)
+        val kb = QwertyKeyboard(container, keySender, extraRowManager, { ic }, prefs)
+
+        kb.updatePackage("com.app.off")
+        assertFalse(kb.isAutocorrectOn())
+
+        kb.updatePackage("com.app.on")
+        assertTrue(kb.isAutocorrectOn())
+    }
+
+    @Test
+    fun `refreshAutocorrect picks up an external toggle for the current package`() {
+        val context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("keyjawn_app_prefs", 0).edit().clear().commit()
+        val prefs = AppPrefs(context)
+        val kb = QwertyKeyboard(container, keySender, extraRowManager, { ic }, prefs)
+        kb.updatePackage("com.example.app")
+        assertFalse(kb.isAutocorrectOn())
+
+        // The MenuPanel toggle writes the pref then signals the keyboard to
+        // refresh through this single update point.
+        prefs.toggleAutocorrect("com.example.app")
+        kb.refreshAutocorrect()
+        assertTrue(kb.isAutocorrectOn())
+    }
 }

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -3,9 +3,11 @@ package com.keyjawn
 import android.app.Activity
 import android.os.Looper
 import android.os.SystemClock
+import android.text.InputType
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.widget.Button
 import android.widget.FrameLayout
@@ -400,6 +402,53 @@ class QwertyKeyboardTest {
         val rowAfter = container.getChildAt(0)
 
         assertNotSame(rowBefore, rowAfter)
+    }
+
+    @Test
+    fun `same-package field switch refreshes the adaptive enter label`() {
+        keyboard.updatePackage("com.example.app")
+        val enterBefore = findButton((container.getChildAt(3) as LinearLayout).getChildAt(4))
+        assertNotEquals("Search", enterBefore.text.toString())
+
+        // Focus moves to a search field in the SAME app: only the IME action
+        // changes, so updatePackage takes its same-package path -- but the Enter
+        // label must still refresh to "Search".
+        keyboard.updateImeAction(EditorInfo.IME_ACTION_SEARCH, 0)
+        keyboard.updatePackage("com.example.app")
+
+        val enterAfter = findButton((container.getChildAt(3) as LinearLayout).getChildAt(4))
+        assertEquals("Search", enterAfter.text.toString())
+    }
+
+    @Test
+    fun `same-package field switch refreshes the input-type quick key override`() {
+        keyboard.updatePackage("com.example.app")
+        val quickBefore = findButton((container.getChildAt(3) as LinearLayout).getChildAt(3))
+        assertEquals("/", quickBefore.text.toString())
+
+        // Focus moves to an email field in the SAME app: the quick key must switch
+        // to "@" even though the package is unchanged.
+        keyboard.updateInputType(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS)
+        keyboard.updatePackage("com.example.app")
+
+        val quickAfter = findButton((container.getChildAt(3) as LinearLayout).getChildAt(3))
+        assertEquals("@", quickAfter.text.toString())
+    }
+
+    @Test
+    fun `same-package refocus with unchanged editor state does not rebuild`() {
+        keyboard.updateImeAction(EditorInfo.IME_ACTION_SEARCH, 0)
+        keyboard.updatePackage("com.example.app")
+        val rowBefore = container.getChildAt(0)
+
+        // Re-focus a field of the same kind in the same app: identical action and
+        // input type, so the #29 optimization must still skip the rebuild.
+        keyboard.updateImeAction(EditorInfo.IME_ACTION_SEARCH, 0)
+        keyboard.updateInputType(0)
+        keyboard.updatePackage("com.example.app")
+        val rowAfter = container.getChildAt(0)
+
+        assertSame(rowBefore, rowAfter)
     }
 
     @Test

--- a/app/src/test/java/com/keyjawn/SlashCommandPopupTest.kt
+++ b/app/src/test/java/com/keyjawn/SlashCommandPopupTest.kt
@@ -1,0 +1,113 @@
+package com.keyjawn
+
+import android.app.Activity
+import android.graphics.drawable.ColorDrawable
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.PopupWindow
+import android.widget.ScrollView
+import android.widget.TextView
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SlashCommandPopupTest {
+
+    private lateinit var registry: SlashCommandRegistry
+    private lateinit var themeManager: ThemeManager
+    private lateinit var controller: ActivityController<Activity>
+    private lateinit var anchor: Button
+
+    @Before
+    fun setUp() {
+        val context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences("keyjawn_theme", 0).edit().clear().commit()
+        registry = SlashCommandRegistry(context)
+        themeManager = ThemeManager(context)
+
+        // PopupWindow.showAtLocation needs an anchor with a window token, so host
+        // the anchor in a started activity.
+        controller = Robolectric.buildActivity(Activity::class.java).setup()
+        anchor = Button(controller.get())
+        controller.get().setContentView(anchor)
+    }
+
+    @After
+    fun tearDown() {
+        controller.pause().stop().destroy()
+    }
+
+    /**
+     * The popup must color its background from keyboardBg() and item text from
+     * keyText() for the active theme. Against the pre-#42 code, which hardcoded
+     * 0xFF1E1E1E for the background and 0xFFFFFFFF for the item text, these
+     * assertions fail for every theme (no theme's keyboardBg/keyText equals those
+     * constants).
+     */
+    @Test
+    fun `popup colors background and item text from the dark theme tokens`() {
+        themeManager.currentTheme = KeyboardTheme.DARK
+        assertPopupThemed(KeyboardTheme.DARK)
+    }
+
+    @Test
+    fun `popup colors background and item text from the light theme tokens`() {
+        themeManager.currentTheme = KeyboardTheme.LIGHT
+        assertPopupThemed(KeyboardTheme.LIGHT)
+    }
+
+    private fun assertPopupThemed(theme: KeyboardTheme) {
+        val expectedBg = themeManager.keyboardBg()
+        val expectedText = themeManager.keyText()
+
+        // Sanity: the theme tokens must differ from the old hardcoded values, or
+        // this test could pass against the pre-fix code by accident.
+        assertNotEquals(OLD_HARDCODED_BG, expectedBg)
+        assertNotEquals(OLD_HARDCODED_TEXT, expectedText)
+
+        val popup = SlashCommandPopup(
+            registry = registry,
+            onCommandSelected = {},
+            onDismissedEmpty = {},
+            themeManager = themeManager
+        )
+        popup.show(anchor)
+        assertTrue("popup did not show for theme $theme", popup.isShowing())
+
+        val window = popupWindowField(popup)
+        val content = window.contentView as ScrollView
+
+        // Background applied to both the content ScrollView and the window itself.
+        assertEquals(expectedBg, (content.background as ColorDrawable).color)
+        assertEquals(expectedBg, (window.background as ColorDrawable).color)
+
+        val list = content.findViewById<LinearLayout>(R.id.command_list)
+        assertTrue("popup produced no command items", list.childCount > 0)
+        for (i in 0 until list.childCount) {
+            val item = list.getChildAt(i) as TextView
+            assertEquals(expectedText, item.currentTextColor)
+        }
+
+        popup.dismiss()
+    }
+
+    private fun popupWindowField(popup: SlashCommandPopup): PopupWindow {
+        val field = SlashCommandPopup::class.java.getDeclaredField("popup")
+        field.isAccessible = true
+        return field.get(popup) as PopupWindow
+    }
+
+    companion object {
+        private val OLD_HARDCODED_BG = 0xFF1E1E1E.toInt()
+        private val OLD_HARDCODED_TEXT = 0xFFFFFFFF.toInt()
+    }
+}

--- a/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
@@ -209,4 +209,78 @@ class ThemeManagerTest {
             assertEquals(swatch.keyText, themeManager.keyText())
         }
     }
+
+    @Test
+    fun `createKeyDrawable hands out a distinct copy of one cached prototype`() {
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val color = themeManager.keyBg()
+
+        // Each call returns its own Drawable (a Drawable can back only one view).
+        val first = themeManager.createKeyDrawable(color)
+        val second = themeManager.createKeyDrawable(color)
+        assertNotSame(first, second)
+
+        // But both copies come from the same cached prototype: the drawable tree
+        // is built once, not per call.
+        assertSame(
+            themeManager.keyDrawablePrototype(color),
+            themeManager.keyDrawablePrototype(color)
+        )
+    }
+
+    @Test
+    fun `key drawable prototype is rebuilt after a theme change`() {
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val darkColor = themeManager.keyBg()
+        val darkProto = themeManager.keyDrawablePrototype(darkColor)
+
+        // Switching themes must invalidate the cache so a later lookup of the
+        // same color value resolves a fresh prototype (the pressed ripple color
+        // is theme-specific even when the surface color repeats).
+        themeManager.currentTheme = KeyboardTheme.TERMINAL
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val rebuiltProto = themeManager.keyDrawablePrototype(darkColor)
+
+        assertNotSame(darkProto, rebuiltProto)
+    }
+
+    @Test
+    fun `refresh rebuilds the key drawable prototype cache`() {
+        val context = RuntimeEnvironment.getApplication()
+        val prefs = context.getSharedPreferences("keyjawn_theme", 0)
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val color = themeManager.keyBg()
+        val before = themeManager.keyDrawablePrototype(color)
+
+        prefs.edit().putString("theme", KeyboardTheme.TERMINAL.name).commit()
+        themeManager.refresh()
+        prefs.edit().putString("theme", KeyboardTheme.DARK.name).commit()
+        themeManager.refresh()
+
+        assertNotSame(before, themeManager.keyDrawablePrototype(color))
+    }
+
+    @Test
+    fun `extra row button drawable reuses one cached prototype per color`() {
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val color = themeManager.arrowBg()
+        val first = themeManager.createExtraRowButtonDrawable(color)
+        val second = themeManager.createExtraRowButtonDrawable(color)
+        assertNotSame(first, second)
+        assertSame(
+            themeManager.extraRowButtonDrawablePrototype(color),
+            themeManager.extraRowButtonDrawablePrototype(color)
+        )
+    }
+
+    @Test
+    fun `createFlatDrawable copies share the immutable gradient constant state`() {
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val color = themeManager.accent()
+        val first = themeManager.createFlatDrawable(color)
+        val second = themeManager.createFlatDrawable(color)
+        // GradientDrawable copies share their ConstantState through newDrawable().
+        assertNotSame(first, second)
+        assertSame(first.constantState, second.constantState)
+    }
 }

--- a/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
@@ -105,6 +105,41 @@ class ThemeManagerTest {
     }
 
     @Test
+    fun `swatch does not read or write the persisted theme pref`() {
+        val context = RuntimeEnvironment.getApplication()
+        val prefs = context.getSharedPreferences("keyjawn_theme", 0)
+        themeManager.currentTheme = KeyboardTheme.LIGHT
+
+        var writes = 0
+        val listener = android.content.SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == "theme") writes++
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        try {
+            // Reading any other theme's palette must not change the live selection.
+            for (theme in KeyboardTheme.entries) {
+                themeManager.swatch(theme)
+            }
+        } finally {
+            prefs.unregisterOnSharedPreferenceChangeListener(listener)
+        }
+
+        assertEquals("swatch must not write the theme pref", 0, writes)
+        assertEquals(KeyboardTheme.LIGHT, themeManager.currentTheme)
+    }
+
+    @Test
+    fun `swatch colors match the instance resolvers for the active theme`() {
+        for (theme in KeyboardTheme.entries) {
+            themeManager.currentTheme = theme
+            val palette = themeManager.swatch(theme)
+            assertEquals("keyboardBg mismatch for $theme", themeManager.keyboardBg(), palette.keyboardBg)
+            assertEquals("keyBg mismatch for $theme", themeManager.keyBg(), palette.keyBg)
+            assertEquals("keyText mismatch for $theme", themeManager.keyText(), palette.keyText)
+        }
+    }
+
+    @Test
     fun `extra row background differs from keyboard background for non-OLED themes`() {
         for (theme in KeyboardTheme.entries) {
             if (theme == KeyboardTheme.OLED) continue // OLED uses pure black for both

--- a/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
@@ -175,6 +175,23 @@ class ThemeManagerTest {
     }
 
     @Test
+    fun `isThemeStale detects an external theme change`() {
+        val context = RuntimeEnvironment.getApplication()
+        val prefs = context.getSharedPreferences("keyjawn_theme", 0)
+
+        themeManager.currentTheme = KeyboardTheme.DARK
+        assertFalse(themeManager.isThemeStale())
+
+        // Another instance (e.g. SettingsActivity) writes a new theme.
+        prefs.edit().putString("theme", KeyboardTheme.LIGHT.name).commit()
+        assertTrue(themeManager.isThemeStale())
+
+        themeManager.refresh()
+        assertFalse(themeManager.isThemeStale())
+        assertEquals(KeyboardTheme.LIGHT, themeManager.currentTheme)
+    }
+
+    @Test
     fun `refresh re-resolves the theme and palette from prefs`() {
         val context = RuntimeEnvironment.getApplication()
         val prefs = context.getSharedPreferences("keyjawn_theme", 0)

--- a/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ThemeManagerTest.kt
@@ -151,4 +151,62 @@ class ThemeManagerTest {
             )
         }
     }
+
+    @Test
+    fun `color lookups do not re-read the theme pref after the theme is set`() {
+        val context = RuntimeEnvironment.getApplication()
+        val prefs = context.getSharedPreferences("keyjawn_theme", 0)
+
+        // Set the theme through the setter (the single refresh point).
+        themeManager.currentTheme = KeyboardTheme.DARK
+        val darkKeyBg = themeManager.keyBg()
+        assertEquals(0xFF2B2B30.toInt(), darkKeyBg)
+
+        // Mutate the persisted pref directly, bypassing the setter. A cached
+        // palette must not observe this change on a plain color lookup.
+        prefs.edit().putString("theme", KeyboardTheme.TERMINAL.name).commit()
+
+        assertEquals(
+            "color lookup must read the cached palette, not re-parse prefs",
+            darkKeyBg,
+            themeManager.keyBg()
+        )
+        assertEquals(KeyboardTheme.DARK, themeManager.currentTheme)
+    }
+
+    @Test
+    fun `refresh re-resolves the theme and palette from prefs`() {
+        val context = RuntimeEnvironment.getApplication()
+        val prefs = context.getSharedPreferences("keyjawn_theme", 0)
+
+        themeManager.currentTheme = KeyboardTheme.DARK
+        // External write, then explicit refresh: the cache picks up the change.
+        prefs.edit().putString("theme", KeyboardTheme.TERMINAL.name).commit()
+        themeManager.refresh()
+
+        assertEquals(KeyboardTheme.TERMINAL, themeManager.currentTheme)
+        assertEquals(0xFF0F2B0F.toInt(), themeManager.keyBg())
+    }
+
+    @Test
+    fun `themeForName resolves every enum name and falls back to DARK`() {
+        for (theme in KeyboardTheme.entries) {
+            assertEquals(theme, ThemeManager.themeForName(theme.name))
+        }
+        assertEquals(KeyboardTheme.DARK, ThemeManager.themeForName("NONEXISTENT"))
+        assertEquals(KeyboardTheme.DARK, ThemeManager.themeForName(null))
+    }
+
+    @Test
+    fun `cached palette matches per-theme colors across all resolvers`() {
+        // Resolve every color for each theme and assert the cache stays in sync
+        // with the theme after each set, with no stale carry-over.
+        for (theme in KeyboardTheme.entries) {
+            themeManager.currentTheme = theme
+            val swatch = themeManager.swatch(theme)
+            assertEquals(swatch.keyboardBg, themeManager.keyboardBg())
+            assertEquals(swatch.keyBg, themeManager.keyBg())
+            assertEquals(swatch.keyText, themeManager.keyText())
+        }
+    }
 }

--- a/app/src/test/java/com/keyjawn/VoiceErrorMessageTest.kt
+++ b/app/src/test/java/com/keyjawn/VoiceErrorMessageTest.kt
@@ -1,0 +1,38 @@
+package com.keyjawn
+
+import android.speech.SpeechRecognizer
+import org.junit.Test
+import org.junit.Assert.*
+
+class VoiceErrorMessageTest {
+
+    @Test
+    fun `no match maps to didn't catch that`() {
+        assertEquals("Didn't catch that", voiceErrorMessage(SpeechRecognizer.ERROR_NO_MATCH))
+    }
+
+    @Test
+    fun `speech timeout maps to didn't catch that`() {
+        assertEquals("Didn't catch that", voiceErrorMessage(SpeechRecognizer.ERROR_SPEECH_TIMEOUT))
+    }
+
+    @Test
+    fun `network maps to no network`() {
+        assertEquals("No network", voiceErrorMessage(SpeechRecognizer.ERROR_NETWORK))
+    }
+
+    @Test
+    fun `network timeout maps to no network`() {
+        assertEquals("No network", voiceErrorMessage(SpeechRecognizer.ERROR_NETWORK_TIMEOUT))
+    }
+
+    @Test
+    fun `recognizer busy maps to busy try again`() {
+        assertEquals("Busy, try again", voiceErrorMessage(SpeechRecognizer.ERROR_RECOGNIZER_BUSY))
+    }
+
+    @Test
+    fun `unknown code falls back to generic message`() {
+        assertEquals("Voice input failed", voiceErrorMessage(SpeechRecognizer.ERROR_AUDIO))
+    }
+}

--- a/app/src/test/java/com/keyjawn/VoiceInputHandlerTest.kt
+++ b/app/src/test/java/com/keyjawn/VoiceInputHandlerTest.kt
@@ -33,4 +33,12 @@ class VoiceInputHandlerTest {
         val handler = VoiceInputHandler(RuntimeEnvironment.getApplication())
         handler.destroy()
     }
+
+    @Test
+    fun `destroy is idempotent`() {
+        // A rebuild may destroy an already destroyed handler.
+        val handler = VoiceInputHandler(RuntimeEnvironment.getApplication())
+        handler.destroy()
+        handler.destroy()
+    }
 }

--- a/app/src/testLite/java/com/keyjawn/KeyJawnServiceClipboardReuseTest.kt
+++ b/app/src/testLite/java/com/keyjawn/KeyJawnServiceClipboardReuseTest.kt
@@ -1,0 +1,52 @@
+package com.keyjawn
+
+import android.view.View
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Gates issue #37: the clipboard manager is hoisted to onCreate() and reused
+ * across input-view rebuilds so a theme change does not drop the user's unpinned
+ * clip history. This drives the real service onCreateInputView() (lite flavor,
+ * whose UploadHandler is a no-op stub that avoids the Android Keystore the full
+ * flavor's encrypted prefs need) and asserts the manager field is never replaced.
+ *
+ * Against a regression that reverts onCreateInputView() to construct a fresh
+ * ClipboardHistoryManager per call, the second-rebuild assertion fails because
+ * the instance changes.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class KeyJawnServiceClipboardReuseTest {
+
+    @Test
+    fun `onCreateInputView reuses the clipboard manager built in onCreate`() {
+        val service = Robolectric.buildService(KeyJawnService::class.java).create().get()
+
+        // onCreate() must have built the manager.
+        val afterCreate = service.clipboardHistoryManager
+        assertNotNull("manager should be built in onCreate", afterCreate)
+
+        // First input-view build must reuse the same instance.
+        val firstView: View = service.onCreateInputView()
+        assertNotNull(firstView)
+        assertSame(
+            "first onCreateInputView must reuse the onCreate manager",
+            afterCreate,
+            service.clipboardHistoryManager
+        )
+
+        // A second build (as a theme change triggers) must also reuse it.
+        val secondView: View = service.onCreateInputView()
+        assertNotNull(secondView)
+        assertSame(
+            "second onCreateInputView must not replace the manager",
+            afterCreate,
+            service.clipboardHistoryManager
+        )
+    }
+}


### PR DESCRIPTION
## What this does

Burns down the open Android enhancement and bug-fix issues for the keyboard — rendering/allocation, IME lifecycle, theming/feedback, and touch. iOS issues (#43–#47) and roadmap items (#23–#27) are out of scope: iOS can't be built or verified on the Windows dev box, and the roadmap items need product direction.

## Closes

Closes #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #49

## Notes (addressed but intentionally not auto-closed)

- **#28** — the in-place rebuild is implemented for the shift toggle (lower↔upper relabel in place) and the same-package focus path is guarded, which covers the two hottest interactions. Layer switches (abc↔symbols) swap the whole key set and still do a full rebuild by design — low-value, high-effort to do in place. Left open in case you want the full custom-view rewrite later.
- **#48** — the offset bug it sits near is fixed (the slide-popup hit-rects were anchored to the wrong edge; see below). The specific latent flip-below clamp #48 asks for is not implemented; it's unreachable on standard phone geometry (the top QWERTY row always has room above for the popup). Left open as a tracked latent item.

## Issues by theme

**Rendering and allocation (no behavior change):**
- #29 / #28 — guard `render()` so a same-layer re-render is a no-op; relabel letter keys in place on a shift toggle
- #30 — cache per-theme key drawables and `ColorStateList`s; clear the platform-default background on alt-key views so the themed frame shows
- #31 — resolve the active theme once into a cached palette; refresh on keyboard open
- #32 — precompute both case variants of alt-key lists; cache display density
- #33 — replace reflective `KeyEvent.keyCodeFromString` on Ctrl-combos with a direct char-to-keycode map
- #34 — cache the per-package autocorrect flag; reuse the injected `AppPrefs`
- #35 — build the `KeyPreview` drawable and animators once and reuse them

**IME lifecycle correctness:**
- #37 — tear down old voice/upload handlers before rebuilding the input view; hoist `ClipboardHistoryManager` to `onCreate` so a reskin keeps unpinned clip history

**Feedback and theming:**
- #36 — render theme swatches from a pure palette without persisting the live theme pref
- #39 — surface voice-recognition error codes as in-keyboard tooltips
- #40 — route SCP upload status through the in-keyboard tooltip bar
- #41 — distinguish Ctrl armed vs locked by shape (underlined label), not color alone; brief transition tooltips
- #42 — theme the slash command popup background and item text

**Touch:**
- #38 — alt-key slide-and-release selection; clamp the popup to the anchor window's visible display frame so hit-test rects match the visible candidates

## Review fixes folded in

Two local review passes (Codex 5.4 low, then 5.5 high) ran to convergence:
- Critical tooltips (upload results, voice errors and permission prompts) were being suppressed when the user disabled transient tooltips. Added a `critical` flag so the preference gates only transient hints.
- The alt-key slide popup's hit-test rects were one key-height too high (`showAsDropDown` anchors to the anchor's bottom). Extracted a pure `popupScreenTop` and derive the rects from it.
- The #29 same-package early-return skipped the render that refreshes the adaptive Enter label and input-type quick-key override on a same-app field switch (#49). Track an editor-display-dirty flag so the optimization still skips a no-change refocus but yields when the labels must change.

## Testing

Both flavors' unit tests pass: `./gradlew testFullDebugUnitTest testLiteDebugUnitTest`. New tests gate every fix; the three review fixes were mutation-verified (revert the fix → the test fails). APK assembly is not run here (local keystore signing is environmental).
