### PR TITLE
test(qwerty): lock lower<->upper position-identity for the in-place shift relabel (#28)

### DIFF
--- a/app/src/test/java/com/keyjawn/KeyboardLayoutTest.kt
+++ b/app/src/test/java/com/keyjawn/KeyboardLayoutTest.kt
@@ -248,4 +248,78 @@ class KeyboardLayoutTest {
     fun `getLayer returns symbols2 for index 3`() {
         assertSame(KeyboardLayouts.symbols2, KeyboardLayouts.getLayer(3))
     }
+
+    // --- lower<->upper position-identity: the invariant the in-place shift
+    // relabel relies on ---
+    //
+    // QwertyKeyboard.applyShiftCase() relabels the existing letter buttons in
+    // place on a lower<->upper toggle instead of tearing the grid down, which is
+    // only safe because the two layers are position-identical: every (row, col)
+    // holds the same KeyOutput type, so a held Character button always maps to a
+    // Character key in the target layer. applyShiftCase has a safety net that
+    // falls back to a full rebuild if a position diverges, so a broken invariant
+    // would not corrupt the grid, but it would silently defeat the optimization
+    // (every shift would rebuild again). These tests lock the invariant so that
+    // regression is caught at build time instead.
+
+    @Test
+    fun `lowercase and uppercase are position-identical in output type`() {
+        val lower = KeyboardLayouts.lowercase
+        val upper = KeyboardLayouts.uppercase
+        assertEquals("row count differs", lower.size, upper.size)
+        for (r in lower.indices) {
+            assertEquals("row $r key count differs", lower[r].size, upper[r].size)
+            for (c in lower[r].indices) {
+                assertEquals(
+                    "output type at ($r,$c) differs between lowercase and uppercase",
+                    lower[r][c].output::class,
+                    upper[r][c].output::class
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every lowercase character position is a character in uppercase`() {
+        // applyShiftCase iterates only the Character positions (charHolders) and
+        // requires the same position in the target layer to also be a Character.
+        val lower = KeyboardLayouts.lowercase
+        val upper = KeyboardLayouts.uppercase
+        for (r in lower.indices) {
+            for (c in lower[r].indices) {
+                if (lower[r][c].output is KeyOutput.Character) {
+                    assertTrue(
+                        "($r,$c) is a Character in lowercase but not in uppercase",
+                        upper[r][c].output is KeyOutput.Character
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `symbol layers are not position-identical to lowercase so they must rebuild`() {
+        // The counterpart to the fast path: a switch to a symbol layer swaps the
+        // key set and count, so QwertyKeyboard rebuilds rather than relabeling.
+        // Assert the symbol layers genuinely are not position-identical, which
+        // documents why the in-place path is scoped to lower<->upper only.
+        val lower = KeyboardLayouts.lowercase
+        for ((name, symLayer) in listOf(
+            "symbols" to KeyboardLayouts.symbols,
+            "symbols2" to KeyboardLayouts.symbols2
+        )) {
+            val shapeMatches = lower.size == symLayer.size &&
+                lower.indices.all { lower[it].size == symLayer[it].size }
+            val positionIdentical = shapeMatches &&
+                lower.indices.all { r ->
+                    lower[r].indices.all { c ->
+                        lower[r][c].output::class == symLayer[r][c].output::class
+                    }
+                }
+            assertFalse(
+                "$name should not be position-identical to lowercase",
+                positionIdentical
+            )
+        }
+    }
 }


### PR DESCRIPTION
## What and why

Verifying #28 against current `main` first: most of its Option B is already implemented.

- Shift toggles (lower↔upper) already relabel the existing buttons in place via `QwertyKeyboard.applyShiftCase()` — no `removeAllViews()`, no re-inflate. That path covers the shift tap, the post-keypress shift auto-reset, and the space auto-capitalize, so the issue's "a single capital letter pays two full rebuilds" no longer holds.
- `updatePackage()` already early-returns on a same-package refocus (landed via #29), so moving between fields in the same app no longer rebuilds the grid.
- `render()` already has a same-layer no-op guard.

What remains of #28 is genuinely layer *set* switches (to/from the symbol layers), which swap the key count and set and so legitimately rebuild under a view-per-key model — that is Option A territory, tracked separately.

This PR hardens the part that already shipped rather than re-doing it. `applyShiftCase()` is safe only because lowercase and uppercase are position-identical: every `(row, col)` holds the same `KeyOutput` type, so a held `Character` button always maps to a `Character` key in the target layer. The method has a rebuild fallback if a position diverges, so a broken invariant would not corrupt output — but it would silently turn every shift back into a full rebuild, the exact waste #28 set out to remove, with nothing to flag it.

The three added tests (pure Kotlin, no Android runtime) pin that invariant:

- lowercase and uppercase are position-identical in output type (shape + per-position `KeyOutput` class),
- every lowercase `Character` position is also a `Character` in uppercase (the precise property `applyShiftCase` iterates on),
- the symbol layers are *not* position-identical to lowercase, documenting why the in-place path is scoped to lower↔upper only and the symbol switch still rebuilds.

## Testing

I could not run the Android unit tests on the machine that authored this (a headless services Pi with no Android SDK). The assertions are pure structural equalities verified by reading the layout definitions in `KeyboardLayout.kt`; CI runs `testFullDebugUnitTest` and `testLiteDebugUnitTest`, so the green check on this PR is the validating run.

Refs #28.

wake-20260703T1505-a29cd3
