### PR TITLE
perf(ios): relabel QWERTY keys in place on shift instead of rebuilding (#45)

### DIFF
--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/QwertyKeyboardView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/QwertyKeyboardView.swift
@@ -44,6 +44,12 @@ public final class QwertyKeyboardView: UIView {
     // MARK: Key views
 
     private var keyButtons: [QwertyKeyButton] = []
+    // The theme the current buttons were built under. Each QwertyKeyButton captures
+    // its theme at init for title and tint colours, so the in-place fast path is only
+    // valid while this matches the view's theme. It diverges when theme is set
+    // directly (the keyboard extension does qwerty.theme = ... rather than going
+    // through applyTheme), and the fast path must fall back to a full rebuild then.
+    private var builtTheme: KeyboardTheme?
 
     // MARK: - Init
 
@@ -61,11 +67,10 @@ public final class QwertyKeyboardView: UIView {
 
     // MARK: - Rebuild / layout
 
-    // Rebuild the key set for the current layer/shift. Reuses the existing buttons
-    // in place when the new layer is position-identical in kind, and only tears down
-    // and reallocates when the structure actually changes. Pass force to skip the
-    // fast path (a theme change has to rebuild so buttons pick up the new colours).
-    private func rebuild(force: Bool = false) {
+    // Rebuild the key set for the current layer/shift. Reuses the existing buttons in
+    // place when the new layer is position-identical in kind and they were built under
+    // the current theme; otherwise tears down and reallocates.
+    private func rebuild() {
         let rows = KeyboardLayers.rows(for: layer_, shiftState: shiftState)
         let newKeys = rows.flatMap { $0 }
 
@@ -77,11 +82,14 @@ public final class QwertyKeyboardView: UIView {
         // and SF Symbol lookups on every shift -- the churn issue #45 set out to kill.
         // The tap target and long-press recogniser stay attached for the button's
         // lifetime, and because the kind is unchanged a character button stays a
-        // character button, so the recogniser stays valid. A structural change (to or
-        // from the symbols layer, or the first build) falls through to the full
-        // rebuild, so a diverging layout degrades to the old behaviour rather than
-        // mislabelling a key. Mirrors the Android applyShiftCase fast path (#28).
-        if !force,
+        // character button, so the recogniser stays valid. Skip the fast path when the
+        // structure changed (to or from the symbols layer, or the first build) or when
+        // the buttons were built under a different theme -- each button keeps the theme
+        // it was created with for its title and tint colours, so reusing them after a
+        // theme change would leave the old text colour on the new background. Either
+        // case degrades to the full rebuild below. Mirrors the Android applyShiftCase
+        // fast path (#28).
+        if builtTheme == theme,
            keyButtons.count == newKeys.count,
            zip(keyButtons, newKeys).allSatisfy({ $0.key.structuralKind == $1.structuralKind }) {
             for (btn, key) in zip(keyButtons, newKeys) {
@@ -105,6 +113,7 @@ public final class QwertyKeyboardView: UIView {
             addSubview(btn)
             keyButtons.append(btn)
         }
+        builtTheme = theme
     }
 
     public override func layoutSubviews() {
@@ -218,10 +227,9 @@ public final class QwertyKeyboardView: UIView {
     public func applyTheme(_ theme: KeyboardTheme) {
         self.theme = theme
         backgroundColor = bg
-        // Force a full rebuild: each button captures the theme at init, so reusing
-        // them would keep the old title colours and shadow. Theme changes are rare
-        // and not latency-sensitive, so the reallocation cost is fine here.
-        rebuild(force: true)
+        // rebuild() sees builtTheme != theme and does a full reallocation, so the
+        // buttons pick up the new title and tint colours rather than being reused.
+        rebuild()
         setNeedsLayout()
     }
 

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/QwertyKeyboardView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/QwertyKeyboardView.swift
@@ -61,24 +61,49 @@ public final class QwertyKeyboardView: UIView {
 
     // MARK: - Rebuild / layout
 
-    private func rebuild() {
+    // Rebuild the key set for the current layer/shift. Reuses the existing buttons
+    // in place when the new layer is position-identical in kind, and only tears down
+    // and reallocates when the structure actually changes. Pass force to skip the
+    // fast path (a theme change has to rebuild so buttons pick up the new colours).
+    private func rebuild(force: Bool = false) {
+        let rows = KeyboardLayers.rows(for: layer_, shiftState: shiftState)
+        let newKeys = rows.flatMap { $0 }
+
+        // Fast path: every lowercase<->uppercase transition (shift off/once/caps and
+        // the one-shot-shift after a capital letter) keeps the same key count and the
+        // same kind at each position, differing only in per-key title, image, and
+        // colour. Relabel the buttons already on screen instead of destroying and
+        // reallocating ~35 UIButtons with fresh shadow layers, gesture recognisers,
+        // and SF Symbol lookups on every shift -- the churn issue #45 set out to kill.
+        // The tap target and long-press recogniser stay attached for the button's
+        // lifetime, and because the kind is unchanged a character button stays a
+        // character button, so the recogniser stays valid. A structural change (to or
+        // from the symbols layer, or the first build) falls through to the full
+        // rebuild, so a diverging layout degrades to the old behaviour rather than
+        // mislabelling a key. Mirrors the Android applyShiftCase fast path (#28).
+        if !force,
+           keyButtons.count == newKeys.count,
+           zip(keyButtons, newKeys).allSatisfy({ $0.key.structuralKind == $1.structuralKind }) {
+            for (btn, key) in zip(keyButtons, newKeys) {
+                btn.apply(key: key)
+                btn.backgroundColor = bgColor(for: key)
+            }
+            return
+        }
+
         keyButtons.forEach { $0.removeFromSuperview() }
         keyButtons.removeAll()
-
-        let rows = KeyboardLayers.rows(for: layer_, shiftState: shiftState)
-        for row in rows {
-            for key in row {
-                let btn = QwertyKeyButton(key: key, theme: theme)
-                btn.backgroundColor = bgColor(for: key)
-                btn.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
-                if case .character = key {
-                    let lp = UILongPressGestureRecognizer(target: self, action: #selector(keyLongPressed(_:)))
-                    lp.minimumPressDuration = 0.4
-                    btn.addGestureRecognizer(lp)
-                }
-                addSubview(btn)
-                keyButtons.append(btn)
+        for key in newKeys {
+            let btn = QwertyKeyButton(key: key, theme: theme)
+            btn.backgroundColor = bgColor(for: key)
+            btn.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
+            if case .character = key {
+                let lp = UILongPressGestureRecognizer(target: self, action: #selector(keyLongPressed(_:)))
+                lp.minimumPressDuration = 0.4
+                btn.addGestureRecognizer(lp)
             }
+            addSubview(btn)
+            keyButtons.append(btn)
         }
     }
 
@@ -193,7 +218,10 @@ public final class QwertyKeyboardView: UIView {
     public func applyTheme(_ theme: KeyboardTheme) {
         self.theme = theme
         backgroundColor = bg
-        rebuild()
+        // Force a full rebuild: each button captures the theme at init, so reusing
+        // them would keep the old title colours and shadow. Theme changes are rare
+        // and not latency-sensitive, so the reallocation cost is fine here.
+        rebuild(force: true)
         setNeedsLayout()
     }
 
@@ -284,35 +312,76 @@ public final class QwertyKeyboardView: UIView {
     }
 }
 
+// MARK: - Structural kind
+
+private extension QwertyKey {
+    // A discriminator that ignores a character key's specific value, so two layers
+    // built from the same sequence of kinds (lowercase and uppercase) compare equal
+    // and their buttons can be relabelled in place. Distinct from Equatable, which
+    // treats .character("a") and .character("A") as different.
+    var structuralKind: Int {
+        switch self {
+        case .character:        return 0
+        case .space:            return 1
+        case .return:           return 2
+        case .backspace:        return 3
+        case .shift:            return 4
+        case .symbolsToggle:    return 5
+        case .alphabeticToggle: return 6
+        case .globe:            return 7
+        case .more:             return 8
+        }
+    }
+}
+
 // MARK: - QwertyKeyButton
 
 @MainActor
 final class QwertyKeyButton: UIButton {
 
-    let key: QwertyKey
+    private(set) var key: QwertyKey
     private let theme: KeyboardTheme
+
+    // Resolve the three SF Symbols once per process rather than on every rebuild:
+    // UIImage(systemName:) is a non-trivial lookup and these images never change.
+    private static let backspaceImage = UIImage(systemName: "delete.backward")
+    private static let shiftImage = UIImage(systemName: "shift")
+    private static let globeImage = UIImage(systemName: "globe")
 
     init(key: QwertyKey, theme: KeyboardTheme) {
         self.key = key
         self.theme = theme
         super.init(frame: .zero)
-        configure()
+        configureChrome()
+        apply(key: key)
     }
 
     required init?(coder: NSCoder) { fatalError("use init(key:theme:)") }
 
-    private func configure() {
+    // One-time visual setup that does not depend on which key this is: title colours
+    // and the rounded-rect drop shadow. Set once at init and never touched again, so
+    // an in-place relabel does not re-run the four CALayer shadow writes.
+    private func configureChrome() {
         let text = theme.keyText
-        let textFaded = text.withAlphaComponent(0.4)
         setTitleColor(text, for: .normal)
-        setTitleColor(textFaded, for: .highlighted)
+        setTitleColor(text.withAlphaComponent(0.4), for: .highlighted)
         layer.cornerRadius    = 5
         layer.masksToBounds   = false
         layer.shadowColor     = UIColor.black.cgColor
         layer.shadowOffset    = CGSize(width: 0, height: 1)
         layer.shadowOpacity   = 0.35
         layer.shadowRadius    = 0.5
+    }
 
+    // Per-key appearance: font, title, and image. Safe to call repeatedly to relabel
+    // a reused button, which QwertyKeyboardView does on a lowercase<->uppercase
+    // toggle. Both the title and the image are cleared first so no stale glyph
+    // survives even if a caller ever reuses a button across kinds.
+    func apply(key: QwertyKey) {
+        self.key = key
+        setTitle(nil, for: .normal)
+        setImage(nil, for: .normal)
+        let text = theme.keyText
         switch key {
         case .character(let s):
             titleLabel?.font = .systemFont(ofSize: 17, weight: .light)
@@ -327,11 +396,11 @@ final class QwertyKeyButton: UIButton {
             setTitle("return", for: .normal)
 
         case .backspace:
-            setImage(UIImage(systemName: "delete.backward"), for: .normal)
+            setImage(Self.backspaceImage, for: .normal)
             tintColor = text
 
         case .shift:
-            setImage(UIImage(systemName: "shift"), for: .normal)
+            setImage(Self.shiftImage, for: .normal)
             tintColor = text
 
         case .symbolsToggle:
@@ -343,7 +412,7 @@ final class QwertyKeyButton: UIButton {
             setTitle("ABC", for: .normal)
 
         case .globe:
-            setImage(UIImage(systemName: "globe"), for: .normal)
+            setImage(Self.globeImage, for: .normal)
             tintColor = text
 
         case .more:


### PR DESCRIPTION
## What and why

`QwertyKeyboardView.rebuild()` tore down and reallocated the whole ~35-button key set on every shift, symbols, or alphabetic toggle, and after typing a single capital letter (the one-shot-shift branch). Verified against `main`:

- `rebuild()` called `removeFromSuperview()` on each `QwertyKeyButton`, cleared the array, then allocated a fresh button per key, re-adding the `touchUpInside` target and, for character keys, a new `UILongPressGestureRecognizer`.
- Each `QwertyKeyButton.configure()` set four `CALayer` shadow properties and did a `UIImage(systemName:)` SF Symbol lookup for backspace/shift/globe.
- `keyTapped(_:)` hit that path on the shift off/once/caps transitions, the symbols and alphabetic toggles, and right after inserting a one-shot-shift capital.

So any shift tap, or typing a single uppercase letter, discarded 30+ `UIButton`s and rebuilt them with shadow setup and symbol lookups: transient allocation and view churn on a frequent, latency-sensitive interaction, inside the keyboard extension (the most memory-constrained iOS process, jetsam ceiling ~60-70MB).

## The fix

Reuse the buttons and relabel them in place when the layer shape is unchanged.

- `lowercase` and `uppercase` are position-identical (same key count, same kind at every position; only title, image, and colour differ), so `rebuild()` now walks the existing buttons and updates only the title, SF Symbol image, and background colour. The tap target and long-press recogniser stay attached for the button's lifetime, and because the kind is unchanged a character button stays a character button, so the recogniser stays valid.
- A structural change (to or from `symbols`, whose row shapes differ, or the first build) falls through to the original teardown-and-reallocate path. A layout edit that ever broke the position-identity invariant would degrade to a full rebuild, never mislabel a key.
- `QwertyKeyButton` splits into `configureChrome()` (the once-only shadow and title-colour setup) and `apply(key:)` (the per-key title and image), so the four `CALayer` shadow writes no longer run on every relabel.
- The three SF Symbols (`delete.backward`, `shift`, `globe`) are cached in static properties, so the lookup runs once per process instead of per rebuild.
- Theme changes force a full rebuild (`rebuild(force: true)`), since each button captures the theme at init.

This mirrors the Android side, which already landed the equivalent `applyShiftCase` in-place relabel and a test pinning the invariant (#28, #56).

## Scope and follow-up

The symbols layer keeps the full-rebuild path because its rows genuinely differ in shape; making it position-mappable too is a larger refactor and out of scope here. The Android invariant is pinned by a build-time test (#56); the iOS package has no test target and imports UIKit, so a Swift test can't run on the Linux CI box today. Adding an iOS test target asserting the lowercase/uppercase position-identity (pure `KeyboardLayers` model, no UIKit) is a reasonable follow-up once there is iOS CI.

## Testing

No iOS CI in this repo (`build.yml` is Android/Gradle only), so nothing here builds Swift. Verified by reading `QwertyKeyboardView.swift` against the `KeyboardLayers` layer model: confirmed lowercase and uppercase are position-identical and symbols is not, so the fast path covers exactly the shift/caps/one-shot transitions and the symbols switch falls back. Needs a local Xcode/simulator build to compile-check and confirm the on-device relabel.

Refs #45.

wake-20260703T1905-6ed36a

## Review round

The cloud review caught that reusing buttons across a theme change would strand old title colours on new backgrounds: the keyboard extension builds the view at the default dark theme and then assigns `qwerty.theme` directly, so the first shift in the light theme turned keys light while labels stayed white. Fixed in `ca6061e` by tracking the theme the buttons were built under and skipping the fast path when it diverges (falling back to the full rebuild), which also let `applyTheme` drop its `force` flag.