### PR TITLE
perf(ios): prepare SCP upload image off the main actor

### DIFF
--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -188,23 +188,51 @@ extension KeyboardViewController: ExtraRowDelegate {
         panel.frame = view.bounds
         panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         panel.hosts = AppGroupHostStore.shared.hosts
+        panel.onDismiss = { [weak self] in self?.hideUploadPanel() }
 
-        guard let imageData = UIPasteboard.general.image?.jpegData(compressionQuality: 0.85) else {
-            panel.statusMessage = "Copy an image first, then tap SCP"
-            panel.onDismiss = { [weak self] in self?.hideUploadPanel() }
+        // Grab the raw encoded image bytes on the main actor (cheap: no decode),
+        // so the heavy decode/downsample/encode can run off it. Reading
+        // UIPasteboard.image here instead would decode the full bitmap on the
+        // keyboard's main thread and freeze key input the moment SCP is tapped (#46).
+        guard let rawImageData = UIPasteboard.general.firstImageData else {
+            // hasImages true here means an image is present but exposes no
+            // readable data representation, so say that instead of implying the
+            // user copied nothing.
+            panel.statusMessage = UIPasteboard.general.hasImages
+                ? "Couldn't read that image. Try copying it again."
+                : "Copy an image first, then tap SCP"
             panel.onUpload = { _ in }
             view.addSubview(panel)
             uploadPanel = panel
             return
         }
 
-        panel.statusMessage = "Select a host to upload"
-        panel.onDismiss = { [weak self] in self?.hideUploadPanel() }
-        panel.onUpload = { [weak self] host in
-            self?.performUpload(imageData: imageData, to: host)
-        }
+        // Show the panel immediately in a preparing state with upload gated off,
+        // then downsample and JPEG-encode off the main actor. A host tap before
+        // the data is ready is a no-op (UploadPanel.isUploadEnabled).
+        panel.statusMessage = "Preparing image..."
+        panel.isUploadEnabled = false
+        panel.onUpload = { _ in }
         view.addSubview(panel)
         uploadPanel = panel
+
+        Task { [weak self] in
+            let imageData = await Task.detached(priority: .userInitiated) {
+                PasteboardImagePreparer.downsampledJPEGData(from: rawImageData)
+            }.value
+
+            // Bail if the panel was dismissed (or replaced) while preparing.
+            guard let self, self.uploadPanel === panel else { return }
+            guard let imageData else {
+                panel.statusMessage = "Couldn't read that image. Try copying it again."
+                return
+            }
+            panel.statusMessage = "Select a host to upload"
+            panel.onUpload = { [weak self] host in
+                self?.performUpload(imageData: imageData, to: host)
+            }
+            panel.isUploadEnabled = true
+        }
     }
 
     private func hideUploadPanel() {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Media/PasteboardImagePreparer.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Media/PasteboardImagePreparer.swift
@@ -1,0 +1,139 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UIKit
+import UniformTypeIdentifiers
+
+/// Prepares a pasteboard image for SCP upload without ever materializing the
+/// full-resolution bitmap.
+///
+/// A keyboard extension runs under a tight jetsam ceiling (roughly 48-70 MB), so
+/// decoding a large screenshot to a bitmap (a 3648x5472 photo is about 80 MB
+/// decoded, plus the JPEG output buffer) can get the extension killed
+/// mid-interaction. ImageIO's thumbnail path decodes straight to a bounded size,
+/// so the full bitmap is never allocated.
+///
+/// Every method here touches only Foundation, ImageIO, and CoreGraphics, all of
+/// which are thread-safe, so it is meant to be called off the main actor.
+public enum PasteboardImagePreparer {
+
+    /// Decoded-pixel budget for an upload, in total pixels (width times height).
+    ///
+    /// The decoded bitmap costs 4 bytes per pixel, so a 6 MP budget caps the
+    /// decode at about 24 MB, which leaves headroom under the extension's jetsam
+    /// ceiling. Bounding total *area* rather than the longest edge is what keeps
+    /// tall scrolling screenshots readable: a 1290x6000 grab downsamples to about
+    /// 1135x5280 (still legible), where a fixed 2048px longest-edge cap would
+    /// have collapsed it to 440x2048.
+    public static let defaultMaxPixelCount = 6_000_000
+
+    /// Downsamples encoded image bytes so the decoded bitmap stays within
+    /// `maxPixelCount` total pixels, then re-encodes them as JPEG, without ever
+    /// decoding the full-resolution bitmap.
+    ///
+    /// - Parameters:
+    ///   - data: raw encoded image bytes (PNG/JPEG/HEIC/...), as read from the
+    ///     pasteboard with ``UIKit/UIPasteboard/firstImageData``.
+    ///   - maxPixelCount: the decoded-pixel budget (width times height). A
+    ///     smaller image is never upscaled.
+    ///   - compressionQuality: JPEG quality for the re-encode (0...1).
+    /// - Returns: JPEG-encoded `Data`, or `nil` if the bytes are not a decodable
+    ///   image.
+    public static func downsampledJPEGData(
+        from data: Data,
+        maxPixelCount: Int = defaultMaxPixelCount,
+        compressionQuality: CGFloat = 0.85
+    ) -> Data? {
+        // The autoreleasepool frees ImageIO's intermediate buffers promptly
+        // rather than at the next runloop turn, which matters under jetsam.
+        autoreleasepool {
+            let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+            guard let source = CGImageSourceCreateWithData(data as CFData, sourceOptions) else {
+                return nil
+            }
+
+            let thumbnailOptions = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                // Bake the EXIF orientation into the pixels so the upload is
+                // upright without carrying an orientation tag.
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxPixelSize(for: source, maxPixelCount: maxPixelCount),
+                kCGImageSourceShouldCacheImmediately: true,
+            ] as CFDictionary
+            guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions) else {
+                return nil
+            }
+
+            let output = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(
+                output as CFMutableData, UTType.jpeg.identifier as CFString, 1, nil
+            ) else {
+                return nil
+            }
+            let destinationOptions = [
+                kCGImageDestinationLossyCompressionQuality: compressionQuality
+            ] as CFDictionary
+            CGImageDestinationAddImage(destination, thumbnail, destinationOptions)
+            guard CGImageDestinationFinalize(destination) else { return nil }
+            return output as Data
+        }
+    }
+
+    /// The longest-edge bound to hand ImageIO so the decoded bitmap stays within
+    /// `maxPixelCount` total pixels, without upscaling a smaller image.
+    ///
+    /// Reads the stored pixel dimensions from the image metadata, so it does not
+    /// decode. `kCGImageSourceThumbnailMaxPixelSize` only bounds the longest
+    /// edge, so this converts the area budget into the matching edge value for
+    /// the source's actual aspect ratio.
+    private static func maxPixelSize(for source: CGImageSource, maxPixelCount: Int) -> Int {
+        guard
+            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+            let width = properties[kCGImagePropertyPixelWidth] as? Int,
+            let height = properties[kCGImagePropertyPixelHeight] as? Int,
+            width > 0, height > 0
+        else {
+            // Dimensions unknown (very rare for real pasteboard images): fall
+            // back to a longest-edge cap derived from the same budget, so
+            // maxPixelCount stays the single source of truth for the decode bound.
+            return max(1, Int(Double(maxPixelCount).squareRoot().rounded()))
+        }
+
+        let longestEdge = max(width, height)
+        let totalPixels = width * height
+        guard totalPixels > maxPixelCount else { return longestEdge }
+
+        let scale = (Double(maxPixelCount) / Double(totalPixels)).squareRoot()
+        return max(1, Int((Double(longestEdge) * scale).rounded()))
+    }
+}
+
+public extension UIPasteboard {
+
+    /// The raw encoded bytes of the first image on the pasteboard, without
+    /// decoding it to a bitmap.
+    ///
+    /// Reading `UIPasteboard.image` eagerly decodes the full bitmap on the
+    /// calling thread; this reads only the stored encoded representation, which
+    /// is cheap and safe to grab on the main actor before handing the bytes to a
+    /// background decode. Returns `nil` if the pasteboard has no image.
+    var firstImageData: Data? {
+        guard hasImages else { return nil }
+
+        // Prefer the common encodings screenshots and photos actually use.
+        let preferred: [UTType] = [.png, .jpeg, .heic, .heif, .tiff, .gif, .bmp]
+        for type in preferred {
+            if let data = data(forPasteboardType: type.identifier) {
+                return data
+            }
+        }
+
+        // Fall back to any present representation that conforms to public.image.
+        for identifier in types where UTType(identifier)?.conforms(to: .image) == true {
+            if let data = data(forPasteboardType: identifier) {
+                return data
+            }
+        }
+        return nil
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/UploadPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/UploadPanel.swift
@@ -16,6 +16,13 @@ public final class UploadPanel: UIView {
     public var hosts: [HostConfig] = [] { didSet { tableView.reloadData() } }
     public var statusMessage: String = "" { didSet { statusLabel.text = statusMessage } }
 
+    /// Gates host taps while the upload image is still being prepared off the
+    /// main actor, so a tap before the data exists is a no-op instead of a crash.
+    /// The host rows dim while disabled to show they are not tappable yet.
+    public var isUploadEnabled: Bool = true {
+        didSet { tableView.alpha = isUploadEnabled ? 1.0 : 0.5 }
+    }
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -135,7 +142,7 @@ extension UploadPanel: UITableViewDataSource, UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard !hosts.isEmpty else { return }
+        guard isUploadEnabled, !hosts.isEmpty else { return }
         onUpload?(hosts[indexPath.row])
     }
 }


### PR DESCRIPTION
## What

Closes #46. The keyboard extension's SCP upload panel decoded the full pasteboard bitmap and re-encoded it to JPEG synchronously on the main actor (`UIPasteboard.general.image?.jpegData(...)`). Two problems:

- Tapping SCP froze key input while a large image decoded on the keyboard's main thread.
- A large enough image (a full-res photo decodes to about 80 MB) could push the extension past its jetsam ceiling (roughly 48-70 MB) and get it killed mid-interaction.

## How

- **Read raw bytes on the main actor, decode off it.** `UIPasteboard.firstImageData` grabs only the already-encoded representation via `data(forPasteboardType:)`, which is cheap and does not decode. The decode, downsample, and encode then run in a `Task.detached`, off the main actor. Pasteboard access stays on the main actor where it belongs; only Sendable `Data` crosses to the background.
- **Downsample with ImageIO bounded by decoded area.** `CGImageSourceCreateThumbnailAtIndex` decodes straight to the bounded size, so the full bitmap is never allocated. The bound is a decoded-pixel-area budget (about 6 MP, roughly 24 MB), not a longest-edge cap, so a tall 1290x6000 scrolling screenshot stays near 1135x5280 (legible) instead of collapsing to 440x2048.
- **Preparing state and readiness gate.** The panel shows immediately with "Preparing image..." and `isUploadEnabled = false`; a host tap before the encode finishes is a no-op, and the dimmed rows signal it. When the data is ready, the panel enables and wires up the real upload.

## Notes

- Swift-only change. keyjawn CI is Android/Gradle and has no iOS build, so this was validated by reading: Swift 6 strict-concurrency isolation (the outer `Task {}` inherits `@MainActor`, the detached task captures only Sendable `Data`), ImageIO API use, and the area-budget math. Local codex 5.4/low review passed clean.
- Deliberately did not cache the app-group `UserDefaults` in `AppGroupHostStore` (the issue's secondary note): a keyboard extension has no reliable cross-process invalidation signal, so recreating the suite per panel-open keeps the host list fresh after the main app adds a host, and the micro-cost is negligible.

wake-20260706T0705-ffc9f5
