### PR TITLE
perf(ios): cache decoded SCP host list keyed by raw bytes

### DIFF
--- a/ios/KeyJawnKeyboard/AppGroupHostStore.swift
+++ b/ios/KeyJawnKeyboard/AppGroupHostStore.swift
@@ -3,18 +3,56 @@ import KeyJawnKit
 
 /// Read-only host config reader for the keyboard extension.
 /// The main app HostStore writes host JSON to the App Group container on every save.
+///
+/// Reads happen once per deliberate SCP-panel open. In a memory-constrained keyboard
+/// extension the main-thread JSON decode on that interactive path is worth avoiding,
+/// so the decoded host list is cached against the raw bytes it came from and a repeat
+/// open with an unchanged list skips the decode.
 final class AppGroupHostStore: @unchecked Sendable {
     static let shared = AppGroupHostStore()
     private init() {}
 
     private let key = "keyjawn.hosts"
+
+    /// Look the suite up per read rather than caching the instance. The main app
+    /// writes host edits from a different process, and a cached `UserDefaults`
+    /// wrapper can keep serving its stale in-process cache until the extension
+    /// restarts, so the next SCP-panel open would show the old host list. Caching
+    /// the instance was tried and reverted for exactly this reason in #46. Only the
+    /// decode is cached (below); the read stays as fresh as it was before.
     private var defaults: UserDefaults? { UserDefaults(suiteName: AppGroupConfig.suiteName) }
 
+    /// Guards the decode cache below. This shared singleton declares
+    /// `@unchecked Sendable`, so the lock is what makes that promise honest for the
+    /// mutable cache state: a read of `hosts` can touch it from any thread, and the
+    /// lock keeps those touches race-free. Do not drop it because reads look
+    /// main-thread-only today.
+    private let lock = NSLock()
+    private var cachedData: Data?
+    private var cachedHosts: [HostConfig] = []
+
+    /// The host list the main app mirrored into the App Group.
+    ///
+    /// Each read fetches the current bytes through a fresh suite lookup, so it is as
+    /// fresh as before, and re-decodes only when those bytes changed since the last
+    /// read. A host added, edited, or removed in the main app rewrites the bytes, so
+    /// the cache misses and re-decodes; when nothing changed, the cached decode is
+    /// returned and the JSON decode is skipped.
     var hosts: [HostConfig] {
-        guard let data = defaults?.data(forKey: key),
-              let decoded = try? JSONDecoder().decode([HostConfig].self, from: data) else {
+        let data = defaults?.data(forKey: key)
+        lock.lock()
+        defer { lock.unlock() }
+        guard let data else {
+            cachedData = nil
+            cachedHosts = []
             return []
         }
+        if data == cachedData {
+            return cachedHosts
+        }
+        let decoded = (try? JSONDecoder().decode([HostConfig].self, from: data)) ?? []
+        cachedData = data
+        cachedHosts = decoded
         return decoded
     }
 }


### PR DESCRIPTION
## What

Closes #47. `AppGroupHostStore` (keyboard extension) re-decoded the full host list from the app-group `UserDefaults` on every SCP-panel open, on the main thread. This caches the decoded `[HostConfig]` against the raw bytes it was decoded from, so a repeat open with an unchanged host list skips the `JSONDecoder` pass.

## The design decision

The issue also suggested caching the `UserDefaults(suiteName:)` instance. This PR deliberately does not: the main app (`HostStore.save()`) writes host edits from a different process, and a cached wrapper can keep serving its stale in-process cache until the extension restarts, so the next panel open would show the old list. That is the exact staleness that reverted #46. So the read still looks the suite up per access (as fresh as before); only the decode is cached.

The issue's other suggestion, observing `UserDefaults.didChangeNotification`, was also skipped: that notification is for same-process writes, and app-group suites do not reliably deliver cross-process change notifications, so it would not catch the main app's writes. Keying the cache on the raw bytes needs no notification: a host added, edited, or removed rewrites the bytes, the cache misses, and it re-decodes.

## Correctness

- Freshness is unchanged: every read re-fetches the bytes through a fresh suite lookup and compares; only the decode is skipped on identical bytes.
- Race-safe: mutable cache state is guarded by an `NSLock`, keeping the type's `@unchecked Sendable` conformance honest. `cachedData` and `cachedHosts` are always written together under the lock.
- nil data (no hosts written yet, or hosts cleared) resets the cache and returns `[]`, matching prior behavior.

## Validation

No Swift toolchain or iOS CI on the build host, so validated by reading. Codex 5.4 review: one P1 caught (the instance-caching staleness above), fixed, re-reviewed clean. Coach pass confirmed the edge cases and the design.

wake-20260706T0905-9653c7
