### PR TITLE
Clamp the slide popup's vertical position to the visible frame

### DIFF
--- a/app/src/main/java/com/keyjawn/AltKeyPopup.kt
+++ b/app/src/main/java/com/keyjawn/AltKeyPopup.kt
@@ -89,9 +89,14 @@ class AltKeyPopup(
         window.isTouchable = false
 
         val popupHeight = btnHeight + (8 * density + 0.5f).toInt()
-        // Vertical is not clamped: a bottom-anchored IME always has room above the
-        // key for the candidate row, so popupTop stays on screen.
-        val yOffset = -(anchor.height + popupHeight)
+        // Lift the candidate row above the key. A bottom-anchored IME normally has
+        // room above the pressed key, but a compact or landscape IME whose top row
+        // sits near the screen top would not: showAsDropDown (clipping enabled) would
+        // then flip the row below the anchor and leave our precomputed rects above it,
+        // desyncing the hit-test the same way an unclamped left did before #38. So the
+        // top is clamped to the visible frame below, and both the rects and the offset
+        // derive from that clamped top (see clampPopupTop, mirroring clampPopupLeft).
+        val requestedYOffset = -(anchor.height + popupHeight)
         val popupWidth = alts.size * (btnSize + 2 * margin) + (8 * density + 0.5f).toInt()
 
         // The popup top-left in screen space. showAsDropDown places the window at
@@ -119,7 +124,14 @@ class AltKeyPopup(
         val requestedLeft = anchorScreenX + (anchor.width - popupWidth) / 2
         val clampedLeft = clampPopupLeft(requestedLeft, popupWidth, displayFrame.left, displayFrame.right)
         val clampedXOffset = clampedLeft - anchorScreenX
-        val popupTop = popupScreenTop(anchorScreenY, anchor.height, yOffset)
+
+        // Same clamp on the vertical axis: pin the requested top into the visible
+        // frame so showAsDropDown finds the row already fits above the key and does not
+        // flip it below, then derive both the rects and the offset from the clamped top
+        // (dropDownYOffset inverts popupScreenTop to recover the anchor-bottom offset).
+        val requestedTop = popupScreenTop(anchorScreenY, anchor.height, requestedYOffset)
+        val clampedTop = clampPopupTop(requestedTop, popupHeight, displayFrame.top, displayFrame.bottom)
+        val clampedYOffset = dropDownYOffset(clampedTop, anchorScreenY, anchor.height)
 
         // Each candidate sits at popup-internal x = pad + i*(btnSize + 2*margin) +
         // margin (the LinearLayout's left padding, the preceding buttons' cells,
@@ -128,11 +140,11 @@ class AltKeyPopup(
         val rects = ArrayList<Rect>(alts.size)
         for (i in alts.indices) {
             val left = clampedLeft + pad + i * (btnSize + 2 * margin) + margin
-            val top = popupTop + pad
+            val top = clampedTop + pad
             rects.add(Rect(left, top, left + btnSize, top + btnHeight))
         }
 
-        window.showAsDropDown(anchor, clampedXOffset, yOffset)
+        window.showAsDropDown(anchor, clampedXOffset, clampedYOffset)
         popup = window
 
         return SlideSession(buttons, rects, themeManager) { dismiss() }
@@ -157,13 +169,27 @@ class AltKeyPopup(
             anchorScreenY + anchorHeight + yOffset
 
         /**
+         * The showAsDropDown yOffset that lands the popup's top edge at [clampedTop].
+         * showAsDropDown measures its offset from the anchor BOTTOM, so this is the
+         * exact inverse of [popupScreenTop]: feeding this offset back through
+         * popupScreenTop returns [clampedTop]. openForSlide derives the offset from the
+         * clamped top (not the raw requested offset) so the shown window and the
+         * precomputed candidate rects share one top edge; a naive offset that dropped
+         * [anchorHeight] would misplace the window while every rect stayed put. Pure
+         * arithmetic so it is unit-testable without a rendered popup.
+         */
+        fun dropDownYOffset(clampedTop: Int, anchorScreenY: Int, anchorHeight: Int): Int =
+            clampedTop - (anchorScreenY + anchorHeight)
+
+        /**
          * Clamp the requested popup left edge to the anchor window's visible display
          * frame -- the same frame showAsDropDown clips against -- so the precomputed
          * candidate rects stay aligned with where the window actually lands in any
          * window mode (full-screen, split-screen, or freeform). [frameLeft] and
          * [frameRight] are screen-space, matching getLocationOnScreen. A popup wider
          * than the frame pins to [frameLeft]; one that overflows left or right is slid
-         * inward to the frame edge; one that already fits is unchanged. Pure arithmetic
+         * inward to the frame edge; one that already fits is unchanged. The horizontal
+         * half of the pair -- [clampPopupTop] mirrors it on the Y axis. Pure arithmetic
          * so it is unit-testable without a rendered popup.
          */
         fun clampPopupLeft(requestedLeft: Int, popupWidth: Int, frameLeft: Int, frameRight: Int): Int {
@@ -173,6 +199,27 @@ class AltKeyPopup(
                 requestedLeft < frameLeft -> frameLeft
                 requestedLeft > maxLeft -> maxLeft
                 else -> requestedLeft
+            }
+        }
+
+        /**
+         * Clamp the requested popup top edge to the anchor window's visible display
+         * frame -- the same frame showAsDropDown clips and flips against -- so the
+         * precomputed candidate rects stay aligned with where the window lands. The
+         * vertical mirror of [clampPopupLeft]: [frameTop] and [frameBottom] are
+         * screen-space. A popup taller than the frame pins to [frameTop]; a requested
+         * top above the frame (where showAsDropDown would flip the row below the anchor
+         * and desync the rects) is pushed down to [frameTop]; one that overflows the
+         * bottom is slid up to the frame; one that already fits is unchanged. Pure
+         * arithmetic so it is unit-testable without a rendered popup.
+         */
+        fun clampPopupTop(requestedTop: Int, popupHeight: Int, frameTop: Int, frameBottom: Int): Int {
+            val maxTop = frameBottom - popupHeight
+            return when {
+                maxTop <= frameTop -> frameTop
+                requestedTop < frameTop -> frameTop
+                requestedTop > maxTop -> maxTop
+                else -> requestedTop
             }
         }
     }

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -442,6 +442,59 @@ class AltKeySlideTest {
         assertEquals(200, AltKeyPopup.clampPopupLeft(requestedLeft = 250, popupWidth = 900, frameLeft = 200, frameRight = 1000))
     }
 
+    // ---- Fix B (#48): the vertical mirror of the left clamp ----
+    // openForSlide lifts the candidate row above the key with a negative yOffset. If
+    // the requested top ever falls above the visible frame, showAsDropDown flips the
+    // row below the anchor and the rects desync -- the same class the left clamp fixed
+    // on the X axis. clampPopupTop is clampPopupLeft with left->top, width->height.
+
+    @Test
+    fun `clampPopupTop pins a requested top above the frame to the frame top`() {
+        // A row lifted above a key near the screen top requests a negative top; the
+        // clamp pins it to the frame top so the visible popup and the rects agree.
+        // Portrait full-height IME: frame is [0, 1920].
+        assertEquals(0, AltKeyPopup.clampPopupTop(requestedTop = -120, popupHeight = 300, frameTop = 0, frameBottom = 1920))
+    }
+
+    @Test
+    fun `clampPopupTop slides an overflowing-bottom popup back inside the frame`() {
+        // Requested bottom edge (1800 + 300 = 2100) overflows the [0, 1920] frame, so
+        // the top clamps to frameBottom - popupHeight = 1620.
+        assertEquals(1620, AltKeyPopup.clampPopupTop(requestedTop = 1800, popupHeight = 300, frameTop = 0, frameBottom = 1920))
+    }
+
+    @Test
+    fun `clampPopupTop leaves a popup that already fits unchanged`() {
+        assertEquals(800, AltKeyPopup.clampPopupTop(requestedTop = 800, popupHeight = 300, frameTop = 0, frameBottom = 1920))
+    }
+
+    @Test
+    fun `clampPopupTop pins a popup taller than the frame to the frame top`() {
+        assertEquals(0, AltKeyPopup.clampPopupTop(requestedTop = -50, popupHeight = 2000, frameTop = 0, frameBottom = 1920))
+    }
+
+    @Test
+    fun `clampPopupTop pins a top-overflowing popup to a non-zero frame top`() {
+        // Split-screen/freeform: the anchor window's visible frame is [200, 1000]. A
+        // requested top of 150 falls above the frame, so it pins to frameTop. A clamp
+        // that ignored frameTop would leave the rects above the window's top edge.
+        assertEquals(200, AltKeyPopup.clampPopupTop(requestedTop = 150, popupHeight = 300, frameTop = 200, frameBottom = 1000))
+    }
+
+    @Test
+    fun `clampPopupTop slides a bottom-overflowing popup to the non-zero frame bottom`() {
+        // Frame [200, 1000], popupHeight 300: requested top 850 would push the bottom
+        // edge to 1150, past frameBottom, so it clamps to frameBottom - popupHeight = 700.
+        assertEquals(700, AltKeyPopup.clampPopupTop(requestedTop = 850, popupHeight = 300, frameTop = 200, frameBottom = 1000))
+    }
+
+    @Test
+    fun `clampPopupTop pins a popup taller than a non-zero frame to the frame top`() {
+        // Frame [200, 1000] is 800 tall; a 900-tall popup cannot fit, so it pins to
+        // frameTop (200), not 0.
+        assertEquals(200, AltKeyPopup.clampPopupTop(requestedTop = 250, popupHeight = 900, frameTop = 200, frameBottom = 1000))
+    }
+
     @Test
     fun `popupScreenTop lands the row popupHeight above the anchor top`() {
         // openForSlide picks yOffset = -(anchorHeight + popupHeight) to lift the
@@ -465,6 +518,21 @@ class AltKeySlideTest {
         // anchorHeight + yOffset. A positive yOffset (drop-down below the key)
         // exercises the same arithmetic the buggy form got wrong.
         assertEquals(560, AltKeyPopup.popupScreenTop(anchorScreenY = 500, anchorHeight = 40, yOffset = 20))
+    }
+
+    @Test
+    fun `dropDownYOffset is the exact inverse of popupScreenTop`() {
+        // The offset handed to showAsDropDown must land the window's top at the same
+        // clampedTop the hit-test rects derive from -- otherwise the visible buttons
+        // and the rects sit at different tops and a slide commits the wrong candidate.
+        // Every gesture test hit-tests against the rects, so none would catch a broken
+        // offset; this round-trip pins it. A form that dropped anchorHeight would fail
+        // here (offset short by one key height) while leaving the rects untouched.
+        val anchorScreenY = 1400
+        val anchorHeight = 132
+        val clampedTop = 900
+        val offset = AltKeyPopup.dropDownYOffset(clampedTop, anchorScreenY, anchorHeight)
+        assertEquals(clampedTop, AltKeyPopup.popupScreenTop(anchorScreenY, anchorHeight, offset))
     }
 
     @Test


### PR DESCRIPTION
Closes #48.

## What

The alt-key slide popup precomputes its candidate hit-test rects, then shows the popup window with `showAsDropDown`. The X axis is already clamped to the anchor window's visible display frame (prior art: the #38 left clamp) so the rects stay aligned with where the framework actually lands the window. The Y axis was left unclamped, on the assumption that a bottom-anchored IME always has room above the pressed key for the candidate row.

## Why it's a bug

That assumption holds on a standard phone QWERTY (the top row always has room above), but not on a compact or landscape IME whose top row sits near the screen top. There, the requested popup top can fall above the visible frame. `showAsDropDown` with clipping enabled then flips the row *below* the anchor to keep it on screen, while the precomputed rects stay *above* the anchor. The hit-test and the visible buttons desync, so a slide can commit the wrong candidate or nothing. This is the same failure class the X clamp fixed, on the other axis. It is latent (not reachable on standard phone geometry), so this is a correctness hardening, not a live crash fix.

## The fix

Mirror the horizontal clamp onto Y:

- `clampPopupTop` — the exact vertical mirror of `clampPopupLeft` (left to top, width to height, right to bottom). Pins a too-tall popup to the frame top, pushes a top-overflowing popup down, slides a bottom-overflowing popup up, leaves a fitting popup unchanged.
- `dropDownYOffset` — derives the `showAsDropDown` yOffset from the clamped top. It is the exact inverse of `popupScreenTop` (which `showAsDropDown` anchors from the anchor bottom), so both the rects and the offset resolve to one top edge.
- `openForSlide` now clamps the requested top and derives both the rects and the offset from `clampedTop`.

On standard geometry `clampedTop == requestedTop`, so the offset collapses to the previous value and behavior is unchanged. The clamp only changes anything in the near-top case.

## Tests

All pure companion functions, unit-tested without a rendered popup (mirroring how the X clamp is tested):

- `clampPopupTop` across full-screen (`[0, 1920]`) and split-screen/freeform (`[200, 1000]`) frames: above-frame, below-frame, fits, and taller-than-frame.
- A round-trip test asserting `dropDownYOffset` is the exact inverse of `popupScreenTop` — the one arithmetic no rect-based test could catch, since every gesture test hit-tests against the rects and is blind to a wrong window offset.

Validated locally: two codex review passes clean, no dangling references after the `yOffset` to `requestedYOffset`/`clampedYOffset` rename. The Android build + Robolectric suite run in CI (no Kotlin toolchain on the build host).

wake-20260706T1205-0ed128