### PR TITLE
Target Android 16 for Google Play compliance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ adb install app/build/outputs/apk/full/debug/app-full-debug.apk
 ## Build environment
 
 - Gradle 8.13, AGP 8.13.2, Kotlin 2.1.0
-- JDK 17, compileSdk 35, minSdk 26
+- JDK 17+ launcher, pinned Gradle daemon JDK 21, compileSdk 36, minSdk 26
 - CI runs on GitHub Actions (`.github/workflows/build.yml`) — builds both flavors, uploads APK artifacts, creates releases on version tags
 
 ## Product flavors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,9 @@ KeyJawn is a standard Android Kotlin project:
 
 - **Android Studio** (latest stable) or command-line Android SDK
 - **JDK 17+**
+- The Gradle wrapper provisions its pinned **JDK 21** daemon toolchain
 - **Min SDK 26** (Android 8.0)
-- **Target SDK 35**
+- **Target SDK 36**
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Anyone who SSHs into a server from their phone to use a CLI-based AI assistant. 
 ./gradlew testLiteDebugUnitTest
 ```
 
-Requires JDK 17, Android SDK with compileSdk 35.
+Requires JDK 17+ and Android SDK 36. The Gradle wrapper provisions its pinned JDK 21 daemon toolchain.
 
 ### iOS
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ if (localPropsFile.exists()) {
 
 android {
     namespace = "com.keyjawn"
-    compileSdk = 35
+    compileSdk = 36
 
     signingConfigs {
         create("release") {
@@ -34,9 +34,9 @@ android {
     defaultConfig {
         applicationId = "com.keyjawn"
         minSdk = 26
-        targetSdk = 35
-        versionCode = 9
-        versionName = "1.3.0"
+        targetSdk = 36
+        versionCode = 10
+        versionName = "1.4.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -119,7 +119,7 @@ dependencies {
     "fullImplementation"("com.android.billingclient:billing-ktx:7.1.1")
 
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.14.1")
+    testImplementation("org.robolectric:robolectric:4.16.1")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -40,17 +40,6 @@
     </issue>
 
     <issue
-        id="OldTargetApi"
-        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
-        errorLine1="        targetSdk = 35"
-        errorLine2="        ~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle.kts"
-            line="36"
-            column="9"/>
-    </issue>
-
-    <issue
         id="PropertyEscape"
         message="Windows file separators (`\`) and drive letter separators (&apos;:&apos;) must be escaped (`\\`) in property files; use C\\:\\\\Users\\\\amdit\\\\AppData\\\\Local\\\\Android\\\\Sdk\\r"
         errorLine1="sdk.dir=C:\\Users\\amdit\\AppData\\Local\\Android\\Sdk"
@@ -92,17 +81,6 @@
             file="src/full/AndroidManifest.xml"
             line="4"
             column="36"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of `compileSdkVersion` than 35 is available: 36"
-        errorLine1="    compileSdk = 35"
-        errorLine2="    ~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle.kts"
-            line="16"
-            column="5"/>
     </issue>
 
     <issue
@@ -180,17 +158,6 @@
             file="build.gradle.kts"
             line="101"
             column="26"/>
-    </issue>
-
-    <issue
-        id="NewerVersionAvailable"
-        message="A newer version of org.robolectric:robolectric than 4.14.1 is available: 4.16.1"
-        errorLine1="    testImplementation(&quot;org.robolectric:robolectric:4.14.1&quot;)"
-        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle.kts"
-            line="107"
-            column="24"/>
     </issue>
 
     <issue


### PR DESCRIPTION
## Summary

- Target Android 16/API 36 for both Android flavors while keeping min SDK 26.
- Bump release metadata to version 1.4.0 (version code 10).
- Upgrade Robolectric to 4.16.1 for API 36 test support.
- Update build documentation and remove the resolved SDK/Robolectric lint-baseline entries.

## Why

Google Play requires app updates to target Android 16/API 36 beginning August 31, 2026. The project still targeted API 35, and Robolectric 4.14.1 could not run tests for a target SDK above 35.

This keeps KeyJawn lite eligible for future Play updates without changing its minimum supported Android version.

## Verification

- `testFullDebugUnitTest`: 358 tests passed.
- `testLiteDebugUnitTest`: 354 tests passed.
- `lintFullDebug lintLiteDebug`: passed with no errors.
- `assembleFullDebug assembleLiteDebug`: passed.
- `bundleFullRelease bundleLiteRelease`: passed with a disposable test signing key, including R8 and release lint-vital.
- Android 16/API 36.1 emulator: lite APK installed; Settings launched; version 1.4.0 displayed; IME registered and selected; no AndroidRuntime or ActivityTaskManager errors.

## Release gate

This PR is intentionally a draft. No production-signed bundle was created, no Play Console upload occurred, and no rollout was started. The final lite AAB should be signed on Legion with the production release key and uploaded to the Play internal track for review.