### PR TITLE
Overhaul the iOS keyboard, settings, and release plumbing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,22 @@ xcodebuild -project KeyJawn.xcodeproj -scheme KeyJawn \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
   -configuration Debug build
 
+# Unit tests (KeyJawnKitTests, hosted by the app — KeyJawnKit links UIKit,
+# so these need a simulator runtime rather than `swift test`)
+xcodebuild test -project KeyJawn.xcodeproj -scheme KeyJawn \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
 # Archive + export for TestFlight/App Store
 bash ios/scripts/build.sh
 ```
+
+**Versioning:** `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` in `ios/project.yml`
+are the single source of truth. Both targets set them and both Info.plists
+interpolate them via `$(...)`, so bumping the app target's build number and the
+extension's together is the whole job. Do not put literal version strings back into
+the `info.properties` blocks — a literal there wins over the build setting, which is
+how a "bumped" build once shipped still identifying as build 1 and got rejected as a
+duplicate upload.
 
 **Architecture:**
 - `KeyJawnKit/` — shared Swift package used by both the main app and the keyboard extension. Contains keyboard models (`KeyboardLayout`, `HostConfig`, `SlashCommand`, `CtrlState`) and UIKit views (`QwertyKeyboardView`, `ExtraRowView`, `SlashCommandPanel`).
@@ -129,7 +142,9 @@ bash ios/scripts/build.sh
 - `KeyJawnKeyboard/` — `UIInputViewController` keyboard extension. Uses `QwertyKeyboardView` + `ExtraRowView` from KeyJawnKit. Uses `group.com.keyjawn` App Group to share host configs and SSH key bytes with the main app (`AppGroupHostStore`, `AppGroupSSHKeyStore`). SCP image upload via `CitadelSCPUploader` (Citadel/SwiftNIO SFTP).
 
 **Key decisions:**
-- One Ed25519 identity key for the whole app (not per-host). Public key is shown in Settings → SSH keys for the user to copy to `authorized_keys`. Private key stored in Keychain under `com.keyjawn / ssh-identity-ed25519`.
+- One Ed25519 identity key for the whole app (not per-host). Public key is shown in Settings → SSH keys for the user to copy to `authorized_keys`. Private key stored in Keychain under `com.keyjawn / ssh-identity-ed25519`, accessible `WhenUnlockedThisDeviceOnly`.
+- The extension can't read that Keychain item, so the key is mirrored into the App Group container by `AppGroupSecretStore` as a file with `.completeFileProtectionUntilUserAuthentication` and `isExcludedFromBackup`. It is deliberately **not** a shared `UserDefaults` value: group container plists are backed up, which would have copied the private key off-device and undone the `ThisDeviceOnly` class. `SSHKeyStore.syncAppGroupMirror()` reconciles the mirror against the Keychain at every launch.
+- Keyboard preferences (`KeyboardPrefs`) live in the `group.com.keyjawn` suite, not `UserDefaults.standard` — the app and the extension have separate standard suites, so anything written there never reaches the keyboard. The extension can only read the shared suite with Full Access; without it the keyboard falls back to defaults.
 - Host key pinning via `NIOSSHPublicKey(openSSHPublicKey:)`. If no host key is stored, connects with `.acceptAnything()` (warns in UI).
 - Keyboard extension cannot use `present()`. Overlays (slash command panel) are added as `UIView` children of the extension root view.
 - Debug build uses automatic signing; Release build uses manual signing with App Store provisioning profiles (`KeyJawn AppStore`, `KeyJawn Keyboard AppStore`).
@@ -189,9 +204,20 @@ git add website/public/screenshots/ios-screenshots/ios-slash-commands.png
 git commit -m "replace slash commands screenshot with unbranded keyboard UI"
 ```
 
+**Step 2b: Run the tests**
+
+```bash
+cd ios && xcodebuild test -project KeyJawn.xcodeproj -scheme KeyJawn \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+This is the first thing to run on the Mac — none of the iOS code has ever been
+compiled in a web session, so the suite is also the build check.
+
 **Step 3: Bump the build number**
 
-Open `ios/project.yml`. Find `CURRENT_PROJECT_VERSION` and increment it by 1 (e.g. `7` → `8`). Then commit:
+Open `ios/project.yml` and increment `CURRENT_PROJECT_VERSION` **on both targets**
+(`KeyJawn` and `KeyJawnKeyboard`) — they must match or App Store Connect rejects the
+upload. The Info.plists interpolate the setting, so this is the only edit needed.
 ```bash
 git add ios/project.yml
 git commit -m "bump iOS build number for 3.2.2 resubmission"

--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Configuration/KeyJawnKeyboard.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 5624SD289G;
 				INFOPLIST_FILE = KeyJawnKeyboard/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -496,6 +497,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.keyjawn.keyboard;
 				PRODUCT_NAME = KeyJawnKeyboard;
 				SDKROOT = iphoneos;
@@ -510,6 +512,7 @@
 				CODE_SIGN_ENTITLEMENTS = Configuration/KeyJawnKeyboard.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 5624SD289G;
 				INFOPLIST_FILE = KeyJawnKeyboard/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -518,6 +521,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.keyjawn.keyboard;
 				PRODUCT_NAME = KeyJawnKeyboard;
 				PROVISIONING_PROFILE_SPECIFIER = "KeyJawn Keyboard AppStore";
@@ -535,7 +539,7 @@
 				CODE_SIGN_ENTITLEMENTS = Configuration/KeyJawn.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 5624SD289G;
 				INFOPLIST_FILE = KeyJawn/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
@@ -560,7 +564,7 @@
 				CODE_SIGN_ENTITLEMENTS = Configuration/KeyJawn.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 8;
 				DEVELOPMENT_TEAM = 5624SD289G;
 				INFOPLIST_FILE = KeyJawn/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;

--- a/ios/KeyJawn/App/ContentView.swift
+++ b/ios/KeyJawn/App/ContentView.swift
@@ -2,18 +2,49 @@ import SwiftUI
 import KeyJawnKit
 
 struct ContentView: View {
-    var body: some View {
-        TabView {
-            TerminalViewControllerRepresentable()
-                .tabItem { Label("Terminal", systemImage: "terminal") }
 
+    private enum Tab: Hashable {
+        case hosts, preview, settings
+    }
+
+    // Hosts, not the terminal. The terminal tab has no session behind it, so opening
+    // the app onto it presented a prompt that echoes keystrokes and connects to
+    // nothing — a first launch that looks broken. Hosts is where the app actually
+    // starts: add a server, tap it, get a shell.
+    @State private var selection: Tab = .hosts
+
+    var body: some View {
+        TabView(selection: $selection) {
             HostListView()
                 .tabItem { Label("Hosts", systemImage: "server.rack") }
+                .tag(Tab.hosts)
+
+            TerminalPreviewView()
+                .tabItem { Label("Preview", systemImage: "terminal") }
+                .tag(Tab.preview)
 
             SettingsView()
                 .tabItem { Label("Settings", systemImage: "gearshape") }
+                .tag(Tab.settings)
         }
         .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - Terminal preview
+
+/// A local-echo terminal for trying the extra row without a server.
+///
+/// It used to be the app's first tab, labelled simply "Terminal", which made a scratch
+/// pad look like a broken SSH session. Named and titled for what it is instead.
+struct TerminalPreviewView: View {
+    var body: some View {
+        NavigationStack {
+            TerminalViewControllerRepresentable()
+                .ignoresSafeArea(edges: .bottom)
+                .navigationTitle("Preview")
+                .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 

--- a/ios/KeyJawn/App/KeyJawnApp.swift
+++ b/ios/KeyJawn/App/KeyJawnApp.swift
@@ -4,6 +4,14 @@ import SwiftUI
 struct KeyJawnApp: App {
     @StateObject private var hostStore = HostStore()
 
+    init() {
+        // Reconcile the extension-visible key mirror with the Keychain at launch.
+        // Without this, an install whose mirror is missing or stale — a storage format
+        // change, a reset group container — leaves SFTP upload from the keyboard
+        // reporting "SSH key not found" with nothing the user can do about it.
+        SSHKeyStore.shared.syncAppGroupMirror()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/ios/KeyJawn/Hosts/HostEditView.swift
+++ b/ios/KeyJawn/Hosts/HostEditView.swift
@@ -2,18 +2,38 @@ import SwiftUI
 import KeyJawnKit
 @preconcurrency import NIOSSH
 
+/// Add or edit a host.
+///
+/// This was add-only: `HostStore.update` had no caller, a typo in a hostname meant
+/// deleting the host and retyping it, and the "host key not verified" warning told
+/// users to add a key in host settings — a screen that did not exist. Passing an
+/// existing host here reuses its `id`, so the store updates in place instead of
+/// appending a duplicate.
 struct HostEditView: View {
-    let onSave: (HostConfig) -> Void
+    private let existing: HostConfig?
+    private let onSave: (HostConfig) -> Void
 
     @Environment(\.dismiss) private var dismiss
 
-    @State private var label = ""
-    @State private var hostname = ""
-    @State private var port = "22"
-    @State private var username = ""
-    @State private var authMethod = HostConfig.AuthMethod.key
-    @State private var hostPublicKey = ""
-    @State private var uploadPath = "/tmp"
+    @State private var label: String
+    @State private var hostname: String
+    @State private var port: String
+    @State private var username: String
+    @State private var authMethod: HostConfig.AuthMethod
+    @State private var hostPublicKey: String
+    @State private var uploadPath: String
+
+    init(host: HostConfig? = nil, onSave: @escaping (HostConfig) -> Void) {
+        self.existing = host
+        self.onSave = onSave
+        _label = State(initialValue: host?.label ?? "")
+        _hostname = State(initialValue: host?.hostname ?? "")
+        _port = State(initialValue: host.map { String($0.port) } ?? "22")
+        _username = State(initialValue: host?.username ?? "")
+        _authMethod = State(initialValue: host?.authMethod ?? .key)
+        _hostPublicKey = State(initialValue: host?.hostPublicKey ?? "")
+        _uploadPath = State(initialValue: host?.uploadPath ?? "/tmp")
+    }
 
     private var isHostKeyValid: Bool {
         let trimmed = hostPublicKey.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -21,11 +41,17 @@ struct HostEditView: View {
         return (try? NIOSSHPublicKey(openSSHPublicKey: trimmed)) != nil
     }
 
+    /// A port has to fit in the `UInt16` the config stores. Validating against `Int`
+    /// let 70000 through, and it was silently saved as 22.
+    private var parsedPort: UInt16? {
+        UInt16(port.trimmingCharacters(in: .whitespaces)).flatMap { $0 > 0 ? $0 : nil }
+    }
+
     private var isValid: Bool {
         !label.trimmingCharacters(in: .whitespaces).isEmpty &&
         !hostname.trimmingCharacters(in: .whitespaces).isEmpty &&
         !username.trimmingCharacters(in: .whitespaces).isEmpty &&
-        Int(port) != nil &&
+        parsedPort != nil &&
         isHostKeyValid
     }
 
@@ -42,7 +68,7 @@ struct HostEditView: View {
                         TextField("hostname or IP", text: $hostname)
                             .multilineTextAlignment(.trailing)
                             .autocorrectionDisabled()
-                            .autocapitalization(.none)
+                            .textInputAutocapitalization(.never)
                             .keyboardType(.URL)
                     }
                     LabeledContent("Port") {
@@ -54,7 +80,7 @@ struct HostEditView: View {
                         TextField("username", text: $username)
                             .multilineTextAlignment(.trailing)
                             .autocorrectionDisabled()
-                            .autocapitalization(.none)
+                            .textInputAutocapitalization(.never)
                     }
                 }
 
@@ -73,7 +99,7 @@ struct HostEditView: View {
                             .font(.caption)
                             .foregroundStyle(.red)
                     } else {
-                        Text("Paste output of: ssh-keyscan -t ed25519 <hostname>\nIf omitted, the server's key is not verified.")
+                        Text("Paste output of: ssh-keyscan -t ed25519 <hostname>\nIf omitted, the server's key is not verified and the connection can be intercepted.")
                             .font(.caption)
                     }
                 }
@@ -87,7 +113,7 @@ struct HostEditView: View {
                     .listRowBackground(Color.clear)
 
                     if authMethod == .key {
-                        Text("Keys are managed in Settings → SSH Keys.")
+                        Text("Keys are managed in Settings → SSH keys.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -98,7 +124,7 @@ struct HostEditView: View {
                         TextField("/tmp", text: $uploadPath)
                             .multilineTextAlignment(.trailing)
                             .autocorrectionDisabled()
-                            .autocapitalization(.none)
+                            .textInputAutocapitalization(.never)
                     }
                 } header: {
                     Text("SCP upload")
@@ -107,31 +133,36 @@ struct HostEditView: View {
                         .font(.caption)
                 }
             }
-            .navigationTitle("Add host")
+            .navigationTitle(existing == nil ? "Add host" : "Edit host")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Save") {
-                        let trimmedKey = hostPublicKey.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let trimmedPath = uploadPath.trimmingCharacters(in: .whitespaces)
-                        let host = HostConfig(
-                            label: label.trimmingCharacters(in: .whitespaces),
-                            hostname: hostname.trimmingCharacters(in: .whitespaces),
-                            port: UInt16(port) ?? 22,
-                            username: username.trimmingCharacters(in: .whitespaces),
-                            authMethod: authMethod,
-                            hostPublicKey: trimmedKey.isEmpty ? nil : trimmedKey,
-                            uploadPath: trimmedPath.isEmpty ? "/tmp" : trimmedPath
-                        )
-                        onSave(host)
-                        dismiss()
-                    }
-                    .disabled(!isValid)
+                    Button("Save") { save() }
+                        .disabled(!isValid)
                 }
             }
         }
+    }
+
+    private func save() {
+        let trimmedKey = hostPublicKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPath = uploadPath.trimmingCharacters(in: .whitespaces)
+        let host = HostConfig(
+            // Carrying the id forward is what makes this an edit rather than a new
+            // host: HostStore.update matches on it.
+            id: existing?.id ?? UUID(),
+            label: label.trimmingCharacters(in: .whitespaces),
+            hostname: hostname.trimmingCharacters(in: .whitespaces),
+            port: parsedPort ?? 22,
+            username: username.trimmingCharacters(in: .whitespaces),
+            authMethod: authMethod,
+            hostPublicKey: trimmedKey.isEmpty ? nil : trimmedKey,
+            uploadPath: trimmedPath.isEmpty ? "/tmp" : trimmedPath
+        )
+        onSave(host)
+        dismiss()
     }
 }

--- a/ios/KeyJawn/Hosts/HostEditView.swift
+++ b/ios/KeyJawn/Hosts/HostEditView.swift
@@ -47,6 +47,16 @@ struct HostEditView: View {
         UInt16(port.trimmingCharacters(in: .whitespaces)).flatMap { $0 > 0 ? $0 : nil }
     }
 
+    /// Built from what has been typed so far, so a non-default port shows up as `-p`
+    /// in the instructions rather than sending the user to scan port 22.
+    private var scanCommand: String {
+        let trimmedHost = hostname.trimmingCharacters(in: .whitespaces)
+        return HostConfig.hostKeyScanCommand(
+            hostname: trimmedHost.isEmpty ? "<hostname>" : trimmedHost,
+            port: parsedPort ?? 22
+        )
+    }
+
     private var isValid: Bool {
         !label.trimmingCharacters(in: .whitespaces).isEmpty &&
         !hostname.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -95,11 +105,11 @@ struct HostEditView: View {
                 } footer: {
                     let trimmed = hostPublicKey.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !trimmed.isEmpty && !isHostKeyValid {
-                        Text("Invalid key format. Paste the full line from: ssh-keyscan -t ed25519 <hostname>")
+                        Text("Invalid key format. Paste the full line from: \(scanCommand)")
                             .font(.caption)
                             .foregroundStyle(.red)
                     } else {
-                        Text("Paste output of: ssh-keyscan -t ed25519 <hostname>\nIf omitted, the server's key is not verified and the connection can be intercepted.")
+                        Text("Paste output of: \(scanCommand)\nIf omitted, the server's key is not verified and the connection can be intercepted.")
                             .font(.caption)
                     }
                 }

--- a/ios/KeyJawn/Hosts/HostListView.swift
+++ b/ios/KeyJawn/Hosts/HostListView.swift
@@ -4,6 +4,7 @@ import KeyJawnKit
 struct HostListView: View {
     @EnvironmentObject private var hostStore: HostStore
     @State private var showingAddHost = false
+    @State private var editingHost: HostConfig?
 
     var body: some View {
         NavigationStack {
@@ -23,11 +24,17 @@ struct HostListView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .accessibilityLabel("Add host")
                 }
             }
             .sheet(isPresented: $showingAddHost) {
                 HostEditView { newHost in
                     hostStore.add(newHost)
+                }
+            }
+            .sheet(item: $editingHost) { host in
+                HostEditView(host: host) { updated in
+                    hostStore.update(updated)
                 }
             }
         }
@@ -58,6 +65,24 @@ struct HostListView: View {
                 NavigationLink(value: host) {
                     HostRow(host: host)
                 }
+                // Tapping a row connects, so editing needs its own affordance. Without
+                // one there was no way to correct a hostname or add a host key after
+                // the fact short of deleting the host and typing it in again.
+                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                    Button {
+                        editingHost = host
+                    } label: {
+                        Label("Edit", systemImage: "pencil")
+                    }
+                    .tint(.blue)
+                }
+                .contextMenu {
+                    Button {
+                        editingHost = host
+                    } label: {
+                        Label("Edit host", systemImage: "pencil")
+                    }
+                }
             }
             .onDelete { indices in
                 hostStore.delete(at: indices)
@@ -74,8 +99,18 @@ struct HostRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
-            Text(host.label)
-                .fontWeight(.medium)
+            HStack(spacing: 6) {
+                Text(host.label)
+                    .fontWeight(.medium)
+                // Surface the unverified state before the user connects, rather than
+                // only in a toolbar button once the session is already live.
+                if host.hostPublicKey == nil {
+                    Image(systemName: "shield.slash")
+                        .font(.caption2)
+                        .foregroundStyle(.orange)
+                        .accessibilityLabel("Host key not verified")
+                }
+            }
             Text("\(host.username)@\(host.hostname):\(host.port)")
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/ios/KeyJawn/Hosts/HostTerminalView.swift
+++ b/ios/KeyJawn/Hosts/HostTerminalView.swift
@@ -76,8 +76,9 @@ struct HostTerminalView: View {
             Button("OK", role: .cancel) {}
         } message: {
             // The previous wording pointed at "host settings", which did not exist —
-            // there was no edit path at all. Name the gesture that now does.
-            Text("No host key is configured for \(host.label). The server's identity cannot be confirmed, making this connection susceptible to interception.\n\nTo fix it, run: ssh-keyscan -t ed25519 \(host.hostname)\n\nThen go back to Hosts, swipe right on \(host.label), tap Edit, and paste the output into Host key. It takes effect on the next connection.")
+            // there was no edit path at all. Name the gesture that now does, and let
+            // HostConfig build the scan command so a non-default port is carried.
+            Text("No host key is configured for \(host.label). The server's identity cannot be confirmed, making this connection susceptible to interception.\n\nTo fix it, run: \(host.hostKeyScanCommand)\n\nThen go back to Hosts, swipe right on \(host.label), tap Edit, and paste the output into Host key. It takes effect on the next connection.")
         }
     }
 

--- a/ios/KeyJawn/Hosts/HostTerminalView.swift
+++ b/ios/KeyJawn/Hosts/HostTerminalView.swift
@@ -75,7 +75,9 @@ struct HostTerminalView: View {
         .alert("Host key not verified", isPresented: $showingKeyWarning) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text("No host key is configured for \(host.label). The server's identity cannot be confirmed, making this connection susceptible to interception.\n\nAdd a host key in host settings to secure future connections.")
+            // The previous wording pointed at "host settings", which did not exist —
+            // there was no edit path at all. Name the gesture that now does.
+            Text("No host key is configured for \(host.label). The server's identity cannot be confirmed, making this connection susceptible to interception.\n\nTo fix it, run: ssh-keyscan -t ed25519 \(host.hostname)\n\nThen go back to Hosts, swipe right on \(host.label), tap Edit, and paste the output into Host key. It takes effect on the next connection.")
         }
     }
 

--- a/ios/KeyJawn/Info.plist
+++ b/ios/KeyJawn/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>

--- a/ios/KeyJawn/Settings/SettingsView.swift
+++ b/ios/KeyJawn/Settings/SettingsView.swift
@@ -1,9 +1,16 @@
 import SwiftUI
+import KeyJawnKit
 
 struct SettingsView: View {
-    @AppStorage("theme") private var theme = "dark"
-    @AppStorage("hapticEnabled") private var hapticEnabled = true
-    @AppStorage("autocorrectEnabled") private var autocorrectEnabled = false
+
+    // Backed by KeyboardPrefs, which writes the shared App Group suite. These used to
+    // be @AppStorage properties in the app's own sandbox under keys nothing ever read:
+    // the theme picker changed nothing, the haptics switch changed nothing, and the
+    // autocorrect switch was not wired to any code at all. Every control here now
+    // changes what the keyboard does.
+    @State private var theme = KeyboardPrefs.shared.theme
+    @State private var hapticsEnabled = KeyboardPrefs.shared.hapticsEnabled
+    @State private var terminalArrowKeys = KeyboardPrefs.shared.terminalArrowKeys
 
     var body: some View {
         NavigationStack {
@@ -14,27 +21,64 @@ struct SettingsView: View {
                     }
                 }
 
-                Section("Keyboard") {
-                    Toggle("Haptic feedback", isOn: $hapticEnabled)
-                    Toggle("Autocorrect", isOn: $autocorrectEnabled)
+                Section {
+                    Toggle("Key press feedback", isOn: $hapticsEnabled)
+                        .onChange(of: hapticsEnabled) { _, newValue in
+                            KeyboardPrefs.shared.hapticsEnabled = newValue
+                        }
+                } header: {
+                    Text("Keyboard")
+                } footer: {
+                    Text("The system's own keyboard feedback settings still apply on top of this.")
+                        .font(.caption)
                 }
 
-                Section("Appearance") {
+                Section {
+                    Toggle("Terminal arrow keys", isOn: $terminalArrowKeys)
+                        .onChange(of: terminalArrowKeys) { _, newValue in
+                            KeyboardPrefs.shared.terminalArrowKeys = newValue
+                        }
+                } header: {
+                    Text("Extra row")
+                } footer: {
+                    Text(terminalArrowKeys
+                         ? "Arrows send escape codes, so up and down reach shell history in a terminal app."
+                         : "Left and right move the text cursor. Up and down have no effect with this off.")
+                        .font(.caption)
+                }
+
+                Section {
                     Picker("Theme", selection: $theme) {
-                        Text("Dark").tag("dark")
-                        Text("Light").tag("light")
-                        Text("OLED").tag("oled")
-                        Text("Terminal").tag("terminal")
+                        ForEach(KeyboardTheme.allCases, id: \.self) { option in
+                            Text(option.displayName).tag(option)
+                        }
                     }
+                    .onChange(of: theme) { _, newValue in
+                        KeyboardPrefs.shared.theme = newValue
+                    }
+                } header: {
+                    Text("Appearance")
+                } footer: {
+                    Text("Applies to the KeyJawn keyboard. The keyboard needs Full Access to read this setting: Settings → General → Keyboard → Keyboards → KeyJawn.")
+                        .font(.caption)
                 }
 
                 Section("About") {
-                    LabeledContent("Version", value: "1.0.0")
+                    LabeledContent("Version", value: Self.versionString)
                     Link("Privacy policy", destination: URL(string: "https://keyjawn.amditis.tech/privacy")!)
                     Link("Manual", destination: URL(string: "https://keyjawn.amditis.tech/manual")!)
                 }
             }
             .navigationTitle("Settings")
         }
+    }
+
+    /// Read from the bundle rather than typed in by hand, so it cannot drift from the
+    /// build the user is actually running.
+    private static var versionString: String {
+        let info = Bundle.main.infoDictionary
+        let short = info?["CFBundleShortVersionString"] as? String ?? "—"
+        let build = info?["CFBundleVersion"] as? String ?? "—"
+        return "\(short) (\(build))"
     }
 }

--- a/ios/KeyJawn/Store/SSHKeyStore.swift
+++ b/ios/KeyJawn/Store/SSHKeyStore.swift
@@ -1,17 +1,20 @@
 import Foundation
 import CryptoKit
 import Security
+import KeyJawnKit
 
 /// Manages the app's single Ed25519 SSH identity key.
-/// The private key is stored in the Keychain and survives reinstalls (if iCloud Keychain is on).
-/// The public key is derived on demand and shown in Settings → SSH Keys for the user to copy to servers.
+///
+/// The private key is stored in the Keychain, pinned to this device, and mirrored into
+/// the App Group container so the keyboard extension can authenticate SFTP uploads.
+/// The public key is derived on demand and shown in Settings → SSH keys for the user
+/// to copy to servers.
 final class SSHKeyStore: @unchecked Sendable {
     static let shared = SSHKeyStore()
     private init() {}
 
     private let service = "com.keyjawn"
     private let account = "ssh-identity-ed25519"
-    private let appGroupRawKey = "keyjawn.ssh-identity-raw"
 
     // MARK: - Key access
 
@@ -34,6 +37,20 @@ final class SSHKeyStore: @unchecked Sendable {
     func regenerate() {
         deleteKey()
         _ = privateKey
+    }
+
+    /// Brings the extension-visible mirror back in line with the Keychain.
+    ///
+    /// The mirror is only written when a key is generated, so it can be missing or
+    /// stale on an install that predates it, after the storage format changed, or if
+    /// the group container was reset — and the extension's only symptom is
+    /// "SSH key not found" on an upload the user has every reason to expect to work.
+    /// The Keychain is the system of record, so reconcile towards it at launch.
+    func syncAppGroupMirror() {
+        guard let existing = loadKey() else { return }
+        let raw = existing.rawRepresentation
+        guard AppGroupSecretStore.identityKeyData() != raw else { return }
+        AppGroupSecretStore.write(identityKeyData: raw)
     }
 
     // MARK: - Keychain
@@ -62,8 +79,11 @@ final class SSHKeyStore: @unchecked Sendable {
         SecItemDelete(attrs as CFDictionary)
         SecItemAdd(attrs as CFDictionary, nil)
 
-        // Mirror raw key bytes to App Group so the keyboard extension can authenticate.
-        UserDefaults(suiteName: "group.com.keyjawn")?.set(key.rawRepresentation, forKey: appGroupRawKey)
+        // Mirror raw key bytes to the App Group so the keyboard extension can
+        // authenticate. Goes through AppGroupSecretStore, which keeps the mirror
+        // encrypted at rest and out of device backups — a plain UserDefaults value
+        // would have been backed up, undoing the ThisDeviceOnly class above.
+        AppGroupSecretStore.write(identityKeyData: key.rawRepresentation)
     }
 
     private func deleteKey() {
@@ -74,8 +94,8 @@ final class SSHKeyStore: @unchecked Sendable {
         ]
         SecItemDelete(query as CFDictionary)
 
-        // Remove mirror too.
-        UserDefaults(suiteName: "group.com.keyjawn")?.removeObject(forKey: appGroupRawKey)
+        // Remove mirror too, including any value left by the pre-file layout.
+        AppGroupSecretStore.deleteIdentityKey()
     }
 }
 

--- a/ios/KeyJawn/Terminal/SSHSession.swift
+++ b/ios/KeyJawn/Terminal/SSHSession.swift
@@ -57,7 +57,14 @@ final class SSHSession: ObservableObject {
     }
 
     private func connect(to host: HostConfig, authenticationMethod: SSHAuthenticationMethod) {
-        guard connectionState == .disconnected else { return }
+        // Guard on what actually conflicts — a connection in flight or established —
+        // rather than on being exactly `.disconnected`. The old check also rejected
+        // `.failed`, so retrying after an error silently did nothing unless the caller
+        // happened to call `disconnect()` first.
+        switch connectionState {
+        case .connecting, .connected: return
+        case .disconnected, .failed: break
+        }
         connectionState = .connecting
         isHostKeyVerified = host.hostPublicKey != nil
 

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -29,15 +29,38 @@ final class TerminalInputView: UITextView {
         autocorrectionType       = .no
         autocapitalizationType   = .none
         spellCheckingType        = .no
+        // Smart substitution turns a typed "--flag" into an en dash and quotes into
+        // curly ones, which reach the shell as characters it does not understand.
+        smartQuotesType          = .no
+        smartDashesType          = .no
+        smartInsertDeleteType    = .no
 
         extraRow.frame     = CGRect(x: 0, y: 0, width: 0, height: 52)
         extraRow.delegate  = self
+        // Same theme the keyboard extension uses, so the row looks like one component
+        // wherever it appears rather than defaulting to dark here and themed there.
+        extraRow.applyTheme(KeyboardPrefs.shared.theme)
         inputAccessoryView = extraRow
     }
 
     // MARK: UIKeyInput — intercept before text hits the text view
 
     override func insertText(_ text: String) {
+        // Apply an armed or locked Ctrl modifier to ordinary typed characters.
+        //
+        // The modifier only ever reached the extra row's own keys, so the three-state
+        // Ctrl machine could arm but the combination it exists for — Ctrl and a letter
+        // — never happened: no Ctrl+D to close stdin, no Ctrl+Z to suspend, no Ctrl+L
+        // to clear, no Ctrl+A or Ctrl+E to jump the line. Restricted to single
+        // characters so a multi-character insertion (a paste, a dictation result) is
+        // not silently collapsed into one control byte.
+        if extraRow.ctrl.isActive,
+           text.count == 1,
+           let bytes = ANSISequence.bytes(for: .character(text), ctrlActive: true) {
+            onRawInput?(bytes)
+            extraRow.ctrl.consume()
+            return
+        }
         onRawInput?(Array(text.utf8))
         // Intentionally no super call — keeps UITextView text empty.
     }

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -40,6 +40,7 @@ final class TerminalInputView: UITextView {
         // Same theme the keyboard extension uses, so the row looks like one component
         // wherever it appears rather than defaulting to dark here and themed there.
         extraRow.applyTheme(KeyboardPrefs.shared.theme)
+        KeyboardHaptics.refresh()
         inputAccessoryView = extraRow
     }
 

--- a/ios/KeyJawn/Terminal/TerminalViewController.swift
+++ b/ios/KeyJawn/Terminal/TerminalViewController.swift
@@ -103,7 +103,11 @@ final class TerminalViewController: UIViewController {
         ])
 
         if session == nil {
-            terminalView.feed(text: "KeyJawn — tap to open keyboard\r\n")
+            // Local echo, no server. Say so, so this does not read as a session that
+            // failed to connect.
+            terminalView.feed(text: "KeyJawn preview — local echo, not connected.\r\n")
+            terminalView.feed(text: "Tap to open the keyboard and try the terminal row.\r\n")
+            terminalView.feed(text: "Add a server in the Hosts tab for a real shell.\r\n\r\n")
         }
     }
 

--- a/ios/KeyJawnKeyboard/AppGroupSSHKeyStore.swift
+++ b/ios/KeyJawnKeyboard/AppGroupSSHKeyStore.swift
@@ -1,15 +1,16 @@
 import Foundation
+import KeyJawnKit
 
 /// Read-only SSH key accessor for the keyboard extension.
-/// Key bytes are mirrored to App Group UserDefaults by SSHKeyStore in the main app.
+///
+/// The main app mirrors the key into the App Group container; see
+/// ``AppGroupSecretStore`` for why it crosses as a protected, backup-excluded file
+/// rather than as a value in the shared `UserDefaults` suite.
 final class AppGroupSSHKeyStore: @unchecked Sendable {
     static let shared = AppGroupSSHKeyStore()
     private init() {}
 
-    private let key = "keyjawn.ssh-identity-raw"
-    private var defaults: UserDefaults? { UserDefaults(suiteName: "group.com.keyjawn") }
-
     var privateKeyData: Data? {
-        defaults?.data(forKey: key)
+        AppGroupSecretStore.identityKeyData()
     }
 }

--- a/ios/KeyJawnKeyboard/CitadelSCPUploader.swift
+++ b/ios/KeyJawnKeyboard/CitadelSCPUploader.swift
@@ -27,8 +27,13 @@ enum CitadelSCPUploader {
 
     /// Uploads `imageData` to `host` via SFTP. Returns the remote file path on success.
     static func upload(imageData: Data, to host: HostConfig, privateKeyData: Data) async throws -> String {
-        // Build the remote path.
-        let filename = "keyjawn-\(Int(Date().timeIntervalSince1970)).jpg"
+        // Build the remote path. The suffix is there because the timestamp alone has
+        // one-second resolution and the write below truncates: two uploads in the same
+        // second silently overwrote each other, and the path handed back for the first
+        // one then pointed at the second one's image.
+        let stamp = Int(Date().timeIntervalSince1970)
+        let suffix = UUID().uuidString.prefix(6).lowercased()
+        let filename = "keyjawn-\(stamp)-\(suffix).jpg"
         let base = host.uploadPath.hasSuffix("/") ? host.uploadPath : host.uploadPath + "/"
         let remotePath = "\(base)\(filename)"
 

--- a/ios/KeyJawnKeyboard/Info.plist
+++ b/ios/KeyJawnKeyboard/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/ios/KeyJawnKeyboard/InputViewAudioFeedback.swift
+++ b/ios/KeyJawnKeyboard/InputViewAudioFeedback.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+/// Opts the keyboard's input view into system key click feedback.
+///
+/// `UIDevice.playInputClick()` is the only feedback channel available to a keyboard
+/// extension — `UIImpactFeedbackGenerator` is inert there — and it is ignored unless
+/// the enclosing input view declares that it wants clicks. Declaring it on
+/// `UIInputView` covers the view `UIInputViewController` vends without having to
+/// replace the controller's view hierarchy.
+///
+/// The system still respects the user's own Keyboard Feedback settings on top of
+/// this, and `KeyboardHaptics` gates it on the app's own preference, so returning
+/// true unconditionally here does not force feedback on anyone.
+extension UIInputView: @retroactive UIInputViewAudioFeedback {
+    public var enableInputClicksWhenVisible: Bool { true }
+}

--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -70,7 +70,7 @@ public final class KeyboardViewController: UIInputViewController {
             theme = current
             applyTheme()
         }
-        KeyboardHaptics.prepare()
+        KeyboardHaptics.refresh()
     }
 
     public override func viewWillLayoutSubviews() {
@@ -414,6 +414,21 @@ extension KeyboardViewController: NumberRowDelegate {
 extension KeyboardViewController: QwertyKeyboardDelegate {
 
     public func keyboard(_ keyboard: QwertyKeyboardView, insertText text: String) {
+        // Apply an armed or locked Ctrl modifier to letters typed on the QWERTY grid.
+        //
+        // The modifier is armed by long-pressing ^C in the extra row, and without this
+        // the arming had nowhere to land: letters went straight to the proxy, so
+        // Ctrl+D, Ctrl+Z, Ctrl+L and Ctrl+A/E worked in the in-app terminal and not in
+        // the keyboard extension, which is the surface the product is actually for.
+        // Restricted to single characters so a multi-character insertion is not
+        // collapsed into one control byte.
+        if extraRow.ctrl.isActive,
+           text.count == 1,
+           let control = ANSISequence.text(for: .character(text), ctrlActive: true) {
+            textDocumentProxy.insertText(control)
+            extraRow.ctrl.consume()
+            return
+        }
         textDocumentProxy.insertText(text)
     }
 

--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -10,59 +10,138 @@ public final class KeyboardViewController: UIInputViewController {
     private var clipboardPanel: ClipboardPanel?
     private var uploadPanel: UploadPanel?
 
-    // Total height: 52 (extra row) + 4 (gap) + 42 (number row) + 4 (gap) + 220 (4 key rows) = 322
-    private static let keyboardHeight: CGFloat = 322
+    private var theme: KeyboardTheme = .dark
+
+    // Height constraints are held so the layout can follow the device and orientation
+    // rather than being pinned to one phone-portrait number.
+    private var extraRowHeight: NSLayoutConstraint!
+    private var numberRowTop: NSLayoutConstraint!
+    private var numberRowHeight: NSLayoutConstraint!
+    private var qwertyTop: NSLayoutConstraint!
+    private var keyboardHeight: NSLayoutConstraint!
+    private var appliedMetrics: Metrics?
+
+    // MARK: - Metrics
+
+    /// Row heights for the current device and orientation.
+    ///
+    /// The keyboard used to be a hardcoded 322pt everywhere. On a phone in landscape
+    /// that is most of the available height, leaving the app it is typing into as a
+    /// sliver; on iPad the same 322pt reads as a cramped strip of tiny keys. Phone
+    /// portrait keeps its existing numbers exactly, so the common case is unchanged.
+    private struct Metrics: Equatable {
+        let extraRow: CGFloat
+        let numberRow: CGFloat
+        let gap: CGFloat
+        let qwerty: CGFloat
+
+        var total: CGFloat { extraRow + gap + numberRow + gap + qwerty }
+
+        static let phonePortrait  = Metrics(extraRow: 52, numberRow: 42, gap: 4, qwerty: 220)
+        static let phoneLandscape = Metrics(extraRow: 40, numberRow: 32, gap: 3, qwerty: 150)
+        static let pad            = Metrics(extraRow: 62, numberRow: 52, gap: 6, qwerty: 300)
+
+        static func current(for traits: UITraitCollection) -> Metrics {
+            if traits.userInterfaceIdiom == .pad { return .pad }
+            // A compact vertical size class on a phone is landscape, including the
+            // larger phones that stay regular-width there.
+            return traits.verticalSizeClass == .compact ? .phoneLandscape : .phonePortrait
+        }
+    }
+
+    // MARK: - Lifecycle
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        let theme = KeyboardPrefs.shared.theme
+        theme = KeyboardPrefs.shared.theme
         view.backgroundColor = theme.keyboardBg
-        setupExtraRow(theme: theme)
+        setupExtraRow()
         setupNumberRow()
-        setupQwerty(theme: theme)
+        setupQwerty()
         setupHeightConstraint()
+    }
+
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // The extension process survives between activations, so a theme picked in the
+        // main app has to be re-read here rather than only at first load.
+        let current = KeyboardPrefs.shared.theme
+        if current != theme {
+            theme = current
+            applyTheme()
+        }
+        KeyboardHaptics.prepare()
+    }
+
+    public override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        applyMetrics()
+    }
+
+    /// Recompute row heights for the current traits.
+    ///
+    /// Safe to call from layout because it is idempotent: the guard returns without
+    /// touching a constraint once the metrics for the current traits are applied, so
+    /// it cannot drive a layout loop.
+    private func applyMetrics() {
+        let metrics = Metrics.current(for: traitCollection)
+        guard metrics != appliedMetrics else { return }
+        appliedMetrics = metrics
+
+        extraRowHeight.constant = metrics.extraRow
+        numberRowTop.constant = metrics.gap
+        numberRowHeight.constant = metrics.numberRow
+        qwertyTop.constant = metrics.gap
+        keyboardHeight.constant = metrics.total
     }
 
     // MARK: - Setup
 
-    private func setupExtraRow(theme: KeyboardTheme) {
+    private func setupExtraRow() {
         extraRow = ExtraRowView()
         extraRow.delegate = self
         extraRow.applyTheme(theme)
         extraRow.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(extraRow)
 
+        extraRowHeight = extraRow.heightAnchor.constraint(equalToConstant: Metrics.phonePortrait.extraRow)
         NSLayoutConstraint.activate([
             extraRow.topAnchor.constraint(equalTo: view.topAnchor),
             extraRow.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             extraRow.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            extraRow.heightAnchor.constraint(equalToConstant: 52),
+            extraRowHeight,
         ])
     }
 
     private func setupNumberRow() {
         numberRow = NumberRowView()
         numberRow.delegate = self
+        numberRow.applyTheme(theme)
         numberRow.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(numberRow)
 
+        numberRowTop = numberRow.topAnchor.constraint(equalTo: extraRow.bottomAnchor,
+                                                      constant: Metrics.phonePortrait.gap)
+        numberRowHeight = numberRow.heightAnchor.constraint(equalToConstant: Metrics.phonePortrait.numberRow)
         NSLayoutConstraint.activate([
-            numberRow.topAnchor.constraint(equalTo: extraRow.bottomAnchor, constant: 4),
+            numberRowTop,
             numberRow.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             numberRow.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            numberRow.heightAnchor.constraint(equalToConstant: 42),
+            numberRowHeight,
         ])
     }
 
-    private func setupQwerty(theme: KeyboardTheme) {
+    private func setupQwerty() {
         qwerty = QwertyKeyboardView()
-        qwerty.theme = theme
+        qwerty.applyTheme(theme)
         qwerty.delegate = self
         qwerty.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(qwerty)
 
+        qwertyTop = qwerty.topAnchor.constraint(equalTo: numberRow.bottomAnchor,
+                                                constant: Metrics.phonePortrait.gap)
         NSLayoutConstraint.activate([
-            qwerty.topAnchor.constraint(equalTo: numberRow.bottomAnchor, constant: 4),
+            qwertyTop,
             qwerty.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             qwerty.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             qwerty.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -72,9 +151,31 @@ public final class KeyboardViewController: UIInputViewController {
     private func setupHeightConstraint() {
         // Priority 999 avoids conflicting with the system's own height constraint during
         // the animation when the keyboard appears.
-        let h = view.heightAnchor.constraint(equalToConstant: Self.keyboardHeight)
-        h.priority = UILayoutPriority(999)
-        h.isActive = true
+        keyboardHeight = view.heightAnchor.constraint(equalToConstant: Metrics.phonePortrait.total)
+        keyboardHeight.priority = UILayoutPriority(999)
+        keyboardHeight.isActive = true
+    }
+
+    private func applyTheme() {
+        view.backgroundColor = theme.keyboardBg
+        extraRow.applyTheme(theme)
+        numberRow.applyTheme(theme)
+        qwerty.applyTheme(theme)
+        // Any panel on screen was built with the old colours; drop it rather than
+        // leave a half-recoloured overlay.
+        hideSlashPanel()
+        hideClipboardPanel()
+        hideUploadPanel()
+    }
+
+    // MARK: - Panel presentation
+
+    /// Panels cover the keyboard rather than replacing it — a keyboard extension
+    /// cannot `present()`, so every overlay is a subview sized to the root view.
+    private func showPanel(_ panel: UIView) {
+        panel.frame = view.bounds
+        panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(panel)
     }
 }
 
@@ -86,29 +187,54 @@ extension KeyboardViewController: ExtraRowDelegate {
         let proxy = textDocumentProxy
 
         switch output {
-        case .tab:
-            proxy.insertText("\t")
-
-        case .escape:
-            // Esc is ignored by most text inputs; insert the escape character
-            // so apps that handle raw input (like terminal emulators) receive it.
-            proxy.insertText("\u{1b}")
-
-        case .arrowLeft:
-            proxy.adjustTextPosition(byCharacterOffset: -1)
-
-        case .arrowRight:
-            proxy.adjustTextPosition(byCharacterOffset: 1)
-
         case .slash:
             showSlashPanel()
+
+        case .tab, .escape, .ctrlC, .ctrlD:
+            // Control characters and Esc go in as literal bytes. Terminal apps forward
+            // inserted text straight to the pty, which is how Esc has always worked
+            // here; Ctrl+C used to fall through to the default branch and do nothing
+            // at all, which made the row's leading key — the one the layout comments
+            // call the most-used key in an agent session — inert.
+            if let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
+                proxy.insertText(text)
+            }
+
+        case .arrowUp, .arrowDown:
+            // No cursor equivalent exists for vertical movement through
+            // UITextDocumentProxy, so outside terminal mode these have nothing to do.
+            if KeyboardPrefs.shared.terminalArrowKeys,
+               let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
+                proxy.insertText(text)
+            }
+
+        case .arrowLeft:
+            if KeyboardPrefs.shared.terminalArrowKeys,
+               let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
+                proxy.insertText(text)
+            } else {
+                proxy.adjustTextPosition(byCharacterOffset: -1)
+            }
+
+        case .arrowRight:
+            if KeyboardPrefs.shared.terminalArrowKeys,
+               let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
+                proxy.insertText(text)
+            } else {
+                proxy.adjustTextPosition(byCharacterOffset: 1)
+            }
 
         case .character(let s):
             proxy.insertText(s)
 
-        default:
-            // Ctrl+C, arrowUp/Down — not supported via UITextDocumentProxy.
-            break
+        case .backspace:
+            proxy.deleteBackward()
+
+        case .return:
+            proxy.insertText("\n")
+
+        case .space:
+            proxy.insertText(" ")
         }
     }
 
@@ -133,9 +259,7 @@ extension KeyboardViewController: ExtraRowDelegate {
     private func showSlashPanel() {
         guard slashPanel == nil else { return }
 
-        let panel = SlashCommandPanel()
-        panel.frame = view.bounds
-        panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        let panel = SlashCommandPanel(theme: theme)
         panel.onSelect = { [weak self] command in
             self?.textDocumentProxy.insertText(command.trigger)
             self?.hideSlashPanel()
@@ -143,7 +267,7 @@ extension KeyboardViewController: ExtraRowDelegate {
         panel.onDismiss = { [weak self] in
             self?.hideSlashPanel()
         }
-        view.addSubview(panel)
+        showPanel(panel)
         slashPanel = panel
     }
 
@@ -159,9 +283,7 @@ extension KeyboardViewController: ExtraRowDelegate {
         // Snapshot current clipboard into history before showing.
         ClipboardHistory.shared.addCurrent()
 
-        let panel = ClipboardPanel()
-        panel.frame = view.bounds
-        panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        let panel = ClipboardPanel(theme: theme)
         panel.refresh()
         panel.onSelect = { [weak self] text in
             self?.textDocumentProxy.insertText(text)
@@ -170,7 +292,7 @@ extension KeyboardViewController: ExtraRowDelegate {
         panel.onDismiss = { [weak self] in
             self?.hideClipboardPanel()
         }
-        view.addSubview(panel)
+        showPanel(panel)
         clipboardPanel = panel
     }
 
@@ -184,11 +306,22 @@ extension KeyboardViewController: ExtraRowDelegate {
     private func showUploadPanel() {
         guard uploadPanel == nil else { return }
 
-        let panel = UploadPanel()
-        panel.frame = view.bounds
-        panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        panel.hosts = AppGroupHostStore.shared.hosts
+        let panel = UploadPanel(theme: theme)
+        panel.hosts = hasFullAccess ? AppGroupHostStore.shared.hosts : []
+        // Without Full Access the shared container is closed to the extension, so the
+        // host list reads back empty and SFTP has no network. Name that instead of
+        // telling the user to add hosts they have already added.
+        panel.emptyReason = hasFullAccess ? .noHostsConfigured : .fullAccessRequired
         panel.onDismiss = { [weak self] in self?.hideUploadPanel() }
+
+        guard hasFullAccess else {
+            panel.statusMessage = "Full Access is required to upload"
+            panel.isUploadEnabled = false
+            panel.onUpload = { _ in }
+            showPanel(panel)
+            uploadPanel = panel
+            return
+        }
 
         // Grab the raw encoded image bytes on the main actor (cheap: no decode),
         // so the heavy decode/downsample/encode can run off it. Reading
@@ -201,8 +334,9 @@ extension KeyboardViewController: ExtraRowDelegate {
             panel.statusMessage = UIPasteboard.general.hasImages
                 ? "Couldn't read that image. Try copying it again."
                 : "Copy an image first, then tap SCP"
+            panel.isUploadEnabled = false
             panel.onUpload = { _ in }
-            view.addSubview(panel)
+            showPanel(panel)
             uploadPanel = panel
             return
         }
@@ -213,7 +347,7 @@ extension KeyboardViewController: ExtraRowDelegate {
         panel.statusMessage = "Preparing image..."
         panel.isUploadEnabled = false
         panel.onUpload = { _ in }
-        view.addSubview(panel)
+        showPanel(panel)
         uploadPanel = panel
 
         Task { [weak self] in
@@ -245,7 +379,10 @@ extension KeyboardViewController: ExtraRowDelegate {
             uploadPanel?.statusMessage = "SSH key not found. Open the main app first."
             return
         }
-        uploadPanel?.statusMessage = "Uploading..."
+        uploadPanel?.statusMessage = "Uploading to \(host.label)..."
+        // A second tap while a transfer is in flight would start a second connection
+        // from a memory-constrained extension; hold the list closed until this returns.
+        uploadPanel?.isUploadEnabled = false
 
         Task { @MainActor in
             do {
@@ -258,6 +395,7 @@ extension KeyboardViewController: ExtraRowDelegate {
                 self.hideUploadPanel()
             } catch {
                 self.uploadPanel?.statusMessage = "Upload failed: \(error.localizedDescription)"
+                self.uploadPanel?.isUploadEnabled = true
             }
         }
     }
@@ -281,6 +419,23 @@ extension KeyboardViewController: QwertyKeyboardDelegate {
 
     public func keyboardDeleteBackward(_ keyboard: QwertyKeyboardView) {
         textDocumentProxy.deleteBackward()
+    }
+
+    /// `UITextDocumentProxy` has no word-delete primitive, so this is N backward
+    /// deletes with N derived from the text before the cursor. The boundary rule keeps
+    /// paths and flags whole; see `WordBoundary`.
+    public func keyboardDeleteWordBackward(_ keyboard: QwertyKeyboardView) {
+        let context = textDocumentProxy.documentContextBeforeInput ?? ""
+        let count = WordBoundary.deleteCount(before: context)
+        guard count > 0 else {
+            // No context available (some hosts withhold it) — fall back to one
+            // character so a held backspace still makes progress.
+            textDocumentProxy.deleteBackward()
+            return
+        }
+        for _ in 0..<count {
+            textDocumentProxy.deleteBackward()
+        }
     }
 
     public func keyboardAdvanceToNextInputMode(_ keyboard: QwertyKeyboardView) {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/AltKeyMappings.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/AltKeyMappings.swift
@@ -2,7 +2,13 @@ import Foundation
 
 public enum AltKeyMappings {
 
-    // Accent alts for lowercase keys. Uppercase is derived automatically.
+    /// Long-press alternates, keyed by the primary key's label.
+    ///
+    /// Accented vowels come first because they are what a long-press means on any
+    /// other keyboard. The punctuation entries are the ones that earn their place on
+    /// a keyboard pointed at a shell: the character people reach for while typing a
+    /// path or a flag, one press away from the key they are already on, so the second
+    /// symbols page stays a fallback rather than a toll on every command.
     static let table: [String: [String]] = [
         "a": ["á", "à", "â", "ä", "å", "æ"],
         "e": ["é", "è", "ê", "ë"],
@@ -13,8 +19,20 @@ public enum AltKeyMappings {
         "c": ["ç"],
         "s": ["ß"],
         "y": ["ÿ"],
-        ".": ["…"],
-        "-": ["—", "–"],
+
+        // Underscore leads: `my_file` outruns an em dash by a wide margin here.
+        "-": ["_", "—", "–"],
+        "/": ["\\", "|"],
+        // Brackets and braces from the first symbols page, so `[]`, `{}` and `<>`
+        // never require a trip to the second.
+        "(": ["[", "{", "<"],
+        ")": ["]", "}", ">"],
+        ".": ["…", ".."],
+        ";": [":"],
+        ":": [";"],
+        "'": ["`", "\u{2018}", "\u{2019}"],
+        "\"": ["`", "\u{201C}", "\u{201D}"],
+        "$": ["€", "£", "¥"],
         "?": ["¿"],
         "!": ["¡"],
     ]
@@ -25,8 +43,10 @@ public enum AltKeyMappings {
         "6": "^", "7": "&", "8": "*", "9": "(", "0": ")"
     ]
 
-    // Returns the alt list for a given key label.
-    // Uppercase keys return uppercased versions of the lowercase alts.
+    /// The alternates for a key label, or an empty array when it has none.
+    ///
+    /// An uppercase letter falls back to the uppercased form of its lowercase
+    /// alternates, so the table only has to carry one case.
     public static func alts(for label: String) -> [String] {
         if let found = table[label] { return found }
         let lower = label.lowercased()

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/AppGroupSecretStore.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/AppGroupSecretStore.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// The SSH identity key as the keyboard extension sees it.
+///
+/// The extension needs the raw private key bytes to authenticate an SFTP upload, and
+/// the Keychain item the main app holds is not reachable from the extension's process
+/// without a shared keychain access group. The bridge is therefore the App Group
+/// container — but *how* it crosses matters.
+///
+/// It used to cross as a plain `UserDefaults` value in the shared suite. That suite is
+/// a property list inside the group container, and group containers are included in
+/// device backups, so the raw Ed25519 private key was copied into every iTunes and
+/// iCloud backup — defeating the `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` class
+/// deliberately chosen for the Keychain copy, which exists precisely to keep the key
+/// on the device it was generated on.
+///
+/// It now crosses as a file with `.completeFileProtectionUntilUserAuthentication` and
+/// `isExcludedFromBackup`, which restores that property: the bytes stay encrypted at
+/// rest until first unlock and never leave the device in a backup. The Keychain
+/// remains the system of record; this is a mirror the extension can read.
+public enum AppGroupSecretStore {
+
+    private static let fileName = "ssh-identity-ed25519.key"
+    private static let legacyDefaultsKey = "keyjawn.ssh-identity-raw"
+
+    private static var fileURL: URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: AppGroupConfig.suiteName)?
+            .appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    // MARK: - Read
+
+    /// The mirrored private key bytes, or nil when none has been written yet — which
+    /// is also what an extension without Full Access sees, since the group container
+    /// is closed to it entirely.
+    public static func identityKeyData() -> Data? {
+        if let url = fileURL, let data = try? Data(contentsOf: url), !data.isEmpty {
+            return data
+        }
+        return migrateLegacyValue()
+    }
+
+    /// Moves a key left behind by the `UserDefaults` mirror into the protected file
+    /// and clears the old copy, so an existing install stops carrying the key in its
+    /// backups without the user having to regenerate and redistribute a new one.
+    ///
+    /// Runs from whichever process reads first. Both have write access to the group
+    /// container, and the write is atomic, so a concurrent migration is a redundant
+    /// write of identical bytes rather than a race.
+    private static func migrateLegacyValue() -> Data? {
+        guard let defaults = UserDefaults(suiteName: AppGroupConfig.suiteName),
+              let legacy = defaults.data(forKey: legacyDefaultsKey),
+              !legacy.isEmpty
+        else { return nil }
+
+        write(identityKeyData: legacy)
+        defaults.removeObject(forKey: legacyDefaultsKey)
+        return legacy
+    }
+
+    // MARK: - Write
+
+    public static func write(identityKeyData data: Data) {
+        guard var url = fileURL else { return }
+        do {
+            try data.write(to: url, options: [.atomic, .completeFileProtectionUntilUserAuthentication])
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try? url.setResourceValues(values)
+        } catch {
+            // A failed mirror is not fatal: the main app still holds the key in the
+            // Keychain and the terminal keeps working. Only the extension's SFTP
+            // upload is affected, and it reports "SSH key not found" for this.
+        }
+    }
+
+    public static func deleteIdentityKey() {
+        if let url = fileURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+        UserDefaults(suiteName: AppGroupConfig.suiteName)?.removeObject(forKey: legacyDefaultsKey)
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/HostConfig.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/HostConfig.swift
@@ -44,4 +44,18 @@ public struct HostConfig: Sendable, Identifiable, Codable, Hashable {
         !username.trimmingCharacters(in: .whitespaces).isEmpty &&
         port > 0
     }
+
+    /// The command that produces the key to paste into ``hostPublicKey``.
+    ///
+    /// Carries `-p` for a non-default port. Without it the instructions scan port 22
+    /// of the same hostname, which is either nothing at all or — worse — a different
+    /// service whose key gets pinned here and makes every later connection fail.
+    public var hostKeyScanCommand: String {
+        Self.hostKeyScanCommand(hostname: hostname, port: port)
+    }
+
+    public static func hostKeyScanCommand(hostname: String, port: UInt16) -> String {
+        let portFlag = port == 22 ? "" : "-p \(port) "
+        return "ssh-keyscan \(portFlag)-t ed25519 \(hostname)"
+    }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayer.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayer.swift
@@ -9,9 +9,9 @@ public enum QwertyKey: Sendable, Equatable {
     case backspace
     case shift
     case symbolsToggle      // 123
-    case alphabeticToggle   // ABC (from symbols layer)
+    case alphabeticToggle   // ABC (from a symbols layer)
     case globe
-    case more               // #+= (extended symbols — cycles back for now)
+    case more               // #+= (second symbols page)
 }
 
 public enum ShiftState: Sendable {
@@ -22,15 +22,28 @@ public enum ShiftState: Sendable {
 
 // MARK: - Layer type
 
-public enum KeyboardLayerType: Sendable {
+public enum KeyboardLayerType: Sendable, CaseIterable {
     case lowercase
     case uppercase
     case symbols
+    case symbols2
 }
 
 // MARK: - Layout data
 
 public enum KeyboardLayers {
+
+    /// Every symbol a shell prompt needs that is not on the letter layers.
+    ///
+    /// The first symbols page carries what prose needs; this set is what a command
+    /// line needs, and until the `#+=` key was wired up none of it could be typed at
+    /// all — no pipe, no underscore, no tilde, no brackets or braces. Asserted as
+    /// reachable by `KeyboardLayersTests` so a future layout edit cannot quietly drop
+    /// one again.
+    public static let shellSymbols: Set<String> = [
+        "[", "]", "{", "}", "#", "%", "^", "*", "+", "=",
+        "_", "\\", "|", "~", "<", ">", "`",
+    ]
 
     /// Returns the four key rows for the given layer/shift combination.
     public static func rows(for layer: KeyboardLayerType,
@@ -58,6 +71,19 @@ public enum KeyboardLayers {
                 chars("1234567890"),
                 chars("-/:;()$&@\""),
                 [.more] + chars(".,?!'") + [.backspace],
+                [.alphabeticToggle, .globe, .space, .return],
+            ]
+
+        // Row 0 matches the system keyboard's own #+= page, so the muscle memory
+        // carries over. Row 1 drops the currency symbols the system puts there for
+        // the characters this keyboard's users actually reach for, backtick included
+        // — the system keyboard has no backtick anywhere, which makes fenced code and
+        // command substitution untypeable on a stock iPhone.
+        case .symbols2:
+            return [
+                chars("[]{}#%^*+="),
+                chars("_\\|~<>`\"'"),
+                [.symbolsToggle] + chars(".,?!;") + [.backspace],
                 [.alphabeticToggle, .globe, .space, .return],
             ]
         }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
@@ -59,6 +59,26 @@ public struct ExtraRowKey: Sendable {
     public let label: String
     public let output: KeyOutput?   // nil for action keys (clipboard, upload)
 
+    /// What VoiceOver announces for this key.
+    ///
+    /// The visible labels are glyphs and abbreviations chosen to fit a ten-key row —
+    /// "▲", "^C", "SCP". Read literally they are useless, so each one gets a spoken
+    /// name here.
+    public var accessibilityLabel: String {
+        switch slot {
+        case .ctrlC:      return "Control C. Double tap and hold to lock the Control modifier."
+        case .tab:        return "Tab"
+        case .arrowUp:    return "Up arrow"
+        case .arrowDown:  return "Down arrow"
+        case .arrowLeft:  return "Left arrow"
+        case .arrowRight: return "Right arrow"
+        case .slash:      return "Slash commands"
+        case .escape:     return "Escape"
+        case .clipboard:  return "Clipboard history"
+        case .upload:     return "Upload image over SFTP"
+        }
+    }
+
     public static let defaults: [ExtraRowKey] = [
         ExtraRowKey(slot: .ctrlC,      label: "^C",  output: .ctrlC),
         ExtraRowKey(slot: .tab,        label: "Tab", output: .tab),
@@ -107,5 +127,17 @@ public enum ANSISequence {
             return ctrlActive ? [byte & 0x1f] : [byte]
         case .slash:                return nil  // handled by slash command popup
         }
+    }
+
+    /// The same sequence as a string, for the keyboard extension.
+    ///
+    /// The extension has no socket to write bytes to — its only channel to the host
+    /// app is `UITextDocumentProxy.insertText`. Terminal apps forward inserted text
+    /// straight to the pty, which is why Esc has always worked there as a literal
+    /// `\u{1b}`; this lets Ctrl+C and the arrow keys reach the shell the same way
+    /// instead of being dropped on the floor.
+    public static func text(for output: KeyOutput, ctrlActive: Bool = false) -> String? {
+        bytes(for: output, ctrlActive: ctrlActive)
+            .map { String(decoding: $0, as: UTF8.self) }
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
@@ -25,16 +25,46 @@ public final class KeyboardPrefs: @unchecked Sendable {
         static let migrated = "keyjawn.prefs.migrated.v2"
     }
 
-    private let defaults: UserDefaults
+    /// Storage supplied by a test. When nil the suite is looked up per access below.
+    private let injectedDefaults: UserDefaults?
 
-    /// - Parameter defaults: backing store. Defaults to the shared App Group suite,
-    ///   falling back to this process's own `standard` suite when the group is not
-    ///   reachable. Injectable so tests can run against a scratch suite.
-    public init(defaults: UserDefaults? = nil) {
-        self.defaults = defaults
-            ?? UserDefaults(suiteName: AppGroupConfig.suiteName)
-            ?? .standard
+    /// Look the suite up on every access rather than holding one wrapper for the
+    /// process's lifetime.
+    ///
+    /// The extension process outlives any single activation, and the main app writes
+    /// these values from a different process. A cached `UserDefaults` wrapper can keep
+    /// serving its own stale in-process cache until the extension restarts, so a theme
+    /// picked in Settings would not appear until the keyboard was killed — the same
+    /// staleness `AppGroupHostStore` reopens its suite to avoid, found and reverted for
+    /// exactly this reason in #46.
+    ///
+    /// Cheap enough for the read sites here, which are activation- and
+    /// interaction-scoped. It is deliberately *not* cheap enough for per-keystroke
+    /// reads: `KeyboardHaptics` caches its flag and refreshes it on appearance rather
+    /// than reopening the suite on every key press.
+    private var defaults: UserDefaults {
+        if let injectedDefaults { return injectedDefaults }
+        return UserDefaults(suiteName: AppGroupConfig.suiteName) ?? .standard
+    }
+
+    /// - Parameters:
+    ///   - defaults: backing store. Defaults to the shared App Group suite, resolved
+    ///     per access. Injectable so tests can run against a scratch suite.
+    ///   - migratesLegacyValues: whether this process should consume the pre-App-Group
+    ///     keys. Defaults to false inside an app extension; see
+    ///     ``migrateLegacyValuesIfNeeded()``.
+    public init(defaults: UserDefaults? = nil, migratesLegacyValues: Bool? = nil) {
+        self.injectedDefaults = defaults
+        self.migratesLegacyValues = migratesLegacyValues ?? !Self.isAppExtension
         migrateLegacyValuesIfNeeded()
+    }
+
+    private let migratesLegacyValues: Bool
+
+    /// True when this code is running inside an app extension rather than the app.
+    /// Extension bundles are `.appex`; the containing app's is `.app`.
+    private static var isAppExtension: Bool {
+        Bundle.main.bundleURL.pathExtension == "appex"
     }
 
     // MARK: - Preferences
@@ -86,22 +116,34 @@ public final class KeyboardPrefs: @unchecked Sendable {
     /// `@AppStorage("hapticEnabled")`. Neither was ever read by the keyboard, so
     /// migrating them is about honouring a choice the user already made rather than
     /// preserving working behaviour.
+    ///
+    /// Only the main app runs this. Both legacy keys live in the *app's* standard
+    /// suite, which an extension cannot see — so an extension running it would find
+    /// nothing, and then set the shared completion flag, and the main app's next
+    /// launch would skip the migration and quietly discard the user's saved theme.
+    /// An upgraded user opening the keyboard before the app is the ordinary case for
+    /// this product, not a corner of it.
     private func migrateLegacyValuesIfNeeded() {
-        guard !defaults.bool(forKey: Key.migrated) else { return }
-        defer { defaults.set(true, forKey: Key.migrated) }
+        guard migratesLegacyValues else { return }
+
+        let store = defaults
+        guard !store.bool(forKey: Key.migrated) else { return }
 
         let legacy = UserDefaults.standard
-        guard legacy != defaults else { return }
+        // Nothing to carry when the shared suite is unavailable and `store` has already
+        // fallen back to the same standard suite the legacy values live in.
+        guard legacy != store else { return }
+        defer { store.set(true, forKey: Key.migrated) }
 
-        if defaults.object(forKey: Key.theme) == nil,
+        if store.object(forKey: Key.theme) == nil,
            let raw = legacy.string(forKey: Key.theme) ?? legacy.string(forKey: "theme"),
            KeyboardTheme(rawValue: raw) != nil {
-            defaults.set(raw, forKey: Key.theme)
+            store.set(raw, forKey: Key.theme)
         }
 
-        if defaults.object(forKey: Key.haptics) == nil,
+        if store.object(forKey: Key.haptics) == nil,
            let legacyHaptics = legacy.object(forKey: "hapticEnabled") as? Bool {
-            defaults.set(legacyHaptics, forKey: Key.haptics)
+            store.set(legacyHaptics, forKey: Key.haptics)
         }
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
@@ -1,22 +1,107 @@
 import Foundation
 
-/// Persists keyboard user preferences using UserDefaults.
-/// In the keyboard extension this is the extension's own sandbox.
-/// In the main app this is the app's sandbox.
-/// Both share the same UserDefaults.standard because they don't share an App Group.
+/// Keyboard preferences shared between the main app and the keyboard extension.
+///
+/// Storage is the `group.com.keyjawn` App Group suite, because that is the only
+/// container both processes can see. Previously this read `UserDefaults.standard`,
+/// which in an app extension is the *extension's* sandbox and not the app's, while
+/// the Settings screen wrote its own unrelated keys into the *app's* sandbox. The
+/// result was that nothing the user changed in Settings ever reached the keyboard —
+/// the theme picker in particular looked functional and did nothing.
+///
+/// A keyboard extension can only open the shared suite once the user grants Full
+/// Access. Without it `UserDefaults(suiteName:)` returns nil and reads fall back to
+/// the extension's own sandbox, so the keyboard runs on defaults. That is a platform
+/// rule rather than a bug; `UIInputViewController.hasFullAccess` is what the UI uses
+/// to explain it where it matters.
 public final class KeyboardPrefs: @unchecked Sendable {
+
     public static let shared = KeyboardPrefs()
-    private init() {}
 
-    private let defaults = UserDefaults.standard
+    private enum Key {
+        static let theme = "keyjawn.theme"
+        static let haptics = "keyjawn.haptics"
+        static let terminalArrows = "keyjawn.terminalArrows"
+        static let migrated = "keyjawn.prefs.migrated.v2"
+    }
 
+    private let defaults: UserDefaults
+
+    /// - Parameter defaults: backing store. Defaults to the shared App Group suite,
+    ///   falling back to this process's own `standard` suite when the group is not
+    ///   reachable. Injectable so tests can run against a scratch suite.
+    public init(defaults: UserDefaults? = nil) {
+        self.defaults = defaults
+            ?? UserDefaults(suiteName: AppGroupConfig.suiteName)
+            ?? .standard
+        migrateLegacyValuesIfNeeded()
+    }
+
+    // MARK: - Preferences
+
+    /// Colour theme applied to every keyboard surface.
     public var theme: KeyboardTheme {
         get {
-            let raw = defaults.string(forKey: "keyjawn.theme") ?? KeyboardTheme.dark.rawValue
-            return KeyboardTheme(rawValue: raw) ?? .dark
+            guard let raw = defaults.string(forKey: Key.theme),
+                  let theme = KeyboardTheme(rawValue: raw) else { return .dark }
+            return theme
         }
-        set {
-            defaults.set(newValue.rawValue, forKey: "keyjawn.theme")
+        set { defaults.set(newValue.rawValue, forKey: Key.theme) }
+    }
+
+    /// Whether key presses produce click/haptic feedback. On by default, matching
+    /// the system keyboard.
+    public var hapticsEnabled: Bool {
+        get { bool(Key.haptics, default: true) }
+        set { defaults.set(newValue, forKey: Key.haptics) }
+    }
+
+    /// Whether the extra row's arrow keys emit ANSI escape sequences (`ESC [ A` and
+    /// friends) instead of moving the text cursor.
+    ///
+    /// On by default because the product exists to drive CLI agents over SSH, where
+    /// escape sequences are the only thing that reaches the shell — and because with
+    /// it off the up and down arrows have nothing at all to do. Turning it off gives
+    /// left/right plain cursor movement for editing prose in an ordinary text field.
+    public var terminalArrowKeys: Bool {
+        get { bool(Key.terminalArrows, default: true) }
+        set { defaults.set(newValue, forKey: Key.terminalArrows) }
+    }
+
+    // MARK: - Helpers
+
+    /// `UserDefaults.bool(forKey:)` reports false for a key that was never set, which
+    /// would silently flip any preference that defaults to true. Check for presence
+    /// first so an unset key falls through to the stated default.
+    private func bool(_ key: String, default defaultValue: Bool) -> Bool {
+        defaults.object(forKey: key) as? Bool ?? defaultValue
+    }
+
+    // MARK: - Migration
+
+    /// Carries values written by the pre-App-Group builds into the shared suite once.
+    ///
+    /// Two legacy sources existed: this type's own `keyjawn.theme` in the app's
+    /// standard suite, and the Settings screen's `@AppStorage("theme")` /
+    /// `@AppStorage("hapticEnabled")`. Neither was ever read by the keyboard, so
+    /// migrating them is about honouring a choice the user already made rather than
+    /// preserving working behaviour.
+    private func migrateLegacyValuesIfNeeded() {
+        guard !defaults.bool(forKey: Key.migrated) else { return }
+        defer { defaults.set(true, forKey: Key.migrated) }
+
+        let legacy = UserDefaults.standard
+        guard legacy != defaults else { return }
+
+        if defaults.object(forKey: Key.theme) == nil,
+           let raw = legacy.string(forKey: Key.theme) ?? legacy.string(forKey: "theme"),
+           KeyboardTheme(rawValue: raw) != nil {
+            defaults.set(raw, forKey: Key.theme)
+        }
+
+        if defaults.object(forKey: Key.haptics) == nil,
+           let legacyHaptics = legacy.object(forKey: "hapticEnabled") as? Bool {
+            defaults.set(legacyHaptics, forKey: Key.haptics)
         }
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardTheme.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardTheme.swift
@@ -1,5 +1,15 @@
 import UIKit
 
+/// Colour roles for every keyboard surface.
+///
+/// Each case is a complete set: key faces, the extra row, and the overlay panels all
+/// resolve their colours from here rather than hardcoding their own. Before this the
+/// number row, the extra row's key labels, and all three panels carried literal dark
+/// values, so picking Light or Terminal recoloured some of the keyboard and left the
+/// rest looking like a rendering fault.
+///
+/// The text roles are chosen to clear WCAG AA (4.5:1) against the backgrounds they sit
+/// on, which `KeyboardThemeContrastTests` enforces for every case.
 public enum KeyboardTheme: String, CaseIterable, Sendable {
     case dark     = "dark"
     case light    = "light"
@@ -14,6 +24,12 @@ public enum KeyboardTheme: String, CaseIterable, Sendable {
         case .terminal: return "Terminal"
         }
     }
+
+    /// True for every theme whose surfaces are dark. Drives the keyboard appearance
+    /// reported to the host app and the chrome inside the overlay panels.
+    public var isDark: Bool { self != .light }
+
+    // MARK: - Keyboard surfaces
 
     public var keyboardBg: UIColor {
         switch self {
@@ -38,7 +54,9 @@ public enum KeyboardTheme: String, CaseIterable, Sendable {
         case .dark:     return UIColor(white: 0.17, alpha: 1)
         case .light:    return UIColor(red: 0.71, green: 0.72, blue: 0.74, alpha: 1)
         case .oled:     return UIColor(white: 0.08, alpha: 1)
-        case .terminal: return UIColor(red: 0.04, green: 0.08, blue: 0.04, alpha: 1)
+        // Lifted off keyboardBg on purpose: when the two matched exactly, shift,
+        // backspace, 123 and return read as holes in the keyboard rather than as keys.
+        case .terminal: return UIColor(red: 0.055, green: 0.105, blue: 0.055, alpha: 1)
         }
     }
 
@@ -69,6 +87,8 @@ public enum KeyboardTheme: String, CaseIterable, Sendable {
         }
     }
 
+    // MARK: - Extra row
+
     public var extraRowBg: UIColor {
         switch self {
         case .dark:     return UIColor(red: 0.145, green: 0.145, blue: 0.145, alpha: 1)
@@ -84,6 +104,64 @@ public enum KeyboardTheme: String, CaseIterable, Sendable {
         case .light:    return UIColor(red: 0.55, green: 0.56, blue: 0.58, alpha: 1)
         case .oled:     return UIColor(white: 0.18, alpha: 1)
         case .terminal: return UIColor(red: 0.08, green: 0.15, blue: 0.08, alpha: 1)
+        }
+    }
+
+    /// Label colour for extra row keys. Shares `keyText` so the terminal green and the
+    /// light theme's black carry across; the extra row used to hardcode white, which
+    /// on Light gave 3.3:1 against its own key background.
+    public var extraRowKeyText: UIColor { keyText }
+
+    // MARK: - Overlay panels
+
+    /// Backing colour for the slash command, clipboard and upload panels. Slightly
+    /// off the keyboard background and near-opaque, so a panel reads as sitting above
+    /// the keys rather than replacing them.
+    public var panelBg: UIColor {
+        switch self {
+        case .dark:     return UIColor(red: 0.11, green: 0.11, blue: 0.11, alpha: 0.97)
+        case .light:    return UIColor(red: 0.96, green: 0.96, blue: 0.97, alpha: 0.97)
+        case .oled:     return UIColor(white: 0.04, alpha: 0.98)
+        case .terminal: return UIColor(red: 0.02, green: 0.05, blue: 0.02, alpha: 0.97)
+        }
+    }
+
+    public var panelText: UIColor {
+        switch self {
+        case .light: return .black
+        default:     return .white
+        }
+    }
+
+    /// Descriptions, empty states and section headers.
+    public var panelSecondaryText: UIColor {
+        switch self {
+        case .light: return UIColor(white: 0.32, alpha: 1)
+        default:     return UIColor(white: 0.78, alpha: 1)
+        }
+    }
+
+    public var panelSeparator: UIColor {
+        switch self {
+        case .light: return UIColor(white: 0.0, alpha: 0.15)
+        default:     return UIColor(white: 1.0, alpha: 0.15)
+        }
+    }
+
+    /// Row highlight behind a selected panel cell.
+    public var panelSelection: UIColor {
+        switch self {
+        case .light: return UIColor(white: 0.0, alpha: 0.08)
+        default:     return UIColor(white: 1.0, alpha: 0.12)
+        }
+    }
+
+    /// Tint for panel actions (Done, Cancel) and for slash command triggers.
+    public var accent: UIColor {
+        switch self {
+        case .dark, .oled: return UIColor(red: 0.40, green: 0.75, blue: 1.00, alpha: 1)
+        case .light:       return UIColor(red: 0.00, green: 0.36, blue: 0.80, alpha: 1)
+        case .terminal:    return UIColor(red: 0.30, green: 0.95, blue: 0.40, alpha: 1)
         }
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/SlashCommand.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/SlashCommand.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// A text shortcut offered by the slash command panel.
+///
+/// Selecting one inserts `trigger` as plain text into whatever field has focus. There
+/// is no integration with, or link to, any other application — the panel is a text
+/// autocomplete list in the same sense as the system keyboard's predictive bar.
 public struct SlashCommand: Sendable, Identifiable, Hashable {
     public let id: String          // e.g. "compact"
     public let trigger: String     // e.g. "/compact"
@@ -22,30 +27,42 @@ public struct SlashCommand: Sendable, Identifiable, Hashable {
     }
 }
 
-// MARK: - Built-in command sets
+// MARK: - Built-in commands
 
 public extension SlashCommand {
-    /// Pre-loaded Claude Code commands.
-    static let claudeCode: [SlashCommand] = [
-        SlashCommand(id: "compact",   trigger: "/compact",   description: "Compact context",           category: .session),
-        SlashCommand(id: "clear",     trigger: "/clear",     description: "Clear conversation",        category: .session),
-        SlashCommand(id: "resume",    trigger: "/resume",    description: "Resume last session",       category: .session),
-        SlashCommand(id: "help",      trigger: "/help",      description: "Show help",                 category: .session),
-        SlashCommand(id: "review",    trigger: "/review",    description: "Review changes",            category: .session),
-        SlashCommand(id: "add",       trigger: "/add",       description: "Add files to context",      category: .session),
-        SlashCommand(id: "model",     trigger: "/model",     description: "Switch model",              category: .session),
-        SlashCommand(id: "cost",      trigger: "/cost",      description: "Show session cost",         category: .session),
+
+    /// The shortcuts the panel offers, grouped by what they do.
+    ///
+    /// This used to be two lists concatenated, which put `/help` and `/clear` in the
+    /// panel twice with identical descriptions and no way to tell the rows apart.
+    /// Triggers are unique here, and `SlashCommandTests` keeps them that way.
+    static let all: [SlashCommand] = [
+        SlashCommand(id: "help",    trigger: "/help",    description: "Show help",              category: .session),
+        SlashCommand(id: "clear",   trigger: "/clear",   description: "Clear conversation",     category: .session),
+        SlashCommand(id: "compact", trigger: "/compact", description: "Compact context",        category: .session),
+        SlashCommand(id: "resume",  trigger: "/resume",  description: "Resume last session",    category: .session),
+        SlashCommand(id: "model",   trigger: "/model",   description: "Switch model",           category: .session),
+        SlashCommand(id: "cost",    trigger: "/cost",    description: "Show session cost",      category: .session),
+        SlashCommand(id: "quit",    trigger: "/quit",    description: "Quit",                   category: .session),
+
+        SlashCommand(id: "add",     trigger: "/add",     description: "Add files to context",   category: .context),
+        SlashCommand(id: "chat",    trigger: "/chat",    description: "Switch to chat mode",    category: .context),
+        SlashCommand(id: "code",    trigger: "/code",    description: "Switch to code mode",    category: .context),
+
+        SlashCommand(id: "review",  trigger: "/review",  description: "Review changes",         category: .files),
+        SlashCommand(id: "diff",    trigger: "/diff",    description: "Show pending diff",      category: .files),
+
+        SlashCommand(id: "tools",   trigger: "/tools",   description: "List available tools",   category: .shell),
     ]
 
-    /// Pre-loaded Gemini CLI commands.
-    static let gemini: [SlashCommand] = [
-        SlashCommand(id: "gemini-help",  trigger: "/help",   description: "Show help",             category: .session),
-        SlashCommand(id: "gemini-clear", trigger: "/clear",  description: "Clear conversation",    category: .session),
-        SlashCommand(id: "gemini-chat",  trigger: "/chat",   description: "Switch to chat mode",   category: .session),
-        SlashCommand(id: "gemini-code",  trigger: "/code",   description: "Switch to code mode",   category: .session),
-        SlashCommand(id: "gemini-quit",  trigger: "/quit",   description: "Quit",                  category: .session),
-        SlashCommand(id: "gemini-tools", trigger: "/tools",  description: "List available tools",  category: .session),
-    ]
-
-    static let all: [SlashCommand] = claudeCode + gemini
+    /// `all` bucketed into the categories that are actually populated, in the order
+    /// `Category.allCases` declares. The panel renders one section per entry, which is
+    /// what makes a list this long scannable — and what finally puts the `category`
+    /// field to use after it sat unread since it was introduced.
+    static var grouped: [(category: Category, commands: [SlashCommand])] {
+        Category.allCases.compactMap { category in
+            let matching = all.filter { $0.category == category }
+            return matching.isEmpty ? nil : (category, matching)
+        }
+    }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/WordBoundary.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/WordBoundary.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Where the word before the cursor starts, for word-at-a-time deletion.
+///
+/// `UITextDocumentProxy` has no word-delete primitive, so a word delete is N calls to
+/// `deleteBackward()` and N has to be computed from the text before the cursor. The
+/// rule below is deliberately coarser than a linguistic word break: a word runs back
+/// to the nearest whitespace, which keeps `src/main/App.kt`, `--no-verify` and
+/// `~/.ssh/config` as single units. Splitting those on punctuation is what makes word
+/// delete useless on a keyboard aimed at shell prompts.
+public enum WordBoundary {
+
+    /// How many characters to delete to remove the word immediately before the cursor.
+    ///
+    /// Trailing spaces and tabs are consumed first, then the run of non-whitespace
+    /// before them. A newline is never crossed, so deleting back through a blank line
+    /// stops at the line break instead of eating the previous line of a multi-line
+    /// prompt; when the line break is all that is left, it is removed on its own so a
+    /// held backspace still makes progress.
+    ///
+    /// - Parameter text: the document text immediately before the cursor. `UIKit` only
+    ///   guarantees a limited window of context here, which is fine: the count is
+    ///   applied to whatever it returned.
+    /// - Returns: a count in `Character`s, clamped to the length of `text`.
+    public static func deleteCount(before text: String) -> Int {
+        var remaining = Array(text)
+        var count = 0
+
+        while let last = remaining.last, last == " " || last == "\t" {
+            remaining.removeLast()
+            count += 1
+        }
+
+        // Nothing but horizontal whitespace back to a line break (or to the start of
+        // the available context). Consume the break itself only when the pass above
+        // found nothing, so a run of trailing spaces is one step and the newline is
+        // the next.
+        if remaining.last == "\n" || remaining.isEmpty {
+            if count > 0 { return count }
+            return text.isEmpty ? 0 : 1
+        }
+
+        while let last = remaining.last, !last.isWhitespace {
+            remaining.removeLast()
+            count += 1
+        }
+
+        return count
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/AltKeyPopup.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/AltKeyPopup.swift
@@ -17,24 +17,26 @@ public final class AltKeyPopup: UIView {
 
     // MARK: - Init
 
-    public init(alts: [String]) {
+    public init(alts: [String], theme: KeyboardTheme = .dark) {
         super.init(frame: .zero)
-        backgroundColor = UIColor(red: 0.15, green: 0.15, blue: 0.15, alpha: 1)
+        backgroundColor = theme.specKeyBg
         layer.cornerRadius = 8
         layer.masksToBounds = true
+        layer.borderWidth = 1
+        layer.borderColor = theme.panelSeparator.cgColor
 
-        buildButtons(alts: alts)
+        buildButtons(alts: alts, theme: theme)
     }
 
-    required init?(coder: NSCoder) { fatalError("use init(alts:)") }
+    required init?(coder: NSCoder) { fatalError("use init(alts:theme:)") }
 
     // MARK: - Build
 
-    private func buildButtons(alts: [String]) {
+    private func buildButtons(alts: [String], theme: KeyboardTheme) {
         for (index, alt) in alts.enumerated() {
             let btn = UIButton(type: .system)
             btn.setTitle(alt, for: .normal)
-            btn.setTitleColor(.white, for: .normal)
+            btn.setTitleColor(theme.keyText, for: .normal)
             btn.titleLabel?.font = UIFont.monospacedSystemFont(ofSize: 16, weight: .regular)
             btn.tag = index
             btn.addTarget(self, action: #selector(altTapped(_:)), for: .touchUpInside)

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ClipboardPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ClipboardPanel.swift
@@ -19,6 +19,7 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
     private let tableView = UITableView(frame: .zero, style: .grouped)
 
     private let cellReuseID = "ClipCell"
+    private let theme: KeyboardTheme
 
     // MARK: - Section constants
 
@@ -43,20 +44,18 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
 
     // MARK: - Init
 
-    public override init(frame: CGRect) {
-        super.init(frame: frame)
+    public init(theme: KeyboardTheme = .dark) {
+        self.theme = theme
+        super.init(frame: .zero)
         setupView()
     }
 
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setupView()
-    }
+    public required init?(coder: NSCoder) { fatalError("use init(theme:)") }
 
     // MARK: - Setup
 
     private func setupView() {
-        backgroundColor = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha: 0.97)
+        backgroundColor = theme.panelBg
 
         // Round only the top corners
         layer.cornerRadius = 12
@@ -74,20 +73,20 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
 
         titleLabel.text = "Clipboard"
         titleLabel.font = UIFont.systemFont(ofSize: 15, weight: .semibold)
-        titleLabel.textColor = .white
+        titleLabel.textColor = theme.panelText
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         toolbar.addSubview(titleLabel)
 
         doneButton.setTitle("Done", for: .normal)
         doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 15, weight: .regular)
-        doneButton.setTitleColor(.systemBlue, for: .normal)
+        doneButton.setTitleColor(theme.accent, for: .normal)
         doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
         doneButton.translatesAutoresizingMaskIntoConstraints = false
         toolbar.addSubview(doneButton)
 
         // Thin separator below toolbar
         let separator = UIView()
-        separator.backgroundColor = UIColor.white.withAlphaComponent(0.15)
+        separator.backgroundColor = theme.panelSeparator
         separator.translatesAutoresizingMaskIntoConstraints = false
         toolbar.addSubview(separator)
 
@@ -180,12 +179,12 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
         var config = cell.defaultContentConfiguration()
         config.textProperties.numberOfLines = 1
         config.textProperties.lineBreakMode = .byTruncatingTail
-        config.textProperties.color = .white
+        config.textProperties.color = theme.panelText
         config.textProperties.font = UIFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
         if rowData.isEmpty {
             config.text = sec.emptyMessage
-            config.textProperties.color = UIColor.white.withAlphaComponent(0.4)
+            config.textProperties.color = theme.panelSecondaryText
             cell.selectionStyle = .none
         } else {
             config.text = rowData[indexPath.row]
@@ -197,7 +196,7 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
 
         // Selection highlight color
         let selectedBG = UIView()
-        selectedBG.backgroundColor = UIColor.white.withAlphaComponent(0.1)
+        selectedBG.backgroundColor = theme.panelSelection
         cell.selectedBackgroundView = selectedBG
 
         return cell
@@ -222,7 +221,7 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
         label.text = sec.title.uppercased()
         label.font = UIFont.systemFont(ofSize: 11, weight: .semibold)
             .withSmallCaps
-        label.textColor = UIColor.white.withAlphaComponent(0.5)
+        label.textColor = theme.panelSecondaryText
         label.translatesAutoresizingMaskIntoConstraints = false
         container.addSubview(label)
 
@@ -239,6 +238,7 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         guard !isEmptyPlaceholder(at: indexPath) else { return }
+        KeyboardHaptics.keyPress()
         let text = rows(for: section(at: indexPath.section))[indexPath.row]
         onSelect?(text)
     }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
@@ -82,7 +82,7 @@ public final class ExtraRowView: UIView {
         ])
 
         for key in ExtraRowKey.defaults {
-            let btn = ExtraRowButton(key: key, bgColor: keyBg)
+            let btn = ExtraRowButton(key: key, bgColor: keyBg, textColor: theme.extraRowKeyText)
             wire(btn)
             stack.addArrangedSubview(btn)
             if key.slot == .ctrlC { ctrlCButton = btn }
@@ -90,6 +90,21 @@ public final class ExtraRowView: UIView {
 
         ctrl.onChange = { [weak self] state in
             self?.applyCtrlVisual(state)
+        }
+    }
+
+    /// Stop auto-repeat when the row leaves the hierarchy.
+    ///
+    /// The repeat timer is normally cancelled on touch-up, but a panel appearing over
+    /// the row, or the keyboard being dismissed mid-hold, tears the view down without
+    /// one — and a repeating `Timer` left on the run loop keeps firing arrow keys into
+    /// whatever gains focus next. Handled here rather than in `deinit`, which cannot
+    /// touch main-actor state under Swift 6 strict concurrency.
+    public override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        if newWindow == nil {
+            repeatTimer?.invalidate()
+            repeatTimer = nil
         }
     }
 
@@ -126,22 +141,26 @@ public final class ExtraRowView: UIView {
     @objc private func ctrlCTapped() {
         // Always sends ^C regardless of current Ctrl modifier state.
         // Long-press is the only way to arm the modifier.
+        KeyboardHaptics.keyPress()
         fire(.ctrlC, ctrlActive: false)
     }
 
     @objc private func ctrlCLongPressed(_ gr: UILongPressGestureRecognizer) {
         guard gr.state == .began else { return }
+        KeyboardHaptics.keyPress()
         ctrl.toggle()
     }
 
     @objc private func keyTapped(_ sender: ExtraRowButton) {
         guard let output = sender.key.output else { return }
+        KeyboardHaptics.keyPress()
         fire(output, ctrlActive: ctrl.isActive)
         ctrl.consume()
     }
 
     @objc private func arrowTouchDown(_ sender: ExtraRowButton) {
         guard let output = sender.key.output else { return }
+        KeyboardHaptics.keyPress()
         fire(output, ctrlActive: ctrl.isActive)
         ctrl.consume()
 
@@ -166,10 +185,12 @@ public final class ExtraRowView: UIView {
     }
 
     @objc private func clipTapped() {
+        KeyboardHaptics.keyPress()
         delegate?.extraRowDidTapClipboard(self)
     }
 
     @objc private func uploadTapped() {
+        KeyboardHaptics.keyPress()
         delegate?.extraRowDidTapUpload(self)
     }
 
@@ -211,7 +232,7 @@ public final class ExtraRowView: UIView {
         backgroundColor = bg
         for subview in stack.arrangedSubviews {
             if let btn = subview as? ExtraRowButton {
-                btn.applyBgColor(keyBg)
+                btn.applyColors(background: keyBg, text: theme.extraRowKeyText)
             }
         }
         applyCtrlVisual(ctrl.state)
@@ -225,27 +246,28 @@ final class ExtraRowButton: UIButton {
 
     let key: ExtraRowKey
 
-    init(key: ExtraRowKey, bgColor: UIColor) {
+    init(key: ExtraRowKey, bgColor: UIColor, textColor: UIColor) {
         self.key = key
         super.init(frame: .zero)
-        configure(bgColor: bgColor)
-    }
-
-    required init?(coder: NSCoder) { fatalError("use init(key:bgColor:)") }
-
-    private func configure(bgColor: UIColor) {
-        backgroundColor = bgColor
-        setTitleColor(.white, for: .normal)
-        setTitleColor(UIColor.white.withAlphaComponent(0.4), for: .highlighted)
         titleLabel?.font = .monospacedSystemFont(ofSize: 13, weight: .semibold)
         setTitle(key.label, for: .normal)
+        accessibilityLabel = key.accessibilityLabel
         layer.cornerRadius = 6
         layer.masksToBounds = false
         layer.shadowOpacity = 0
+        applyColors(background: bgColor, text: textColor)
     }
 
-    func applyBgColor(_ color: UIColor) {
-        backgroundColor = color
+    required init?(coder: NSCoder) { fatalError("use init(key:bgColor:textColor:)") }
+
+    /// The label colour used to be a hardcoded white, which survived every theme
+    /// change: on Light that put white glyphs on a mid-grey key at 3.3:1, below the
+    /// 4.5:1 floor, and on Terminal it broke the green-on-green treatment the rest of
+    /// the keyboard uses.
+    func applyColors(background: UIColor, text: UIColor) {
+        backgroundColor = background
+        setTitleColor(text, for: .normal)
+        setTitleColor(text.withAlphaComponent(0.4), for: .highlighted)
     }
 
     override var isHighlighted: Bool {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/KeyboardHaptics.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/KeyboardHaptics.swift
@@ -19,11 +19,22 @@ public enum KeyboardHaptics {
 
     private static let generator = UIImpactFeedbackGenerator(style: .light)
 
-    /// Warms the Taptic Engine so the first press of a session is not late.
-    /// Cheap to call repeatedly; safe to call when feedback is disabled.
-    public static func prepare() {
-        guard KeyboardPrefs.shared.hapticsEnabled else { return }
-        generator.prepare()
+    /// Cached rather than read per press.
+    ///
+    /// `KeyboardPrefs` reopens the App Group suite on every access so a preference
+    /// changed in the main app is not served stale to a long-lived extension process.
+    /// That is the right trade at activation scope and the wrong one on the keystroke
+    /// path, where it would put a `UserDefaults` construction between the finger and
+    /// the character. Refreshed on appearance instead, which is the only moment the
+    /// value can have changed — the Settings screen is in the other process, so it
+    /// cannot be reached without leaving the keyboard.
+    private static var isEnabled = true
+
+    /// Re-read the preference and warm the Taptic Engine so the first press of a
+    /// session is not late. Call when the keyboard or the terminal appears.
+    public static func refresh() {
+        isEnabled = KeyboardPrefs.shared.hapticsEnabled
+        if isEnabled { generator.prepare() }
     }
 
     /// Feedback for a single deliberate key press.
@@ -31,7 +42,7 @@ public enum KeyboardHaptics {
     /// Deliberately not called from auto-repeat ticks — a held backspace firing this
     /// eleven times a second reads as a malfunction rather than as feedback.
     public static func keyPress() {
-        guard KeyboardPrefs.shared.hapticsEnabled else { return }
+        guard isEnabled else { return }
         UIDevice.current.playInputClick()
         generator.impactOccurred(intensity: 0.55)
     }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/KeyboardHaptics.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/KeyboardHaptics.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+/// Key press feedback, shared by every key surface.
+///
+/// Two mechanisms are fired because neither one works in both contexts:
+///
+/// - `UIDevice.playInputClick()` is the only feedback route a keyboard extension
+///   has. It produces the system keyboard click, and on iOS 16+ the system keyboard
+///   haptic when the user has that enabled. It is silently ignored unless the
+///   surrounding input view opts in via `UIInputViewAudioFeedback`, which the
+///   extension does; outside an input view it is a no-op.
+/// - `UIImpactFeedbackGenerator` is what works in the main app's terminal, where the
+///   extra row is an `inputAccessoryView` rather than an input view.
+///
+/// Each is inert in the other's context, so calling both is safe and keeps callers
+/// from having to know which one they are running in.
+@MainActor
+public enum KeyboardHaptics {
+
+    private static let generator = UIImpactFeedbackGenerator(style: .light)
+
+    /// Warms the Taptic Engine so the first press of a session is not late.
+    /// Cheap to call repeatedly; safe to call when feedback is disabled.
+    public static func prepare() {
+        guard KeyboardPrefs.shared.hapticsEnabled else { return }
+        generator.prepare()
+    }
+
+    /// Feedback for a single deliberate key press.
+    ///
+    /// Deliberately not called from auto-repeat ticks — a held backspace firing this
+    /// eleven times a second reads as a malfunction rather than as feedback.
+    public static func keyPress() {
+        guard KeyboardPrefs.shared.hapticsEnabled else { return }
+        UIDevice.current.playInputClick()
+        generator.impactOccurred(intensity: 0.55)
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/NumberRowView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/NumberRowView.swift
@@ -15,8 +15,10 @@ public final class NumberRowView: UIView {
 
     public weak var delegate: NumberRowDelegate?
 
-    private static let bg     = UIColor(red: 0.145, green: 0.145, blue: 0.145, alpha: 1)
-    private static let keyBg  = UIColor(white: 0.27, alpha: 1)
+    /// Colours for the row. This used to be two hardcoded dark greys, which left a
+    /// band of the wrong colour across the middle of the keyboard under every theme
+    /// but Dark. Set it through ``applyTheme(_:)`` so the existing keys recolour.
+    public private(set) var theme: KeyboardTheme = .dark
 
     private let labels = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]
     private var buttons: [UIButton] = []
@@ -40,13 +42,11 @@ public final class NumberRowView: UIView {
     // MARK: - Setup
 
     private func setup() {
-        backgroundColor = Self.bg
+        backgroundColor = theme.keyboardBg
         for label in labels {
             let btn = UIButton(type: .custom)
             btn.setTitle(label, for: .normal)
-            btn.setTitleColor(.white, for: .normal)
             btn.titleLabel?.font = UIFont.monospacedSystemFont(ofSize: 16, weight: .light)
-            btn.backgroundColor = Self.keyBg
             btn.layer.cornerRadius = cornerRadius
             btn.layer.masksToBounds = true
             btn.addTarget(self, action: #selector(digitTapped(_:)), for: .touchUpInside)
@@ -57,6 +57,23 @@ public final class NumberRowView: UIView {
 
             addSubview(btn)
             buttons.append(btn)
+        }
+        applyThemeColors()
+    }
+
+    // MARK: - Theme
+
+    public func applyTheme(_ theme: KeyboardTheme) {
+        self.theme = theme
+        applyThemeColors()
+    }
+
+    private func applyThemeColors() {
+        backgroundColor = theme.keyboardBg
+        for btn in buttons {
+            btn.backgroundColor = theme.keyBg
+            btn.setTitleColor(theme.keyText, for: .normal)
+            btn.setTitleColor(theme.keyText.withAlphaComponent(0.4), for: .highlighted)
         }
     }
 
@@ -85,6 +102,7 @@ public final class NumberRowView: UIView {
 
     @objc private func digitTapped(_ sender: UIButton) {
         guard let label = sender.title(for: .normal) else { return }
+        KeyboardHaptics.keyPress()
         delegate?.numberRow(self, insertText: label)
     }
 
@@ -94,6 +112,7 @@ public final class NumberRowView: UIView {
               let label = btn.title(for: .normal),
               let shifted = AltKeyMappings.numberShifts[label]
         else { return }
+        KeyboardHaptics.keyPress()
         delegate?.numberRow(self, insertText: shifted)
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/QwertyKeyboardView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/QwertyKeyboardView.swift
@@ -6,7 +6,18 @@ import UIKit
 public protocol QwertyKeyboardDelegate: AnyObject {
     func keyboard(_ keyboard: QwertyKeyboardView, insertText text: String)
     func keyboardDeleteBackward(_ keyboard: QwertyKeyboardView)
+    /// Delete the whole word before the cursor. Sent once per repeat tick after a
+    /// held backspace has escalated past character-at-a-time deletion.
+    func keyboardDeleteWordBackward(_ keyboard: QwertyKeyboardView)
     func keyboardAdvanceToNextInputMode(_ keyboard: QwertyKeyboardView)
+}
+
+public extension QwertyKeyboardDelegate {
+    /// Falls back to a single character delete, so a host that has not implemented
+    /// word deletion degrades to the old behaviour instead of stalling on a hold.
+    func keyboardDeleteWordBackward(_ keyboard: QwertyKeyboardView) {
+        keyboardDeleteBackward(keyboard)
+    }
 }
 
 // MARK: - QwertyKeyboardView
@@ -99,21 +110,42 @@ public final class QwertyKeyboardView: UIView {
             return
         }
 
+        stopBackspaceRepeat()
         keyButtons.forEach { $0.removeFromSuperview() }
         keyButtons.removeAll()
         for key in newKeys {
             let btn = QwertyKeyButton(key: key, theme: theme)
             btn.backgroundColor = bgColor(for: key)
             btn.addTarget(self, action: #selector(keyTapped(_:)), for: .touchUpInside)
-            if case .character = key {
+            switch key {
+            case .character:
                 let lp = UILongPressGestureRecognizer(target: self, action: #selector(keyLongPressed(_:)))
                 lp.minimumPressDuration = 0.4
                 btn.addGestureRecognizer(lp)
+            case .backspace:
+                // Holding backspace did nothing at all before this — every deletion
+                // cost a separate tap, which is punishing on a keyboard whose whole
+                // job is editing long prompts. The recogniser cancels the button's
+                // own touch tracking once it fires, so a tap still emits exactly one
+                // delete and a hold emits the repeat below instead of both.
+                let lp = UILongPressGestureRecognizer(target: self, action: #selector(backspaceLongPressed(_:)))
+                lp.minimumPressDuration = 0.35
+                btn.addGestureRecognizer(lp)
+            default:
+                break
             }
             addSubview(btn)
             keyButtons.append(btn)
         }
         builtTheme = theme
+    }
+
+    /// Cancel auto-repeat when the keyboard leaves the hierarchy mid-hold, which
+    /// touch-up would otherwise never report. Handled here rather than in `deinit`,
+    /// which cannot reach main-actor state under Swift 6 strict concurrency.
+    public override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        if newWindow == nil { stopBackspaceRepeat() }
     }
 
     public override func layoutSubviews() {
@@ -199,7 +231,13 @@ public final class QwertyKeyboardView: UIView {
 
     private func rowType(_ row: [QwertyKey]) -> RowType {
         if row.contains(.space)     { return .bottomBar }
-        if row.contains(.backspace) && (row.first == .shift || row.first == .more) {
+        // The third row is always a wide leading modifier, the letters or punctuation,
+        // and a wide backspace. `.symbolsToggle` joins the list because it is the key
+        // that leads that row on the second symbols page; without it that page's row
+        // fell through to the centred branch and rendered a narrow, floating backspace.
+        if row.contains(.backspace),
+           let first = row.first,
+           first == .shift || first == .more || first == .symbolsToggle {
             return .wideSides
         }
         // If fewer keys than a full row, center them; otherwise fill equally
@@ -236,6 +274,8 @@ public final class QwertyKeyboardView: UIView {
     // MARK: - Key tap handler
 
     @objc private func keyTapped(_ sender: QwertyKeyButton) {
+        KeyboardHaptics.keyPress()
+
         switch sender.key {
 
         case .character(let s):
@@ -266,6 +306,8 @@ public final class QwertyKeyboardView: UIView {
             setNeedsLayout()
 
         case .symbolsToggle:
+            // Reached from a letter layer and from the second symbols page, and it
+            // means the same thing in both places: go to the first symbols page.
             layer_      = .symbols
             shiftState  = .off
             rebuild()
@@ -278,13 +320,68 @@ public final class QwertyKeyboardView: UIView {
             setNeedsLayout()
 
         case .more:
-            // Cycle symbols → back to symbols for now (extend later)
+            // Used to rebuild the layer it was already on, so #+= looked like a
+            // broken key and the shell symbols behind it were unreachable.
+            layer_      = .symbols2
+            shiftState  = .off
             rebuild()
             setNeedsLayout()
 
         case .globe:
             delegate?.keyboardAdvanceToNextInputMode(self)
         }
+    }
+
+    // MARK: - Backspace auto-repeat
+
+    private var backspaceTimer: Timer?
+    private var backspaceTicks = 0
+
+    /// Ticks of character-at-a-time deletion before a held backspace switches to whole
+    /// words. At the interval below that is a little over a second of holding, which
+    /// is long enough to be a decision rather than an accident.
+    private static let backspaceWordThreshold = 12
+    private static let backspaceRepeatInterval: TimeInterval = 0.09
+
+    @objc private func backspaceLongPressed(_ gr: UILongPressGestureRecognizer) {
+        switch gr.state {
+        case .began:
+            // The recogniser cancelled the button's touch, so the press that started
+            // the hold has not deleted anything yet. Emit it here before repeating.
+            backspaceTicks = 0
+            delegate?.keyboardDeleteBackward(self)
+            startBackspaceRepeat()
+        case .ended, .cancelled, .failed:
+            stopBackspaceRepeat()
+        default:
+            break
+        }
+    }
+
+    private func startBackspaceRepeat() {
+        backspaceTimer?.invalidate()
+        backspaceTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.backspaceRepeatInterval,
+            repeats: true
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.backspaceTick() }
+        }
+    }
+
+    private func backspaceTick() {
+        backspaceTicks += 1
+        // No haptic per tick on purpose: eleven pulses a second reads as a fault.
+        if backspaceTicks > Self.backspaceWordThreshold {
+            delegate?.keyboardDeleteWordBackward(self)
+        } else {
+            delegate?.keyboardDeleteBackward(self)
+        }
+    }
+
+    private func stopBackspaceRepeat() {
+        backspaceTimer?.invalidate()
+        backspaceTimer = nil
+        backspaceTicks = 0
     }
 
     // MARK: - Long-press alt characters
@@ -298,13 +395,15 @@ public final class QwertyKeyboardView: UIView {
         let alts = AltKeyMappings.alts(for: s)
         if alts.isEmpty { return }
 
+        KeyboardHaptics.keyPress()
+
         if alts.count == 1 {
             delegate?.keyboard(self, insertText: alts[0])
             return
         }
 
         guard let window = gr.view?.window else { return }
-        let popup = AltKeyPopup(alts: alts)
+        let popup = AltKeyPopup(alts: alts, theme: theme)
         popup.onSelect = { [weak self] alt in
             guard let self else { return }
             self.delegate?.keyboard(self, insertText: alt)
@@ -312,15 +411,45 @@ public final class QwertyKeyboardView: UIView {
 
         let btnFrame = btn.convert(btn.bounds, to: window)
         let popupW = min(CGFloat(alts.count) * 52, window.bounds.width - 16)
+        let popupH: CGFloat = 44
         let popupX = max(8, min(btnFrame.midX - popupW / 2, window.bounds.width - popupW - 8))
-        let popupY = btnFrame.minY - 52
-        popup.frame = CGRect(x: popupX, y: popupY, width: popupW, height: 44)
+
+        // Preferred position is above the key. Clamp it into the window, and flip
+        // below the key when there is no room above, so a long-press on the top row
+        // (or in landscape, where the keyboard sits close to the top of a short
+        // window) does not push the popup off screen. Mirrors the Android fix in #62.
+        let minY = window.safeAreaInsets.top + 4
+        let maxY = window.bounds.height - window.safeAreaInsets.bottom - popupH - 4
+        var popupY = btnFrame.minY - popupH - 8
+        if popupY < minY {
+            popupY = btnFrame.maxY + 8
+        }
+        popupY = min(max(popupY, minY), max(minY, maxY))
+
+        popup.frame = CGRect(x: popupX, y: popupY, width: popupW, height: popupH)
         window.addSubview(popup)
         popup.attachDimmer(to: window)
     }
 }
 
 // MARK: - Structural kind
+
+extension QwertyKey {
+    /// What VoiceOver announces for this key.
+    var spokenName: String? {
+        switch self {
+        case .character(let s):  return s
+        case .space:             return "Space"
+        case .return:            return "Return"
+        case .backspace:         return "Delete. Hold to repeat, keep holding to delete whole words."
+        case .shift:             return "Shift"
+        case .symbolsToggle:     return "Numbers and symbols"
+        case .alphabeticToggle:  return "Letters"
+        case .globe:             return "Next keyboard"
+        case .more:              return "More symbols"
+        }
+    }
+}
 
 private extension QwertyKey {
     // A discriminator that ignores a character key's specific value, so two layers
@@ -389,6 +518,9 @@ final class QwertyKeyButton: UIButton {
         self.key = key
         setTitle(nil, for: .normal)
         setImage(nil, for: .normal)
+        // The image keys carry no title for VoiceOver to read, and "#+=" and "123"
+        // are announced character by character. Name each one instead.
+        accessibilityLabel = key.spokenName
         let text = theme.keyText
         switch key {
         case .character(let s):

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/SlashCommandPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/SlashCommandPanel.swift
@@ -1,29 +1,39 @@
 import UIKit
 
-/// Overlay panel that presents slash commands as a scrollable list.
+/// Overlay panel that presents slash commands as a grouped, scrollable list.
 /// Add it to the keyboard extension's root view when the slash key is tapped,
 /// then remove it when the user selects a command or dismisses.
+///
+/// Selecting a row inserts its trigger as plain text into the focused field. The
+/// panel neither launches nor links to anything else.
 @MainActor
 public final class SlashCommandPanel: UIView {
 
     public var onSelect: ((SlashCommand) -> Void)?
     public var onDismiss: (() -> Void)?
 
-    private let commands: [SlashCommand]
+    private let sections: [(category: SlashCommand.Category, commands: [SlashCommand])]
+    private let theme: KeyboardTheme
     private let table = UITableView(frame: .zero, style: .plain)
 
-    public init(commands: [SlashCommand] = SlashCommand.all) {
-        self.commands = commands
+    public init(commands: [SlashCommand] = SlashCommand.all, theme: KeyboardTheme = .dark) {
+        // Group by category so a list this long stays scannable, preserving the
+        // declared order within each group.
+        self.sections = SlashCommand.Category.allCases.compactMap { category in
+            let matching = commands.filter { $0.category == category }
+            return matching.isEmpty ? nil : (category, matching)
+        }
+        self.theme = theme
         super.init(frame: .zero)
         build()
     }
 
-    required init?(coder: NSCoder) { fatalError("use init(commands:)") }
+    required init?(coder: NSCoder) { fatalError("use init(commands:theme:)") }
 
     // MARK: - Layout
 
     private func build() {
-        backgroundColor = UIColor(red: 0.11, green: 0.11, blue: 0.11, alpha: 0.97)
+        backgroundColor = theme.panelBg
 
         // Header row
         let header = buildHeader()
@@ -32,7 +42,7 @@ public final class SlashCommandPanel: UIView {
 
         // Divider
         let div = UIView()
-        div.backgroundColor = UIColor(white: 0.25, alpha: 1)
+        div.backgroundColor = theme.panelSeparator
         div.translatesAutoresizingMaskIntoConstraints = false
         addSubview(div)
 
@@ -40,10 +50,12 @@ public final class SlashCommandPanel: UIView {
         table.dataSource = self
         table.delegate   = self
         table.backgroundColor   = .clear
-        table.separatorColor    = UIColor(white: 0.2, alpha: 1)
+        table.separatorColor    = theme.panelSeparator
         table.separatorInset    = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
         table.rowHeight         = 44
-        table.alwaysBounceVertical = false
+        table.sectionHeaderTopPadding = 0
+        table.alwaysBounceVertical = true
+        table.keyboardDismissMode = .none
         table.register(CommandCell.self, forCellReuseIdentifier: CommandCell.id)
         table.translatesAutoresizingMaskIntoConstraints = false
         addSubview(table)
@@ -72,14 +84,15 @@ public final class SlashCommandPanel: UIView {
 
         let label = UILabel()
         label.text      = "Slash commands"
-        label.textColor = UIColor(white: 0.75, alpha: 1)
+        label.textColor = theme.panelSecondaryText
         label.font      = .systemFont(ofSize: 13, weight: .semibold)
         label.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(label)
 
         let close = UIButton(type: .system)
         close.setImage(UIImage(systemName: "xmark"), for: .normal)
-        close.tintColor = UIColor(white: 0.55, alpha: 1)
+        close.tintColor = theme.panelSecondaryText
+        close.accessibilityLabel = "Close slash commands"
         close.addTarget(self, action: #selector(dismiss), for: .touchUpInside)
         close.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(close)
@@ -90,8 +103,8 @@ public final class SlashCommandPanel: UIView {
 
             close.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             close.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -12),
-            close.widthAnchor.constraint(equalToConstant: 30),
-            close.heightAnchor.constraint(equalToConstant: 30),
+            close.widthAnchor.constraint(equalToConstant: 44),
+            close.heightAnchor.constraint(equalToConstant: 36),
         ])
 
         return view
@@ -106,21 +119,49 @@ public final class SlashCommandPanel: UIView {
 
 extension SlashCommandPanel: UITableViewDataSource, UITableViewDelegate {
 
+    public func numberOfSections(in tableView: UITableView) -> Int {
+        sections.count
+    }
+
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        commands.count
+        sections[section].commands.count
+    }
+
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        26
+    }
+
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let container = UIView()
+        container.backgroundColor = .clear
+
+        let label = UILabel()
+        label.text = sections[section].category.rawValue.uppercased()
+        label.font = .systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = theme.panelSecondaryText
+        label.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
+            label.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -4),
+        ])
+
+        return container
     }
 
     public func tableView(_ tableView: UITableView,
                           cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: CommandCell.id,
-                                                for: indexPath) as! CommandCell
-        cell.configure(with: commands[indexPath.row])
+                                                 for: indexPath) as! CommandCell
+        cell.configure(with: sections[indexPath.section].commands[indexPath.row], theme: theme)
         return cell
     }
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
-        onSelect?(commands[indexPath.row])
+        KeyboardHaptics.keyPress()
+        onSelect?(sections[indexPath.section].commands[indexPath.row])
     }
 }
 
@@ -137,18 +178,12 @@ private final class CommandCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         backgroundColor = .clear
-        selectedBackgroundView = {
-            let v = UIView()
-            v.backgroundColor = UIColor(white: 0.22, alpha: 1)
-            return v
-        }()
 
-        trigger.font      = .monospacedSystemFont(ofSize: 14, weight: .semibold)
-        trigger.textColor = UIColor(red: 0.4, green: 0.75, blue: 1.0, alpha: 1)
+        trigger.font = .monospacedSystemFont(ofSize: 14, weight: .semibold)
         trigger.translatesAutoresizingMaskIntoConstraints = false
+        trigger.setContentCompressionResistancePriority(.required, for: .horizontal)
 
-        detail.font      = .systemFont(ofSize: 13, weight: .regular)
-        detail.textColor = UIColor(white: 0.6, alpha: 1)
+        detail.font = .systemFont(ofSize: 13, weight: .regular)
         detail.translatesAutoresizingMaskIntoConstraints = false
 
         contentView.addSubview(trigger)
@@ -157,7 +192,10 @@ private final class CommandCell: UITableViewCell {
         NSLayoutConstraint.activate([
             trigger.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             trigger.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 14),
-            trigger.widthAnchor.constraint(equalToConstant: 100),
+            // Reserve a column so the descriptions line up, but let a longer trigger
+            // grow past it instead of being clipped — the fixed 100pt width this
+            // replaced would truncate anything longer than "/compact".
+            trigger.widthAnchor.constraint(greaterThanOrEqualToConstant: 92),
 
             detail.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             detail.leadingAnchor.constraint(equalTo: trigger.trailingAnchor, constant: 8),
@@ -167,8 +205,16 @@ private final class CommandCell: UITableViewCell {
 
     required init?(coder: NSCoder) { fatalError() }
 
-    func configure(with cmd: SlashCommand) {
+    func configure(with cmd: SlashCommand, theme: KeyboardTheme) {
         trigger.text = cmd.trigger
+        trigger.textColor = theme.accent
         detail.text  = cmd.description
+        detail.textColor = theme.panelSecondaryText
+
+        let selected = UIView()
+        selected.backgroundColor = theme.panelSelection
+        selectedBackgroundView = selected
+
+        accessibilityLabel = "\(cmd.trigger), \(cmd.description)"
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/UploadPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/UploadPanel.swift
@@ -13,8 +13,32 @@ public final class UploadPanel: UIView {
     private let cellID = "HostCell"
     private let statusLabel = UILabel()
 
+    private let theme: KeyboardTheme
+
     public var hosts: [HostConfig] = [] { didSet { tableView.reloadData() } }
     public var statusMessage: String = "" { didSet { statusLabel.text = statusMessage } }
+
+    /// What the empty host list means, which is not always "you have no hosts".
+    ///
+    /// A keyboard extension without Full Access cannot open the App Group at all, so
+    /// the host list the main app mirrored there reads back empty. Telling those users
+    /// to add a host in the main app sends them to re-add hosts they already have;
+    /// this distinguishes the two cases so the panel names the actual blocker.
+    public enum EmptyReason {
+        case noHostsConfigured
+        case fullAccessRequired
+
+        var message: String {
+            switch self {
+            case .noHostsConfigured:
+                return "No hosts configured. Add one in the main app."
+            case .fullAccessRequired:
+                return "Turn on Full Access to reach your hosts: Settings → General → Keyboard → Keyboards → KeyJawn."
+            }
+        }
+    }
+
+    public var emptyReason: EmptyReason = .noHostsConfigured { didSet { tableView.reloadData() } }
 
     /// Gates host taps while the upload image is still being prepared off the
     /// main actor, so a tap before the data exists is a no-op instead of a crash.
@@ -23,18 +47,16 @@ public final class UploadPanel: UIView {
         didSet { tableView.alpha = isUploadEnabled ? 1.0 : 0.5 }
     }
 
-    public override init(frame: CGRect) {
-        super.init(frame: frame)
+    public init(theme: KeyboardTheme = .dark) {
+        self.theme = theme
+        super.init(frame: .zero)
         setup()
     }
 
-    public required init?(coder: NSCoder) {
-        super.init(coder: coder)
-        setup()
-    }
+    public required init?(coder: NSCoder) { fatalError("use init(theme:)") }
 
     private func setup() {
-        backgroundColor = UIColor(red: 0.13, green: 0.13, blue: 0.13, alpha: 0.97)
+        backgroundColor = theme.panelBg
         layer.cornerRadius = 12
         layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         clipsToBounds = true
@@ -43,30 +65,32 @@ public final class UploadPanel: UIView {
         toolbar.translatesAutoresizingMaskIntoConstraints = false
         addSubview(toolbar)
 
-        titleLabel.text = "SCP Upload"
+        titleLabel.text = "SCP upload"
         titleLabel.font = .systemFont(ofSize: 15, weight: .semibold)
-        titleLabel.textColor = .white
+        titleLabel.textColor = theme.panelText
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         toolbar.addSubview(titleLabel)
 
         cancelButton.setTitle("Cancel", for: .normal)
         cancelButton.titleLabel?.font = .systemFont(ofSize: 15)
-        cancelButton.setTitleColor(.systemBlue, for: .normal)
+        cancelButton.setTitleColor(theme.accent, for: .normal)
         cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
         cancelButton.translatesAutoresizingMaskIntoConstraints = false
         toolbar.addSubview(cancelButton)
 
         let sep = UIView()
-        sep.backgroundColor = UIColor.white.withAlphaComponent(0.15)
+        sep.backgroundColor = theme.panelSeparator
         sep.translatesAutoresizingMaskIntoConstraints = false
         toolbar.addSubview(sep)
 
         // Status
         statusLabel.text = ""
         statusLabel.font = .systemFont(ofSize: 12)
-        statusLabel.textColor = UIColor.white.withAlphaComponent(0.6)
+        statusLabel.textColor = theme.panelSecondaryText
         statusLabel.textAlignment = .center
-        statusLabel.numberOfLines = 2
+        // The Full Access instruction is a full sentence with a settings path in it,
+        // so give the status line room rather than truncating the fix.
+        statusLabel.numberOfLines = 3
         statusLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(statusLabel)
 
@@ -119,30 +143,37 @@ extension UploadPanel: UITableViewDataSource, UITableViewDelegate {
         let cell = tableView.dequeueReusableCell(withIdentifier: cellID, for: indexPath)
         var config = cell.defaultContentConfiguration()
         if hosts.isEmpty {
-            config.text = "No hosts configured. Add one in the main app."
-            config.textProperties.color = UIColor.white.withAlphaComponent(0.4)
+            config.text = emptyReason.message
+            config.textProperties.numberOfLines = 0
+            config.textProperties.color = theme.panelSecondaryText
             cell.selectionStyle = .none
         } else {
             let host = hosts[indexPath.row]
             config.text = host.label.isEmpty ? host.hostname : host.label
             config.secondaryText = "\(host.username)@\(host.hostname):\(host.uploadPath)"
-            config.textProperties.color = .white
-            config.secondaryTextProperties.color = UIColor.white.withAlphaComponent(0.5)
+            config.textProperties.color = theme.panelText
+            config.secondaryTextProperties.color = theme.panelSecondaryText
             cell.selectionStyle = .default
         }
         cell.contentConfiguration = config
         cell.backgroundColor = .clear
         let bg = UIView()
-        bg.backgroundColor = UIColor.white.withAlphaComponent(0.1)
+        bg.backgroundColor = theme.panelSelection
         cell.selectedBackgroundView = bg
         return cell
     }
 
-    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat { 52 }
+    public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        // The Full Access message wraps; let its row grow instead of clipping it.
+        hosts.isEmpty ? UITableView.automaticDimension : 52
+    }
+
+    public func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat { 52 }
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         guard isUploadEnabled, !hosts.isEmpty else { return }
+        KeyboardHaptics.keyPress()
         onUpload?(hosts[indexPath.row])
     }
 }

--- a/ios/Tests/ANSISequenceTests.swift
+++ b/ios/Tests/ANSISequenceTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import KeyJawnKit
+
+/// The byte sequences here are the entire contract between a key press and a remote
+/// shell. A wrong byte is not a visual glitch — it is an interrupt that does not
+/// interrupt, or history that does not scroll.
+final class ANSISequenceTests: XCTestCase {
+
+    func testControlCharacters() {
+        XCTAssertEqual(ANSISequence.bytes(for: .ctrlC), [0x03])
+        XCTAssertEqual(ANSISequence.bytes(for: .ctrlD), [0x04])
+        XCTAssertEqual(ANSISequence.bytes(for: .escape), [0x1b])
+        XCTAssertEqual(ANSISequence.bytes(for: .tab), [0x09])
+        XCTAssertEqual(ANSISequence.bytes(for: .backspace), [0x7f])
+        XCTAssertEqual(ANSISequence.bytes(for: .return), [0x0d])
+        XCTAssertEqual(ANSISequence.bytes(for: .space), [0x20])
+    }
+
+    func testArrowsAreCSISequences() {
+        XCTAssertEqual(ANSISequence.bytes(for: .arrowUp), [0x1b, 0x5b, 0x41])
+        XCTAssertEqual(ANSISequence.bytes(for: .arrowDown), [0x1b, 0x5b, 0x42])
+        XCTAssertEqual(ANSISequence.bytes(for: .arrowRight), [0x1b, 0x5b, 0x43])
+        XCTAssertEqual(ANSISequence.bytes(for: .arrowLeft), [0x1b, 0x5b, 0x44])
+    }
+
+    func testCtrlModifiedArrowsUseTheModifierForm() {
+        XCTAssertEqual(ANSISequence.bytes(for: .arrowLeft, ctrlActive: true),
+                       [0x1b, 0x5b, 0x31, 0x3b, 0x35, 0x44])
+        XCTAssertEqual(ANSISequence.bytes(for: .arrowRight, ctrlActive: true),
+                       [0x1b, 0x5b, 0x31, 0x3b, 0x35, 0x43])
+    }
+
+    /// Ctrl+letter is the combination the three-state modifier exists to produce.
+    func testCtrlMasksCharactersIntoControlCodes() {
+        XCTAssertEqual(ANSISequence.bytes(for: .character("c"), ctrlActive: true), [0x03])
+        XCTAssertEqual(ANSISequence.bytes(for: .character("d"), ctrlActive: true), [0x04])
+        XCTAssertEqual(ANSISequence.bytes(for: .character("z"), ctrlActive: true), [0x1a])
+        XCTAssertEqual(ANSISequence.bytes(for: .character("l"), ctrlActive: true), [0x0c])
+        XCTAssertEqual(ANSISequence.bytes(for: .character("a"), ctrlActive: true), [0x01])
+        // Case does not change the control code, matching every terminal emulator.
+        XCTAssertEqual(ANSISequence.bytes(for: .character("C"), ctrlActive: true), [0x03])
+    }
+
+    func testPlainCharacterPassesThrough() {
+        XCTAssertEqual(ANSISequence.bytes(for: .character("x")), [0x78])
+    }
+
+    func testSlashHasNoBytesBecauseThePanelHandlesIt() {
+        XCTAssertNil(ANSISequence.bytes(for: .slash))
+        XCTAssertNil(ANSISequence.text(for: .slash))
+    }
+
+    /// What the keyboard extension actually inserts, since it has no byte channel.
+    func testTextFormMatchesTheByteForm() {
+        XCTAssertEqual(ANSISequence.text(for: .arrowUp), "\u{1b}[A")
+        XCTAssertEqual(ANSISequence.text(for: .arrowDown), "\u{1b}[B")
+        XCTAssertEqual(ANSISequence.text(for: .escape), "\u{1b}")
+        XCTAssertEqual(ANSISequence.text(for: .ctrlC), "\u{03}")
+        XCTAssertEqual(ANSISequence.text(for: .tab), "\t")
+    }
+
+    /// Every key the extra row can emit has to produce something, or it is a key that
+    /// looks live and does nothing — which is exactly what ^C and the vertical arrows
+    /// were before they were routed through here.
+    func testEveryExtraRowKeyProducesOutput() {
+        for key in ExtraRowKey.defaults {
+            guard let output = key.output else { continue }   // clipboard, upload
+            if output == .slash { continue }                  // opens the panel instead
+            XCTAssertNotNil(ANSISequence.bytes(for: output),
+                            "\(key.label) produces no bytes")
+            XCTAssertNotNil(ANSISequence.text(for: output),
+                            "\(key.label) produces no insertable text")
+        }
+    }
+
+    /// The visible labels are glyphs and abbreviations; VoiceOver needs words.
+    func testEveryExtraRowKeyHasASpokenName() {
+        for key in ExtraRowKey.defaults {
+            XCTAssertFalse(key.accessibilityLabel.isEmpty, "\(key.label) is unnamed for VoiceOver")
+        }
+        // The arrow glyphs in particular read as nothing useful on their own.
+        let arrows: [ExtraRowSlot] = [.arrowUp, .arrowDown, .arrowLeft, .arrowRight]
+        for key in ExtraRowKey.defaults where arrows.contains(key.slot) {
+            XCTAssertNotEqual(key.accessibilityLabel, key.label,
+                              "\(key.label) falls back to its glyph for VoiceOver")
+        }
+    }
+}

--- a/ios/Tests/AltKeyMappingsTests.swift
+++ b/ios/Tests/AltKeyMappingsTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class AltKeyMappingsTests: XCTestCase {
+
+    func testAccentedVowels() {
+        XCTAssertEqual(AltKeyMappings.alts(for: "e"), ["é", "è", "ê", "ë"])
+        XCTAssertEqual(AltKeyMappings.alts(for: "n"), ["ñ"])
+    }
+
+    /// The table only carries lowercase; uppercase is derived so it cannot drift.
+    func testUppercaseIsDerivedFromLowercase() {
+        XCTAssertEqual(AltKeyMappings.alts(for: "E"), ["É", "È", "Ê", "Ë"])
+        XCTAssertEqual(AltKeyMappings.alts(for: "N"), ["Ñ"])
+    }
+
+    func testKeysWithoutAlternatesReturnEmpty() {
+        XCTAssertTrue(AltKeyMappings.alts(for: "q").isEmpty)
+        XCTAssertTrue(AltKeyMappings.alts(for: "Q").isEmpty)
+        XCTAssertTrue(AltKeyMappings.alts(for: "&").isEmpty)
+    }
+
+    // MARK: - Shell-oriented alternates
+
+    /// Underscore is the single most-typed alternate on this keyboard, so it leads —
+    /// the em dash it displaced belongs to prose, not to `my_file`.
+    func testHyphenLeadsWithUnderscore() {
+        XCTAssertEqual(AltKeyMappings.alts(for: "-").first, "_")
+    }
+
+    func testSlashOffersBackslashAndPipe() {
+        XCTAssertEqual(AltKeyMappings.alts(for: "/"), ["\\", "|"])
+    }
+
+    /// Brackets one press from the first symbols page, so `[]`, `{}` and `<>` never
+    /// require a detour to the second.
+    func testParenthesesOfferBracketsAndBraces() {
+        XCTAssertEqual(AltKeyMappings.alts(for: "("), ["[", "{", "<"])
+        XCTAssertEqual(AltKeyMappings.alts(for: ")"), ["]", "}", ">"])
+    }
+
+    func testQuotesOfferBacktick() {
+        XCTAssertEqual(AltKeyMappings.alts(for: "'").first, "`")
+        XCTAssertEqual(AltKeyMappings.alts(for: "\"").first, "`")
+    }
+
+    // MARK: - Number row
+
+    func testNumberRowShiftsCoverEveryDigit() {
+        for digit in "0123456789" {
+            XCTAssertNotNil(AltKeyMappings.numberShifts[String(digit)], "\(digit) has no shifted symbol")
+        }
+        XCTAssertEqual(AltKeyMappings.numberShifts.count, 10)
+    }
+
+    func testNumberRowShiftsMatchTheStandardLayout() {
+        XCTAssertEqual(AltKeyMappings.numberShifts["1"], "!")
+        XCTAssertEqual(AltKeyMappings.numberShifts["7"], "&")
+        XCTAssertEqual(AltKeyMappings.numberShifts["0"], ")")
+    }
+
+    // MARK: - Invariants
+
+    func testNoAlternateIsEmptyOrDuplicated() {
+        for (key, alts) in AltKeyMappings.table {
+            XCTAssertFalse(alts.isEmpty, "\(key) maps to an empty list, which reads as a dead long-press")
+            XCTAssertEqual(Set(alts).count, alts.count, "\(key) repeats an alternate")
+            XCTAssertFalse(alts.contains(key), "\(key) lists itself as its own alternate")
+            for alt in alts {
+                XCTAssertFalse(alt.isEmpty, "\(key) has an empty alternate")
+            }
+        }
+    }
+
+    /// The popup is sized at 52pt per alternate against the window width, so a very
+    /// long list would be squeezed to unusable targets on a small phone.
+    func testAlternateListsStayTappable() {
+        for (key, alts) in AltKeyMappings.table {
+            XCTAssertLessThanOrEqual(alts.count, 6, "\(key) has too many alternates to tap comfortably")
+        }
+    }
+}

--- a/ios/Tests/CtrlStateTests.swift
+++ b/ios/Tests/CtrlStateTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import KeyJawnKit
+
+@MainActor
+final class CtrlStateTests: XCTestCase {
+
+    func testTapCyclesOffArmedLockedOff() {
+        let ctrl = CtrlState()
+        XCTAssertEqual(ctrl.state, .off)
+        ctrl.toggle()
+        XCTAssertEqual(ctrl.state, .armed)
+        ctrl.toggle()
+        XCTAssertEqual(ctrl.state, .locked)
+        ctrl.toggle()
+        XCTAssertEqual(ctrl.state, .off)
+    }
+
+    func testConsumeReleasesArmedAfterOneKey() {
+        let ctrl = CtrlState()
+        ctrl.toggle()
+        ctrl.consume()
+        XCTAssertEqual(ctrl.state, .off)
+    }
+
+    /// The whole point of the locked state: it survives keypresses until tapped off.
+    func testConsumeLeavesLockedAlone() {
+        let ctrl = CtrlState()
+        ctrl.toggle()
+        ctrl.toggle()
+        ctrl.consume()
+        ctrl.consume()
+        XCTAssertEqual(ctrl.state, .locked)
+    }
+
+    func testConsumeFromOffIsANoOp() {
+        let ctrl = CtrlState()
+        var notifications = 0
+        ctrl.onChange = { _ in notifications += 1 }
+        ctrl.consume()
+        XCTAssertEqual(ctrl.state, .off)
+        XCTAssertEqual(notifications, 0, "consume from off should not tell the UI to redraw")
+    }
+
+    func testIsActiveCoversArmedAndLocked() {
+        let ctrl = CtrlState()
+        XCTAssertFalse(ctrl.isActive)
+        ctrl.toggle()
+        XCTAssertTrue(ctrl.isActive)
+        ctrl.toggle()
+        XCTAssertTrue(ctrl.isActive)
+    }
+
+    func testOnChangeReportsEveryTransition() {
+        let ctrl = CtrlState()
+        var seen: [CtrlState.State] = []
+        ctrl.onChange = { seen.append($0) }
+        ctrl.toggle()
+        ctrl.toggle()
+        ctrl.consume()   // locked, no change
+        ctrl.toggle()
+        XCTAssertEqual(seen, [.armed, .locked, .off])
+    }
+}

--- a/ios/Tests/HostConfigTests.swift
+++ b/ios/Tests/HostConfigTests.swift
@@ -52,6 +52,29 @@ final class HostConfigTests: XCTestCase {
         XCTAssertFalse(HostConfig(label: "a", hostname: "h", port: 0, username: "u").isValid)
     }
 
+    // MARK: - Host key scan command
+
+    func testScanCommandOmitsThePortFlagForTheDefaultPort() {
+        let host = HostConfig(label: "a", hostname: "example.internal", port: 22, username: "u")
+        XCTAssertEqual(host.hostKeyScanCommand, "ssh-keyscan -t ed25519 example.internal")
+    }
+
+    /// Without `-p` the instructions scan port 22 of the same hostname, which is either
+    /// nothing at all or a different service whose key gets pinned here — and then
+    /// every later connection fails on a mismatch the user cannot explain.
+    func testScanCommandCarriesANonDefaultPort() {
+        let host = HostConfig(label: "a", hostname: "example.internal", port: 2222, username: "u")
+        XCTAssertEqual(host.hostKeyScanCommand, "ssh-keyscan -p 2222 -t ed25519 example.internal")
+    }
+
+    func testScanCommandMatchesTheHostItIsBuiltFrom() {
+        for port: UInt16 in [22, 22222, 2022, 1] {
+            let host = HostConfig(label: "a", hostname: "h.internal", port: port, username: "u")
+            XCTAssertEqual(host.hostKeyScanCommand,
+                           HostConfig.hostKeyScanCommand(hostname: "h.internal", port: port))
+        }
+    }
+
     func testAuthMethodRawValuesAreStable() {
         // Persisted verbatim in the shared container; renaming a case would orphan
         // every host an existing install has saved.

--- a/ios/Tests/HostConfigTests.swift
+++ b/ios/Tests/HostConfigTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import KeyJawnKit
+
+/// `HostConfig` is the wire format between the app and the keyboard extension: the app
+/// encodes it into the shared container and the extension decodes it there. A field
+/// that stops round-tripping shows up as an empty host list in the SCP panel.
+final class HostConfigTests: XCTestCase {
+
+    private let sample = HostConfig(
+        label: "houseofjawn",
+        hostname: "example.internal",
+        port: 2222,
+        username: "jawn",
+        authMethod: .key,
+        hostPublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample",
+        uploadPath: "/srv/uploads"
+    )
+
+    func testRoundTripsThroughJSON() throws {
+        let data = try JSONEncoder().encode(sample)
+        let decoded = try JSONDecoder().decode(HostConfig.self, from: data)
+        XCTAssertEqual(decoded, sample)
+    }
+
+    func testArrayRoundTripsThroughJSON() throws {
+        let hosts = [sample, HostConfig(label: "b", hostname: "b.internal", username: "root")]
+        let data = try JSONEncoder().encode(hosts)
+        XCTAssertEqual(try JSONDecoder().decode([HostConfig].self, from: data), hosts)
+    }
+
+    func testIdentitySurvivesEncoding() throws {
+        let data = try JSONEncoder().encode(sample)
+        let decoded = try JSONDecoder().decode(HostConfig.self, from: data)
+        // The id is what HostStore.update matches on, so an edit that lost it would
+        // append a duplicate host instead of replacing the original.
+        XCTAssertEqual(decoded.id, sample.id)
+    }
+
+    func testDefaults() {
+        let host = HostConfig(label: "minimal", hostname: "h", username: "u")
+        XCTAssertEqual(host.port, 22)
+        XCTAssertEqual(host.authMethod, .key)
+        XCTAssertNil(host.hostPublicKey)
+        XCTAssertEqual(host.uploadPath, "/tmp")
+    }
+
+    func testValidation() {
+        XCTAssertTrue(HostConfig(label: "a", hostname: "h", username: "u").isValid)
+        XCTAssertFalse(HostConfig(label: "a", hostname: "", username: "u").isValid)
+        XCTAssertFalse(HostConfig(label: "a", hostname: "h", username: "").isValid)
+        XCTAssertFalse(HostConfig(label: "a", hostname: "   ", username: "u").isValid)
+        XCTAssertFalse(HostConfig(label: "a", hostname: "h", port: 0, username: "u").isValid)
+    }
+
+    func testAuthMethodRawValuesAreStable() {
+        // Persisted verbatim in the shared container; renaming a case would orphan
+        // every host an existing install has saved.
+        XCTAssertEqual(HostConfig.AuthMethod.key.rawValue, "key")
+        XCTAssertEqual(HostConfig.AuthMethod.password.rawValue, "password")
+    }
+}

--- a/ios/Tests/KeyboardLayersTests.swift
+++ b/ios/Tests/KeyboardLayersTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class KeyboardLayersTests: XCTestCase {
+
+    // MARK: - Shape
+
+    /// The positioning code derives key widths from row shape, so these counts are
+    /// load-bearing rather than cosmetic.
+    func testRowShapes() {
+        XCTAssertEqual(shape(of: .lowercase), [10, 9, 9, 4])
+        XCTAssertEqual(shape(of: .uppercase), [10, 9, 9, 4])
+        XCTAssertEqual(shape(of: .symbols),   [10, 10, 7, 4])
+        XCTAssertEqual(shape(of: .symbols2),  [10, 9, 7, 4])
+    }
+
+    func testEveryLayerHasFourRows() {
+        for layer in KeyboardLayerType.allCases {
+            XCTAssertEqual(KeyboardLayers.rows(for: layer).count, 4, "\(layer)")
+        }
+    }
+
+    /// The in-place relabel fast path in QwertyKeyboardView reuses buttons across a
+    /// shift only while the two layers agree position by position on the kind of key.
+    func testLowercaseAndUppercaseArePositionIdentical() {
+        let lower = KeyboardLayers.rows(for: .lowercase).flatMap { $0 }
+        let upper = KeyboardLayers.rows(for: .uppercase).flatMap { $0 }
+        XCTAssertEqual(lower.count, upper.count)
+        for (l, u) in zip(lower, upper) {
+            switch (l, u) {
+            case (.character(let a), .character(let b)):
+                XCTAssertEqual(a.uppercased(), b, "\(a) should shift to \(b)")
+            default:
+                XCTAssertEqual(l, u, "non-character keys must sit in the same slots")
+            }
+        }
+    }
+
+    func testEveryLayerEndsWithTheSameBottomBar() {
+        for layer in KeyboardLayerType.allCases {
+            let bottom = KeyboardLayers.rows(for: layer)[3]
+            XCTAssertEqual(bottom.count, 4, "\(layer)")
+            XCTAssertEqual(bottom[1], .globe, "\(layer)")
+            XCTAssertEqual(bottom[2], .space, "\(layer)")
+            XCTAssertEqual(bottom[3], .return, "\(layer)")
+        }
+    }
+
+    /// Row two is a wide modifier, the middle keys, then a wide backspace.
+    /// `QwertyKeyboardView.rowType` keys off exactly this.
+    func testThirdRowLeadsWithAModifierAndEndsWithBackspace() {
+        let expectedLead: [KeyboardLayerType: QwertyKey] = [
+            .lowercase: .shift,
+            .uppercase: .shift,
+            .symbols: .more,
+            .symbols2: .symbolsToggle,
+        ]
+        for layer in KeyboardLayerType.allCases {
+            let row = KeyboardLayers.rows(for: layer)[2]
+            XCTAssertEqual(row.first, expectedLead[layer], "\(layer)")
+            XCTAssertEqual(row.last, .backspace, "\(layer)")
+        }
+    }
+
+    // MARK: - Reachability
+
+    /// Before the second symbols page existed, none of these could be typed on this
+    /// keyboard at all — no pipe, no underscore, no tilde, no brackets or braces on a
+    /// keyboard whose entire purpose is driving a shell.
+    func testShellSymbolsAreAllReachable() {
+        let typeable = allCharacters()
+        for symbol in KeyboardLayers.shellSymbols.sorted() {
+            XCTAssertTrue(typeable.contains(symbol), "\(symbol) cannot be typed on any layer")
+        }
+    }
+
+    func testSecondSymbolsPageCarriesTheShellSymbols() {
+        let page2 = characters(in: .symbols2)
+        for symbol in KeyboardLayers.shellSymbols.sorted() {
+            XCTAssertTrue(page2.contains(symbol), "\(symbol) is missing from the #+= page")
+        }
+    }
+
+    /// Long-press alternates and the number row's shifted symbols are the other two
+    /// routes to a character. Together with the layers they have to cover everything a
+    /// command line needs.
+    func testCommonShellCharactersAreReachableSomehow() {
+        var reachable = allCharacters()
+        reachable.formUnion(AltKeyMappings.numberShifts.values)
+        for label in reachable.union(["-", "/", "(", ")", ".", "'", "\"", "$", ";", ":"]) {
+            reachable.formUnion(AltKeyMappings.alts(for: label))
+        }
+
+        let needed = ["|", "&", ";", "$", "*", "?", "~", "_", "-", "/", "\\", "`",
+                      "\"", "'", "(", ")", "[", "]", "{", "}", "<", ">", "=", "+",
+                      "#", "%", "^", "@", ":", ".", ","]
+        for character in needed {
+            XCTAssertTrue(reachable.contains(character), "\(character) is unreachable")
+        }
+    }
+
+    func testDigitsAreOnTheSymbolsPage() {
+        let page1 = characters(in: .symbols)
+        for digit in "0123456789" {
+            XCTAssertTrue(page1.contains(String(digit)), "\(digit) missing from symbols")
+        }
+    }
+
+    /// The `#+=` key is the only route to the second page, and it used to rebuild the
+    /// page it was already on.
+    func testMoreKeyExistsOnlyOnTheFirstSymbolsPage() {
+        for layer in KeyboardLayerType.allCases {
+            let hasMore = KeyboardLayers.rows(for: layer).flatMap { $0 }.contains(.more)
+            XCTAssertEqual(hasMore, layer == .symbols, "\(layer)")
+        }
+    }
+
+    /// And the second page needs a way back that is not the letters key.
+    func testSecondPageOffersARouteBackToTheFirst() {
+        let keys = KeyboardLayers.rows(for: .symbols2).flatMap { $0 }
+        XCTAssertTrue(keys.contains(.symbolsToggle))
+        XCTAssertTrue(keys.contains(.alphabeticToggle))
+    }
+
+    // MARK: - Helpers
+
+    private func shape(of layer: KeyboardLayerType) -> [Int] {
+        KeyboardLayers.rows(for: layer).map(\.count)
+    }
+
+    private func characters(in layer: KeyboardLayerType) -> Set<String> {
+        Set(KeyboardLayers.rows(for: layer).flatMap { $0 }.compactMap { key in
+            if case .character(let s) = key { return s }
+            return nil
+        })
+    }
+
+    private func allCharacters() -> Set<String> {
+        KeyboardLayerType.allCases.reduce(into: Set<String>()) { result, layer in
+            result.formUnion(characters(in: layer))
+        }
+    }
+}

--- a/ios/Tests/KeyboardPrefsTests.swift
+++ b/ios/Tests/KeyboardPrefsTests.swift
@@ -110,6 +110,34 @@ final class KeyboardPrefsTests: XCTestCase {
         XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, .oled)
     }
 
+    /// The upgrade path this migration exists for is a user who opens the *keyboard*
+    /// before the app — the ordinary case for this product. The extension cannot see
+    /// the app's standard suite, so if it ran the migration it would find nothing,
+    /// set the shared completion flag anyway, and the app's next launch would skip the
+    /// migration and silently discard the user's saved theme. A non-migrating process
+    /// must leave both the values and the flag alone.
+    func testANonMigratingProcessLeavesTheFlagUnset() {
+        let legacyKey = "theme"
+        let previous = UserDefaults.standard.string(forKey: legacyKey)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: legacyKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: legacyKey)
+            }
+        }
+        UserDefaults.standard.set("terminal", forKey: legacyKey)
+
+        // Stands in for the keyboard extension.
+        let extensionSide = KeyboardPrefs(defaults: suite, migratesLegacyValues: false)
+        XCTAssertEqual(extensionSide.theme, .dark, "extension should not consume app-side keys")
+        XCTAssertFalse(suite.bool(forKey: "keyjawn.prefs.migrated.v2"),
+                       "extension claimed the migration it could not perform")
+
+        // The app opens later and the choice is still recoverable.
+        XCTAssertEqual(KeyboardPrefs(defaults: suite, migratesLegacyValues: true).theme, .terminal)
+    }
+
     func testAnExplicitChoiceIsNotOverwrittenByALegacyValue() {
         let legacyKey = "theme"
         let previous = UserDefaults.standard.string(forKey: legacyKey)

--- a/ios/Tests/KeyboardPrefsTests.swift
+++ b/ios/Tests/KeyboardPrefsTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import KeyJawnKit
+
+/// These preferences cross a process boundary, so the interesting cases are the ones
+/// where nothing has been written yet — the state every fresh install is in, and the
+/// state a keyboard extension without Full Access is permanently in.
+final class KeyboardPrefsTests: XCTestCase {
+
+    private var suiteName: String!
+    private var suite: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.keyjawn.tests.\(UUID().uuidString)"
+        suite = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        suite = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Defaults
+
+    func testThemeDefaultsToDark() {
+        XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, .dark)
+    }
+
+    /// `UserDefaults.bool(forKey:)` returns false for a key that was never written, so
+    /// reading this naively would ship every install with feedback silently off.
+    func testFeedbackDefaultsToOn() {
+        XCTAssertTrue(KeyboardPrefs(defaults: suite).hapticsEnabled)
+    }
+
+    /// On by default because the product exists to drive shells over SSH, and because
+    /// with it off the up and down arrows have nothing to do.
+    func testTerminalArrowKeysDefaultToOn() {
+        XCTAssertTrue(KeyboardPrefs(defaults: suite).terminalArrowKeys)
+    }
+
+    // MARK: - Round trip
+
+    func testEveryThemeRoundTrips() {
+        for theme in KeyboardTheme.allCases {
+            let writer = KeyboardPrefs(defaults: suite)
+            writer.theme = theme
+            XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, theme,
+                           "\(theme.rawValue) did not survive a write and re-read")
+        }
+    }
+
+    func testBooleanPreferencesRoundTripInBothDirections() {
+        let prefs = KeyboardPrefs(defaults: suite)
+        for value in [false, true, false] {
+            prefs.hapticsEnabled = value
+            prefs.terminalArrowKeys = value
+            let reread = KeyboardPrefs(defaults: suite)
+            XCTAssertEqual(reread.hapticsEnabled, value)
+            XCTAssertEqual(reread.terminalArrowKeys, value)
+        }
+    }
+
+    /// A theme removed in a later release, or a value corrupted in the shared
+    /// container, must not leave the keyboard with no colours at all.
+    func testUnknownThemeFallsBackToDark() {
+        suite.set("solarized-mauve", forKey: "keyjawn.theme")
+        XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, .dark)
+    }
+
+    // MARK: - Migration
+
+    /// The pre-App-Group Settings screen wrote `@AppStorage("theme")` into the app's
+    /// own sandbox where the keyboard could never see it. Honour that choice once
+    /// rather than resetting the user to Dark on upgrade.
+    func testLegacySettingsThemeIsAdopted() {
+        let legacyKey = "theme"
+        let previous = UserDefaults.standard.string(forKey: legacyKey)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: legacyKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: legacyKey)
+            }
+        }
+
+        UserDefaults.standard.set("terminal", forKey: legacyKey)
+        XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, .terminal)
+    }
+
+    /// Migration runs once. A later legacy write must not overwrite a choice the user
+    /// has since made in the new Settings screen.
+    func testMigrationDoesNotRunTwice() {
+        let legacyKey = "theme"
+        let previous = UserDefaults.standard.string(forKey: legacyKey)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: legacyKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: legacyKey)
+            }
+        }
+
+        UserDefaults.standard.set("terminal", forKey: legacyKey)
+        _ = KeyboardPrefs(defaults: suite)          // migrates
+        KeyboardPrefs(defaults: suite).theme = .oled // user picks something else
+
+        UserDefaults.standard.set("light", forKey: legacyKey)
+        XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, .oled)
+    }
+
+    func testAnExplicitChoiceIsNotOverwrittenByALegacyValue() {
+        let legacyKey = "theme"
+        let previous = UserDefaults.standard.string(forKey: legacyKey)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: legacyKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: legacyKey)
+            }
+        }
+
+        suite.set(KeyboardTheme.light.rawValue, forKey: "keyjawn.theme")
+        UserDefaults.standard.set("terminal", forKey: legacyKey)
+        XCTAssertEqual(KeyboardPrefs(defaults: suite).theme, .light)
+    }
+}

--- a/ios/Tests/KeyboardThemeContrastTests.swift
+++ b/ios/Tests/KeyboardThemeContrastTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+import UIKit
+@testable import KeyJawnKit
+
+/// Legibility as a test rather than as a thing someone notices on a device.
+///
+/// This is the check that would have caught the extra row's hardcoded white labels:
+/// they survived every theme change, and on Light they sat on a mid-grey key at 3.3:1
+/// — readable enough in a screenshot, tiring on a phone in daylight.
+///
+/// Ratios are WCAG 2.1 relative luminance. The panel backgrounds are near-opaque and
+/// compared as their own colour rather than composited, which is the conservative
+/// reading: what shows through is the keyboard behind them, in the same theme.
+final class KeyboardThemeContrastTests: XCTestCase {
+
+    /// WCAG AA for normal text. Key glyphs are small and used one-handed in bad light,
+    /// so this is a floor rather than a target.
+    private let minimumRatio = 4.5
+
+    func testKeyLabelsAreLegibleOnKeyFaces() {
+        for theme in KeyboardTheme.allCases {
+            assertContrast(theme.keyText, on: theme.keyBg, theme: theme, label: "keyText on keyBg")
+        }
+    }
+
+    func testKeyLabelsAreLegibleOnModifierKeys() {
+        for theme in KeyboardTheme.allCases {
+            assertContrast(theme.keyText, on: theme.specKeyBg, theme: theme, label: "keyText on specKeyBg")
+        }
+    }
+
+    func testExtraRowLabelsAreLegible() {
+        for theme in KeyboardTheme.allCases {
+            assertContrast(theme.extraRowKeyText, on: theme.extraRowKeyBg,
+                           theme: theme, label: "extraRowKeyText on extraRowKeyBg")
+        }
+    }
+
+    func testPanelTextIsLegible() {
+        for theme in KeyboardTheme.allCases {
+            assertContrast(theme.panelText, on: theme.panelBg, theme: theme, label: "panelText")
+            assertContrast(theme.panelSecondaryText, on: theme.panelBg, theme: theme, label: "panelSecondaryText")
+            assertContrast(theme.accent, on: theme.panelBg, theme: theme, label: "accent")
+        }
+    }
+
+    /// A modifier key whose face matches the keyboard behind it reads as a hole rather
+    /// than as a key. The Terminal theme used to have exactly that.
+    func testModifierKeysAreDistinguishableFromTheKeyboardBackground() {
+        for theme in KeyboardTheme.allCases {
+            XCTAssertNotEqual(components(theme.specKeyBg), components(theme.keyboardBg),
+                              "\(theme.rawValue): special keys are invisible against the keyboard")
+            XCTAssertNotEqual(components(theme.keyBg), components(theme.keyboardBg),
+                              "\(theme.rawValue): keys are invisible against the keyboard")
+        }
+    }
+
+    /// The armed and locked Ctrl states have to be told apart — one means the next key
+    /// carries Ctrl, the other means every key does until it is turned off.
+    ///
+    /// Asserted as a colour difference, not a luminance ratio: the two are separated by
+    /// hue (blue against red), which sits at roughly 1.06:1 in luminance terms. That is
+    /// legible to most people and is the palette the Android build already uses, but it
+    /// does mean the distinction is carried by hue alone.
+    func testArmedAndLockedAreDistinct() {
+        for theme in KeyboardTheme.allCases {
+            XCTAssertNotEqual(components(theme.armed), components(theme.locked),
+                              "\(theme.rawValue): armed and locked are the same colour")
+            XCTAssertNotEqual(components(theme.armed), components(theme.extraRowKeyBg),
+                              "\(theme.rawValue): an armed Ctrl looks the same as an idle key")
+        }
+    }
+
+    func testIsDarkMatchesTheActualBackground() {
+        for theme in KeyboardTheme.allCases {
+            let bright = relativeLuminance(theme.keyboardBg) > 0.5
+            XCTAssertEqual(theme.isDark, !bright, "\(theme.rawValue) misreports its own brightness")
+        }
+    }
+
+    func testEveryThemeIsNamed() {
+        for theme in KeyboardTheme.allCases {
+            XCTAssertFalse(theme.displayName.isEmpty)
+            XCTAssertFalse(theme.rawValue.isEmpty)
+        }
+        XCTAssertEqual(Set(KeyboardTheme.allCases.map(\.displayName)).count,
+                       KeyboardTheme.allCases.count,
+                       "two themes share a name in the picker")
+    }
+
+    // MARK: - Helpers
+
+    private func assertContrast(_ foreground: UIColor,
+                                on background: UIColor,
+                                theme: KeyboardTheme,
+                                label: String,
+                                file: StaticString = #filePath,
+                                line: UInt = #line) {
+        let ratio = contrastRatio(foreground, background)
+        XCTAssertGreaterThanOrEqual(
+            ratio, minimumRatio,
+            "\(theme.rawValue): \(label) is \(rounded(ratio)):1, below the \(minimumRatio):1 floor",
+            file: file, line: line
+        )
+    }
+
+    private func contrastRatio(_ a: UIColor, _ b: UIColor) -> Double {
+        let la = relativeLuminance(a)
+        let lb = relativeLuminance(b)
+        let lighter = max(la, lb)
+        let darker = min(la, lb)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private func relativeLuminance(_ color: UIColor) -> Double {
+        let rgb = components(color)
+        func linear(_ channel: Double) -> Double {
+            channel <= 0.03928 ? channel / 12.92 : pow((channel + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(rgb.red) + 0.7152 * linear(rgb.green) + 0.0722 * linear(rgb.blue)
+    }
+
+    private struct RGB: Equatable {
+        let red: Double
+        let green: Double
+        let blue: Double
+    }
+
+    private func components(_ color: UIColor) -> RGB {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        // Handles the grayscale colour space too, which UIColor(white:alpha:) and the
+        // .white / .black constants use.
+        guard color.getRed(&r, green: &g, blue: &b, alpha: &a) else {
+            XCTFail("could not read components from \(color)")
+            return RGB(red: 0, green: 0, blue: 0)
+        }
+        return RGB(red: Double(r), green: Double(g), blue: Double(b))
+    }
+
+    private func rounded(_ value: Double) -> String {
+        String(format: "%.2f", value)
+    }
+}

--- a/ios/Tests/SlashCommandTests.swift
+++ b/ios/Tests/SlashCommandTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class SlashCommandTests: XCTestCase {
+
+    /// The list used to be two sets concatenated, which put `/help` and `/clear` in
+    /// the panel twice with identical descriptions and no way to tell the rows apart.
+    func testTriggersAreUnique() {
+        let triggers = SlashCommand.all.map(\.trigger)
+        XCTAssertEqual(Set(triggers).count, triggers.count,
+                       "duplicate triggers: \(duplicates(in: triggers))")
+    }
+
+    func testIdentifiersAreUnique() {
+        let ids = SlashCommand.all.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "duplicate ids: \(duplicates(in: ids))")
+    }
+
+    func testEveryTriggerIsASlashCommand() {
+        for command in SlashCommand.all {
+            XCTAssertTrue(command.trigger.hasPrefix("/"), "\(command.trigger) is not a slash command")
+            XCTAssertFalse(command.trigger.contains(" "), "\(command.trigger) contains a space")
+            XCTAssertGreaterThan(command.trigger.count, 1, "\(command.id) has an empty trigger")
+        }
+    }
+
+    func testEveryCommandIsDescribed() {
+        for command in SlashCommand.all {
+            XCTAssertFalse(command.description.isEmpty, "\(command.trigger) has no description")
+        }
+    }
+
+    // MARK: - Grouping
+
+    /// Grouping is what the panel renders, so it has to account for every command
+    /// exactly once — a command in no group would silently vanish from the list.
+    func testGroupingIsATotalPartition() {
+        // Closures rather than key paths: Swift has no key paths into tuple elements.
+        let grouped = SlashCommand.grouped.flatMap { $0.commands }
+        XCTAssertEqual(grouped.count, SlashCommand.all.count)
+        XCTAssertEqual(Set(grouped.map(\.id)), Set(SlashCommand.all.map(\.id)))
+    }
+
+    func testGroupsAreNeverEmpty() {
+        for group in SlashCommand.grouped {
+            XCTAssertFalse(group.commands.isEmpty, "\(group.category) renders an empty section header")
+        }
+    }
+
+    func testGroupsFollowDeclaredCategoryOrder() {
+        let order = SlashCommand.Category.allCases
+        let produced = SlashCommand.grouped.map { $0.category }
+        let expected = order.filter { category in produced.contains(category) }
+        XCTAssertEqual(produced, expected)
+    }
+
+    func testEveryCommandInAGroupCarriesThatCategory() {
+        for group in SlashCommand.grouped {
+            for command in group.commands {
+                XCTAssertEqual(command.category, group.category, "\(command.trigger) is filed wrong")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func duplicates(in values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { !seen.insert($0).inserted }
+    }
+}

--- a/ios/Tests/WordBoundaryTests.swift
+++ b/ios/Tests/WordBoundaryTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import KeyJawnKit
+
+/// Word deletion is N backward deletes, so an off-by-one here eats a character of the
+/// previous word or leaves one behind — both of which read as a broken keyboard.
+final class WordBoundaryTests: XCTestCase {
+
+    func testDeletesTheWordBeforeTheCursor() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "hello world"), 5)
+    }
+
+    func testConsumesTrailingSpacesWithTheWord() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "hello world "), 6)
+        XCTAssertEqual(WordBoundary.deleteCount(before: "hello world   "), 8)
+    }
+
+    /// A path is one word. Splitting on the slashes would make word delete useless for
+    /// the thing this keyboard is mostly used to type.
+    func testPathsAreASingleWord() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "cat src/main/App.kt"), 15)
+        XCTAssertEqual(WordBoundary.deleteCount(before: "ls ~/.ssh/config"), 13)
+    }
+
+    func testFlagsAreASingleWord() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "git commit --no-verify"), 11)
+    }
+
+    func testStopsAtALineBreak() {
+        // The word on this line only — the previous line survives.
+        XCTAssertEqual(WordBoundary.deleteCount(before: "first line\nsecond"), 6)
+    }
+
+    /// Sitting on an empty line, the break itself is the next thing to remove, so a
+    /// held backspace keeps making progress instead of stalling.
+    func testRemovesABareLineBreak() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "text\n"), 1)
+    }
+
+    /// Trailing spaces go first, then the break — two steps, not one, so a hold does
+    /// not jump a whole line at once.
+    func testTrailingSpacesAfterABreakGoFirst() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "text\n   "), 3)
+    }
+
+    func testEmptyContextDeletesNothing() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: ""), 0)
+    }
+
+    func testOnlyWhitespace() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "   "), 3)
+        XCTAssertEqual(WordBoundary.deleteCount(before: "\t\t"), 2)
+    }
+
+    func testSingleWord() {
+        XCTAssertEqual(WordBoundary.deleteCount(before: "npm"), 3)
+    }
+
+    /// Never more than there is to delete, whatever the input.
+    func testCountNeverExceedsTheContext() {
+        let samples = [
+            "", " ", "\n", "a", "a ", " a", "\n ", " \n", "a\nb", "--flag=value",
+            "echo \"hello world\"", "cd ..", "\ttabbed", "emoji 🎹 here",
+        ]
+        for sample in samples {
+            let count = WordBoundary.deleteCount(before: sample)
+            XCTAssertGreaterThanOrEqual(count, 0, "negative count for \(sample.debugDescription)")
+            XCTAssertLessThanOrEqual(count, sample.count,
+                                     "over-delete for \(sample.debugDescription)")
+        }
+    }
+
+    /// Repeatedly applying the rule always terminates and always empties the string,
+    /// which is what a user holding backspace on a long prompt is doing.
+    func testRepeatedApplicationDrainsAnyString() {
+        var text = "git commit -m \"fix: the thing\"\nnpm run build -- --watch"
+        var steps = 0
+        while !text.isEmpty {
+            let count = WordBoundary.deleteCount(before: text)
+            XCTAssertGreaterThan(count, 0, "stalled with \(text.debugDescription) remaining")
+            text.removeLast(count)
+            steps += 1
+            XCTAssertLessThan(steps, 200, "did not converge")
+        }
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -52,7 +52,15 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Configuration/KeyJawn.entitlements
         DEVELOPMENT_TEAM: 5624SD289G
         CODE_SIGN_STYLE: Automatic
-        CURRENT_PROJECT_VERSION: 1
+        # THE ONLY PLACE TO BUMP THE BUILD NUMBER.
+        # The Info.plist values below interpolate these, and the keyboard extension
+        # target mirrors them, so both bundles stay in lockstep — App Store Connect
+        # rejects an upload whose extension version does not match the app's.
+        # Previously the plists carried literal "1.0.0"/"1" and won over these
+        # settings, so bumping CURRENT_PROJECT_VERSION as the release checklist
+        # instructed produced a build that still identified as build 1, which the
+        # store rejects as a duplicate.
+        CURRENT_PROJECT_VERSION: 8
         MARKETING_VERSION: "1.0.0"
         TARGETED_DEVICE_FAMILY: "1,2"
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
@@ -62,13 +70,17 @@ targets:
           CODE_SIGN_STYLE: Manual
           CODE_SIGN_IDENTITY: "iPhone Distribution"
           PROVISIONING_PROFILE_SPECIFIER: "KeyJawn AppStore"
+    scheme:
+      testTargets:
+        - KeyJawnKitTests
+      gatherCoverageData: true
     info:
       path: KeyJawn/Info.plist
       properties:
         CFBundleName: KeyJawn
         CFBundleDisplayName: KeyJawn
-        CFBundleShortVersionString: "1.0.0"
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         LSRequiresIPhoneOS: true
         UILaunchScreen:
           UIColorName: LaunchScreenBackground
@@ -113,6 +125,11 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Configuration/KeyJawnKeyboard.entitlements
         DEVELOPMENT_TEAM: 5624SD289G
         CODE_SIGN_STYLE: Automatic
+        # Must match the app target above. The extension had no version settings at
+        # all and hardcoded them in its plist, so it could silently ship a version
+        # that disagreed with the app's — an upload rejection at the last step.
+        CURRENT_PROJECT_VERSION: 8
+        MARKETING_VERSION: "1.0.0"
       configs:
         Release:
           CODE_SIGN_STYLE: Manual
@@ -122,8 +139,8 @@ targets:
       path: KeyJawnKeyboard/Info.plist
       properties:
         CFBundleDisplayName: KeyJawn Keyboard
-        CFBundleShortVersionString: "1.0.0"
-        CFBundleVersion: "1"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
         NSExtension:
           NSExtensionAttributes:
             IsASCIICapable: false
@@ -132,3 +149,28 @@ targets:
             RequestsOpenAccess: true
           NSExtensionPointIdentifier: com.apple.keyboard-service
           NSExtensionPrincipalClass: $(PRODUCT_MODULE_NAME).KeyboardViewController
+
+  # Logic tests for KeyJawnKit. Hosted by the app because the package links UIKit, so
+  # they need a simulator runtime rather than a plain `swift test`.
+  #
+  #   xcodebuild test -project KeyJawn.xcodeproj -scheme KeyJawn \
+  #     -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+  KeyJawnKitTests:
+    type: bundle.unit-test
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: Tests
+    dependencies:
+      - target: KeyJawn
+      - package: KeyJawnKit
+        product: KeyJawnKit
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        PRODUCT_BUNDLE_IDENTIFIER: com.keyjawn.tests
+        GENERATE_INFOPLIST_FILE: true
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/KeyJawn.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/KeyJawn"
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 5624SD289G


### PR DESCRIPTION
A pass over the whole iOS surface. Most of what follows is not new behaviour — it is behaviour the app already advertised and did not have.

> **Not compiled.** This was written in a web session with no Swift toolchain. `xcodebuild test` on the Mac is the first gate, and the new test target doubles as the build check.

## Settings that did nothing

`KeyboardPrefs` read `UserDefaults.standard`, which in an app extension is the *extension's* sandbox, not the app's. Meanwhile the Settings screen wrote `@AppStorage("theme")` and `@AppStorage("hapticEnabled")` into the *app's* sandbox under keys nothing read, plus an autocorrect toggle wired to no code at all. Three controls, zero effect.

Preferences now live in the `group.com.keyjawn` suite both processes can see, with a one-time migration of both legacy key sets. Key feedback is actually implemented — `playInputClick()` in the extension (where impact generators are inert) and an impact generator in the app (where `playInputClick` is). The autocorrect toggle is removed rather than left as decoration, and replaced by a terminal-arrow-keys preference that does something.

## A theme that reached half the keyboard

The number row, the extra row's key labels, and all three overlay panels carried hardcoded dark colours. Picking Light or Terminal recoloured part of the keyboard and left the rest looking like a rendering fault; the extra row's white-on-grey labels measured 3.3:1 on Light. Every surface now resolves from `KeyboardTheme`, which grew panel and extra-row roles, and `KeyboardThemeContrastTests` holds every text/background pairing to 4.5:1.

## Keys that did nothing

| Key | Before | Now |
|---|---|---|
| `^C` | `default: break` | inserts `\u{03}` |
| `▲` `▼` | `default: break` | ANSI `ESC [ A` / `ESC [ B` |
| `#+=` | rebuilt the layer it was already on | opens a second symbols page |
| Ctrl + letter | never reached typed characters | Ctrl+D, Ctrl+Z, Ctrl+L, Ctrl+A/E work |
| hold backspace | nothing; every delete cost a tap | repeats, escalates to word delete |

`#+=` mattered most: `_ | ~ \ { } [ ] < > = + # % ^ *` could not be typed **at all** on a keyboard whose stated purpose is driving a shell. Word delete keeps `src/main/App.kt` and `--no-verify` whole and never crosses a newline. Long-press alternates gained the shell characters too — `-` leads with `_`, `/` offers `\` and `|`, `(`/`)` reach brackets and braces, quotes reach backtick.

## Dead ends

- `HostStore.update` had no caller and `HostEditView` was add-only, so the "host key not verified" alert told users to visit a screen that did not exist. Hosts are editable now (swipe or long-press), the alert names the actual gesture and the `ssh-keyscan` line, and unverified hosts are flagged in the list before you connect rather than only mid-session.
- Without Full Access the App Group is closed to the extension, so the SCP panel reported "No hosts configured" to people who had configured hosts. It names Full Access as the blocker now.
- The app opened onto a terminal tab with no session behind it — a first launch that looks broken. Renamed to Preview, captioned, and no longer the launch tab.
- Retrying a failed SSH connection was a no-op unless the caller happened to call `disconnect()` first.

## Layout

The keyboard was a fixed 322pt in every orientation, which on a landscape phone leaves the app you are typing into as a sliver. Metrics follow device and orientation now; phone portrait is unchanged. The alt-key popup is clamped into the window and flips below the key when there is no room above — the iOS half of #62.

## Security

The Ed25519 private key was mirrored to App Group `UserDefaults` in plaintext. Group container plists are included in device backups, so the key left the device on every backup, undoing the `WhenUnlockedThisDeviceOnly` class deliberately chosen for the Keychain copy. It now crosses as a file with `.completeFileProtectionUntilUserAuthentication` and `isExcludedFromBackup`, migrating and clearing the old value on first read. `SSHKeyStore.syncAppGroupMirror()` reconciles at launch, which also fixes the case where the mirror silently went missing and the extension reported "SSH key not found" with nothing the user could do.

## Release plumbing

`project.yml` hardcoded `CFBundleVersion: "1"` in the generated Info.plist, and a literal there wins over `CURRENT_PROJECT_VERSION`. Bumping the build number **exactly as the release checklist instructs** produced a build still identifying as build 1 — rejected by App Store Connect as a duplicate upload. The keyboard extension had no version settings at all. Both targets interpolate the build settings now, and `CLAUDE.md` says so.

## Tests

There were none for iOS. Adds a simulator-hosted target covering the Ctrl state machine, ANSI sequences, word boundaries, layer shapes and symbol reachability, alt mappings, slash command uniqueness, `HostConfig`'s wire format, prefs defaults and migration, and theme contrast.

```bash
cd ios && xcodebuild test -project KeyJawn.xcodeproj -scheme KeyJawn \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
```

## Also

Deduplicated the slash command list (`/help` and `/clear` each appeared twice with identical descriptions) and grouped it by category, finally using the `Category` field that had sat unread since it was added. Dropped the tool-branded `SlashCommand.claudeCode` / `.gemini` statics for functional names, consistent with the 3.2.2 remediation. VoiceOver labels for every glyph key. SCP filenames that survive two uploads in the same second. Smart quotes and dashes disabled in the terminal input, so a typed `--flag` is not turned into an en dash before it reaches the shell.

## Behaviour changes to flag

- Arrow keys default to sending escape codes. In an ordinary text field left/right no longer move the cursor unless **Settings → Extra row → Terminal arrow keys** is turned off.
- `^C` always inserts a literal control character, in any app.
- The app launches on Hosts, not the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJ6BfPqiw3jufokDfdMcGt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ6BfPqiw3jufokDfdMcGt)_