### PR TITLE
Fix phase-one keyboard haptics

### DIFF
--- a/app/src/main/java/com/keyjawn/BackspaceTouchListener.kt
+++ b/app/src/main/java/com/keyjawn/BackspaceTouchListener.kt
@@ -56,10 +56,6 @@ class BackspaceTouchListener(
             val interval: Long
             if (repeatCount >= wordDeleteAfter) {
                 onDeleteWord()
-                // Word deletes are rare and consequential, so each one gets a
-                // tick; per-character repeats do not, or a long hold turns into
-                // one continuous buzz.
-                onHaptic()
                 interval = wordIntervalMs
             } else {
                 onDeleteChar()

--- a/app/src/main/java/com/keyjawn/ExtraRowManager.kt
+++ b/app/src/main/java/com/keyjawn/ExtraRowManager.kt
@@ -35,7 +35,11 @@ class ExtraRowManager(
     private val onThemeChanged: (() -> Unit)? = null,
     private val currentPackageProvider: (() -> String)? = null,
     private val onAutocorrectChanged: (() -> Unit)? = null,
-    private val onTypingPrefsChanged: (() -> Unit)? = null
+    private val onTypingPrefsChanged: (() -> Unit)? = null,
+    private val haptics: KeyboardHaptics = KeyboardHaptics(
+        view,
+        enabled = { appPrefs?.isHapticEnabled() != false }
+    )
 ) {
 
     val ctrlState = CtrlState()
@@ -165,7 +169,7 @@ class ExtraRowManager(
                 }
                 button.text = AppPrefs.getExtraSlotLabel(config)
                 button.setOnClickListener {
-                    performHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
+                    haptics.key(KeyOutput.KeyCode(keyCode))
                     val ic = inputConnectionProvider() ?: return@setOnClickListener
                     keySender.sendKey(ic, keyCode)
                 }
@@ -177,7 +181,7 @@ class ExtraRowManager(
                 val text = config.removePrefix("text:")
                 button.text = text
                 button.setOnClickListener {
-                    performHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
+                    haptics.key(KeyOutput.Character(text))
                     val ic = inputConnectionProvider() ?: return@setOnClickListener
                     keySender.sendText(ic, text)
                 }
@@ -224,6 +228,7 @@ class ExtraRowManager(
                 onItemSelected = { text ->
                     val ic = inputConnectionProvider() ?: return@ClipboardPanel
                     clipboardHistoryManager.pasteItem(ic, text)
+                    haptics.confirm()
                 },
                 onShowTooltip = { msg -> showTooltip(msg) }
             )
@@ -270,7 +275,7 @@ class ExtraRowManager(
     private fun wireArrow(buttonId: Int, keyCode: Int) {
         val button = view.findViewById<Button>(buttonId)
         val listener = RepeatTouchListener(
-            onPress = { performHaptic(HapticFeedbackConstants.KEYBOARD_TAP) }
+            onPress = { haptics.repeatPress() }
         ) {
             val ic = inputConnectionProvider() ?: return@RepeatTouchListener
             val ctrl = ctrlState.isActive()
@@ -485,16 +490,10 @@ class ExtraRowManager(
         }
     }
 
-    private fun performHaptic(type: Int) {
-        if (appPrefs?.isHapticEnabled() != false) {
-            view.performHapticFeedback(type)
-        }
-    }
-
     private fun updateCtrlAppearance(mode: CtrlMode) {
         // Gated like every other haptic: the toggle claims to govern feedback
         // for the whole keyboard, and Ctrl was the one key still ignoring it.
-        performHaptic(HapticFeedbackConstants.CONTEXT_CLICK)
+        haptics.perform(HapticFeedbackConstants.CONTEXT_CLICK)
         applyCtrlLabel(mode)
         val tm = themeManager
         if (tm != null) {

--- a/app/src/main/java/com/keyjawn/KeyJawnService.kt
+++ b/app/src/main/java/com/keyjawn/KeyJawnService.kt
@@ -62,6 +62,10 @@ class KeyJawnService : InputMethodService() {
 
         val view = LayoutInflater.from(this).inflate(R.layout.keyboard_view, null)
         val tm = themeManager
+        val haptics = KeyboardHaptics(
+            view,
+            enabled = { appPrefs.isHapticEnabled() }
+        )
         // The theme can be changed from SettingsActivity (a separate
         // ThemeManager instance writing the shared pref). The palette is cached,
         // so re-resolve it from prefs before applying colors to pick up a change
@@ -137,7 +141,8 @@ class KeyJawnService : InputMethodService() {
                 // toggle has to invalidate that cache to take effect without a
                 // keyboard restart. No keycap changes, so no re-render.
                 qwertyKeyboard?.refreshTypingPrefs()
-            }
+            },
+            haptics = haptics
         )
         extraRowManager = erm
 
@@ -159,11 +164,22 @@ class KeyJawnService : InputMethodService() {
                     val ic = currentInputConnection ?: return@SlashCommandPopup
                     keySender.sendText(ic, "/")
                 },
-                themeManager = tm
+                themeManager = tm,
+                haptics = haptics
             )
         } else null
 
-        val qwerty = QwertyKeyboard(container, keySender, erm, { currentInputConnection }, appPrefs, slashPopup, tm, keyPreview)
+        val qwerty = QwertyKeyboard(
+            container,
+            keySender,
+            erm,
+            { currentInputConnection },
+            appPrefs,
+            slashPopup,
+            tm,
+            keyPreview,
+            haptics
+        )
         qwerty.setLayer(KeyboardLayouts.LAYER_LOWER)
         qwertyKeyboard = qwerty
 

--- a/app/src/main/java/com/keyjawn/KeyboardHaptics.kt
+++ b/app/src/main/java/com/keyjawn/KeyboardHaptics.kt
@@ -1,0 +1,47 @@
+package com.keyjawn
+
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import android.view.View
+
+/**
+ * Maps keyboard interactions to platform haptic semantics.
+ *
+ * The enabled callback is evaluated for every event so preference changes take
+ * effect without rebuilding the input view.
+ */
+class KeyboardHaptics(
+    private val view: View,
+    private val enabled: () -> Boolean,
+    private val sdkInt: Int = Build.VERSION.SDK_INT
+) {
+
+    fun key(output: KeyOutput) {
+        val type = if (output is KeyOutput.Enter && sdkInt >= Build.VERSION_CODES.R) {
+            HapticFeedbackConstants.CONFIRM
+        } else {
+            HapticFeedbackConstants.KEYBOARD_TAP
+        }
+        perform(type)
+    }
+
+    fun repeatPress() {
+        perform(
+            HapticFeedbackConstants.KEYBOARD_TAP,
+            HapticFeedbackConstants.FLAG_IGNORE_VIEW_SETTING
+        )
+    }
+
+    fun confirm() {
+        perform(HapticFeedbackConstants.CONTEXT_CLICK)
+    }
+
+    fun perform(type: Int, flags: Int = 0) {
+        if (!enabled()) return
+        if (flags == 0) {
+            view.performHapticFeedback(type)
+        } else {
+            view.performHapticFeedback(type, flags)
+        }
+    }
+}

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -595,6 +595,7 @@ class QwertyKeyboard(
                                 if (currentAlts.size == 1) {
                                     val ic = inputConnectionProvider() ?: return@Runnable
                                     keySender.sendText(ic, currentAlts[0])
+                                    haptics.confirm()
                                 } else {
                                     // Open the slide popup and capture the anchor's
                                     // screen position so MOVE can convert key-local

--- a/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
+++ b/app/src/main/java/com/keyjawn/QwertyKeyboard.kt
@@ -1,7 +1,6 @@
 package com.keyjawn
 
 import android.graphics.Typeface
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.text.InputType
@@ -32,7 +31,11 @@ class QwertyKeyboard(
     private val appPrefs: AppPrefs? = null,
     private val slashPopup: SlashCommandPopup? = null,
     private val themeManager: ThemeManager? = null,
-    private val keyPreview: KeyPreview? = null
+    private val keyPreview: KeyPreview? = null,
+    private val haptics: KeyboardHaptics = KeyboardHaptics(
+        container,
+        enabled = { appPrefs?.isHapticEnabled() != false }
+    )
 ) {
 
     private val altKeyPopup = AltKeyPopup(keySender, inputConnectionProvider, themeManager)
@@ -337,7 +340,7 @@ class QwertyKeyboard(
                         true
                     }
                 }
-                if (handled) performHaptic(HapticFeedbackConstants.LONG_PRESS)
+                if (handled) haptics.perform(HapticFeedbackConstants.LONG_PRESS)
                 handled
             })
         }
@@ -462,7 +465,7 @@ class QwertyKeyboard(
                                 }
                             }
                         },
-                        onHaptic = { performHaptic() }
+                        onHaptic = { haptics.repeatPress() }
                     )
                 )
             }
@@ -759,7 +762,10 @@ class QwertyKeyboard(
             null
         }
         if (selected != null) {
-            inputConnectionProvider()?.let { ic -> keySender.sendText(ic, selected) }
+            inputConnectionProvider()?.let { ic ->
+                keySender.sendText(ic, selected)
+                haptics.confirm()
+            }
         }
         session.dismiss()
         if (currentSlideSession === session) currentSlideSession = null
@@ -771,20 +777,8 @@ class QwertyKeyboard(
         if (currentSlideSession === session) currentSlideSession = null
     }
 
-    private fun performHaptic(type: Int = HapticFeedbackConstants.KEYBOARD_TAP) {
-        if (appPrefs?.isHapticEnabled() != false) {
-            container.performHapticFeedback(type)
-        }
-    }
-
     private fun handleKeyPress(key: Key) {
-        // Determine haptic type based on key output (item 6)
-        val hapticType = when (key.output) {
-            is KeyOutput.Enter -> if (Build.VERSION.SDK_INT >= 27)
-                HapticFeedbackConstants.KEYBOARD_PRESS else HapticFeedbackConstants.KEYBOARD_TAP
-            else -> HapticFeedbackConstants.KEYBOARD_TAP
-        }
-        performHaptic(hapticType)
+        haptics.key(key.output)
 
         // Reset double-tap space tracking for any non-space key (item 3)
         if (key.output !is KeyOutput.Space) {
@@ -882,7 +876,7 @@ class QwertyKeyboard(
     }
 
     private fun handleShiftTap() {
-        performHaptic(HapticFeedbackConstants.CLOCK_TICK)
+        haptics.perform(HapticFeedbackConstants.CLOCK_TICK)
         val now = System.currentTimeMillis()
         val timeSinceLastTap = now - lastShiftTapTime
         lastShiftTapTime = now

--- a/app/src/main/java/com/keyjawn/SlashCommandPopup.kt
+++ b/app/src/main/java/com/keyjawn/SlashCommandPopup.kt
@@ -14,7 +14,8 @@ class SlashCommandPopup(
     private val registry: SlashCommandRegistry,
     private val onCommandSelected: (String) -> Unit,
     private val onDismissedEmpty: () -> Unit,
-    private val themeManager: ThemeManager? = null
+    private val themeManager: ThemeManager? = null,
+    private val haptics: KeyboardHaptics? = null
 ) {
 
     private var popup: PopupWindow? = null
@@ -38,6 +39,7 @@ class SlashCommandPopup(
             item.setOnClickListener {
                 registry.recordUsage(command)
                 onCommandSelected(command)
+                haptics?.confirm()
                 dismiss()
             }
             commandList.addView(item)

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -322,6 +322,7 @@ class AltKeySlideTest {
 
         assertNull("single-alt key opens no slide popup", keyboard.currentSlideSession)
         verify(keySender).sendText(any(), eq(alts[0]))
+        verify(haptics).confirm()
     }
 
     @Test

--- a/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
+++ b/app/src/test/java/com/keyjawn/AltKeySlideTest.kt
@@ -31,6 +31,7 @@ class AltKeySlideTest {
     private lateinit var extraRowManager: ExtraRowManager
     private lateinit var ic: InputConnection
     private lateinit var keyboard: QwertyKeyboard
+    private lateinit var haptics: KeyboardHaptics
     private lateinit var activityController: ActivityController<Activity>
 
     @Before
@@ -49,6 +50,7 @@ class AltKeySlideTest {
         addExtraRowButtons(extraRowView, context)
         val parentView = LinearLayout(context).apply { addView(extraRowView) }
         extraRowManager = ExtraRowManager(parentView, keySender, { ic })
+        haptics = mock()
 
         val root = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
@@ -58,7 +60,13 @@ class AltKeySlideTest {
         activityController = Robolectric.buildActivity(Activity::class.java).setup()
         activityController.get().setContentView(root)
 
-        keyboard = QwertyKeyboard(container, keySender, extraRowManager, { ic })
+        keyboard = QwertyKeyboard(
+            container,
+            keySender,
+            extraRowManager,
+            { ic },
+            haptics = haptics
+        )
         keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
 
         // Robolectric does not lay out the view tree automatically, so key views
@@ -174,6 +182,7 @@ class AltKeySlideTest {
         val session = keyboard.currentSlideSession
         assertNotNull("long-press on a multi-alt key opens a slide session", session)
         assertTrue(session!!.isShowing())
+        clearInvocations(haptics)
 
         val rect1 = session.candidateRectsForTest()[1]
         val moveX = localXForCandidate(aButton, rect1)
@@ -189,6 +198,7 @@ class AltKeySlideTest {
         up.recycle()
 
         verify(keySender).sendText(any(), eq(alts[1]))
+        verify(haptics).confirm()
         assertFalse("popup dismissed after release", session.isShowing())
         assertNull(keyboard.currentSlideSession)
     }

--- a/app/src/test/java/com/keyjawn/BackspaceTouchListenerTest.kt
+++ b/app/src/test/java/com/keyjawn/BackspaceTouchListenerTest.kt
@@ -33,6 +33,7 @@ class BackspaceTouchListenerTest {
 
     private fun listener(
         counts: Counts,
+        onHaptic: () -> Unit = {},
         initialDelayMs: Long = 100,
         repeatIntervalMs: Long = 50,
         fastIntervalMs: Long = 50,
@@ -42,6 +43,7 @@ class BackspaceTouchListenerTest {
     ) = BackspaceTouchListener(
         onDeleteChar = { counts.chars++ },
         onDeleteWord = { counts.words++ },
+        onHaptic = onHaptic,
         initialDelayMs = initialDelayMs,
         repeatIntervalMs = repeatIntervalMs,
         fastIntervalMs = fastIntervalMs,
@@ -98,6 +100,25 @@ class BackspaceTouchListenerTest {
         assertEquals(2, counts.words)
         // The character gear stopped once the word gear took over.
         assertEquals(3, counts.chars)
+
+        l.onTouch(v, event(MotionEvent.ACTION_UP))
+    }
+
+    @Test
+    fun `a held delete haptics once even after word repeat starts`() {
+        val counts = Counts()
+        var haptics = 0
+        val l = listener(counts, onHaptic = { haptics++ })
+        val v = makeView()
+
+        l.onTouch(v, event(MotionEvent.ACTION_DOWN))
+        idle(100) // repeat 1
+        idle(50)  // repeat 2
+        idle(50)  // repeat 3: first word delete
+        idle(50)  // repeat 4: second word delete
+
+        assertEquals(2, counts.words)
+        assertEquals(1, haptics)
 
         l.onTouch(v, event(MotionEvent.ACTION_UP))
     }

--- a/app/src/test/java/com/keyjawn/ExtraRowManagerTest.kt
+++ b/app/src/test/java/com/keyjawn/ExtraRowManagerTest.kt
@@ -21,6 +21,7 @@ class ExtraRowManagerTest {
     private lateinit var keySender: KeySender
     private lateinit var mockIc: InputConnection
     private lateinit var erm: ExtraRowManager
+    private lateinit var haptics: KeyboardHaptics
 
     @Before
     fun setUp() {
@@ -29,10 +30,12 @@ class ExtraRowManagerTest {
         keySender = KeySender()
         mockIc = mock()
         whenever(mockIc.sendKeyEvent(any())).thenReturn(true)
+        haptics = mock()
         erm = ExtraRowManager(
             view = view,
             keySender = keySender,
-            inputConnectionProvider = { mockIc }
+            inputConnectionProvider = { mockIc },
+            haptics = haptics
         )
     }
 
@@ -137,6 +140,63 @@ class ExtraRowManagerTest {
         val captor = argumentCaptor<KeyEvent>()
         verify(ic, atLeast(1)).sendKeyEvent(captor.capture())
         assertTrue(captor.allValues.any { it.keyCode == KeyEvent.KEYCODE_TAB })
+    }
+
+    @Test
+    fun `arrow press uses repeat context haptic flags`() {
+        val context = RuntimeEnvironment.getApplication()
+        val view = LayoutInflater.from(context).inflate(R.layout.keyboard_view, null)
+        val localHaptics: KeyboardHaptics = mock()
+        val ic: InputConnection = mock()
+        whenever(ic.sendKeyEvent(any())).thenReturn(true)
+        ExtraRowManager(
+            view = view,
+            keySender = KeySender(),
+            inputConnectionProvider = { ic },
+            haptics = localHaptics
+        )
+        val left = view.findViewById<View>(R.id.key_left)
+        val down = android.view.MotionEvent.obtain(
+            0, 0, android.view.MotionEvent.ACTION_DOWN, 0f, 0f, 0
+        )
+        val up = android.view.MotionEvent.obtain(
+            0, 0, android.view.MotionEvent.ACTION_UP, 0f, 0f, 0
+        )
+
+        left.dispatchTouchEvent(down)
+        left.dispatchTouchEvent(up)
+
+        verify(localHaptics).repeatPress()
+        down.recycle()
+        up.recycle()
+    }
+
+    @Test
+    fun `clipboard item selection fires one confirm style haptic`() {
+        val context = RuntimeEnvironment.getApplication()
+        val view = LayoutInflater.from(context).inflate(R.layout.keyboard_view, null)
+        val history = ClipboardHistoryManager(context)
+        history.addToHistory("copy me")
+        val localHaptics: KeyboardHaptics = mock()
+        val ic: InputConnection = mock()
+        val panel = view.findViewById<android.widget.ScrollView>(R.id.clipboard_panel)
+        val list = view.findViewById<android.widget.LinearLayout>(R.id.clipboard_list)
+        ExtraRowManager(
+            view = view,
+            keySender = KeySender(),
+            inputConnectionProvider = { ic },
+            clipboardHistoryManager = history,
+            clipboardPanelView = panel,
+            clipboardListView = list,
+            haptics = localHaptics
+        )
+
+        view.findViewById<View>(R.id.key_clipboard).performClick()
+        list.getChildAt(1).performClick() // index 0 is the flexible spacer
+
+        verify(localHaptics).confirm()
+        verify(ic).commitText("copy me", 1)
+        history.destroy()
     }
 
     // --- Critical tooltips bypass the tooltips-disabled preference (Codex 5.4 finding) ---

--- a/app/src/test/java/com/keyjawn/KeyboardHapticsTest.kt
+++ b/app/src/test/java/com/keyjawn/KeyboardHapticsTest.kt
@@ -1,0 +1,101 @@
+package com.keyjawn
+
+import android.content.Context
+import android.view.HapticFeedbackConstants
+import android.view.View
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class KeyboardHapticsTest {
+
+    private data class Event(val type: Int, val flags: Int)
+
+    private class RecordingView(context: Context) : View(context) {
+        val events = mutableListOf<Event>()
+
+        override fun performHapticFeedback(feedbackConstant: Int): Boolean {
+            events += Event(feedbackConstant, 0)
+            return true
+        }
+
+        override fun performHapticFeedback(feedbackConstant: Int, flags: Int): Boolean {
+            events += Event(feedbackConstant, flags)
+            return true
+        }
+    }
+
+    @Test
+    fun `enter uses confirm while a character stays keyboard tap`() {
+        val view = RecordingView(RuntimeEnvironment.getApplication())
+        val haptics = KeyboardHaptics(view, enabled = { true }, sdkInt = 33)
+
+        haptics.key(KeyOutput.Character("a"))
+        haptics.key(KeyOutput.Enter)
+
+        assertEquals(
+            listOf(
+                Event(HapticFeedbackConstants.KEYBOARD_TAP, 0),
+                Event(HapticFeedbackConstants.CONFIRM, 0)
+            ),
+            view.events
+        )
+    }
+
+    @Test
+    fun `enter falls back to keyboard tap below api 30`() {
+        val view = RecordingView(RuntimeEnvironment.getApplication())
+        val haptics = KeyboardHaptics(view, enabled = { true }, sdkInt = 29)
+
+        haptics.key(KeyOutput.Enter)
+
+        assertEquals(listOf(Event(HapticFeedbackConstants.KEYBOARD_TAP, 0)), view.events)
+    }
+
+    @Test
+    fun `repeat press ignores only the view setting`() {
+        val view = RecordingView(RuntimeEnvironment.getApplication())
+        val haptics = KeyboardHaptics(view, enabled = { true }, sdkInt = 33)
+
+        haptics.repeatPress()
+
+        assertEquals(
+            listOf(
+                Event(
+                    HapticFeedbackConstants.KEYBOARD_TAP,
+                    HapticFeedbackConstants.FLAG_IGNORE_VIEW_SETTING
+                )
+            ),
+            view.events
+        )
+    }
+
+    @Test
+    fun `confirm style pick uses context click`() {
+        val view = RecordingView(RuntimeEnvironment.getApplication())
+        val haptics = KeyboardHaptics(view, enabled = { true }, sdkInt = 33)
+
+        haptics.confirm()
+
+        assertEquals(listOf(Event(HapticFeedbackConstants.CONTEXT_CLICK, 0)), view.events)
+    }
+
+    @Test
+    fun `disabled haptics suppress every semantic event`() {
+        val view = RecordingView(RuntimeEnvironment.getApplication())
+        val haptics = KeyboardHaptics(view, enabled = { false }, sdkInt = 33)
+
+        haptics.key(KeyOutput.Enter)
+        haptics.repeatPress()
+        haptics.confirm()
+        haptics.perform(HapticFeedbackConstants.LONG_PRESS)
+
+        assertTrue(view.events.isEmpty())
+    }
+}

--- a/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
+++ b/app/src/test/java/com/keyjawn/QwertyKeyboardTest.kt
@@ -34,6 +34,7 @@ class QwertyKeyboardTest {
     private lateinit var extraRowManager: ExtraRowManager
     private lateinit var ic: InputConnection
     private lateinit var keyboard: QwertyKeyboard
+    private lateinit var haptics: KeyboardHaptics
     private lateinit var activityController: ActivityController<Activity>
 
     @Before
@@ -56,6 +57,7 @@ class QwertyKeyboardTest {
             addView(extraRowView)
         }
         extraRowManager = ExtraRowManager(parentView, keySender, { ic })
+        haptics = mock()
 
         // Host the keyboard container in an attached Activity window so the
         // one-shot shift reset and auto-capitalize relabel -- which the keyboard
@@ -71,7 +73,13 @@ class QwertyKeyboardTest {
         activityController = Robolectric.buildActivity(Activity::class.java).setup()
         activityController.get().setContentView(root)
 
-        keyboard = QwertyKeyboard(container, keySender, extraRowManager, { ic })
+        keyboard = QwertyKeyboard(
+            container,
+            keySender,
+            extraRowManager,
+            { ic },
+            haptics = haptics
+        )
         keyboard.setLayer(KeyboardLayouts.LAYER_LOWER)
     }
 
@@ -125,6 +133,32 @@ class QwertyKeyboardTest {
     private fun charButtonAt(rowIndex: Int, colIndex: Int): Button {
         val row = container.getChildAt(rowIndex) as LinearLayout
         return findButton(row.getChildAt(colIndex))
+    }
+
+    @Test
+    fun `enter dispatches the semantic enter haptic`() {
+        val row = container.getChildAt(3) as LinearLayout
+        val enter = findButton(row.getChildAt(4))
+
+        enter.performClick()
+
+        verify(haptics).key(KeyOutput.Enter)
+    }
+
+    @Test
+    fun `backspace press uses repeat context haptic flags`() {
+        val row = container.getChildAt(2) as LinearLayout
+        val backspace = findButton(row.getChildAt(row.childCount - 1))
+        val now = SystemClock.uptimeMillis()
+        val down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, 0f, 0f, 0)
+        val up = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, 0f, 0f, 0)
+
+        backspace.dispatchTouchEvent(down)
+        backspace.dispatchTouchEvent(up)
+
+        verify(haptics).repeatPress()
+        down.recycle()
+        up.recycle()
     }
 
     @Test

--- a/app/src/test/java/com/keyjawn/SlashCommandPopupTest.kt
+++ b/app/src/test/java/com/keyjawn/SlashCommandPopupTest.kt
@@ -17,6 +17,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.android.controller.ActivityController
 import org.robolectric.annotation.Config
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33])
@@ -63,6 +65,25 @@ class SlashCommandPopupTest {
     fun `popup colors background and item text from the light theme tokens`() {
         themeManager.currentTheme = KeyboardTheme.LIGHT
         assertPopupThemed(KeyboardTheme.LIGHT)
+    }
+
+    @Test
+    fun `selecting a command fires one confirm style haptic`() {
+        val haptics: KeyboardHaptics = mock()
+        val popup = SlashCommandPopup(
+            registry = registry,
+            onCommandSelected = {},
+            onDismissedEmpty = {},
+            themeManager = themeManager,
+            haptics = haptics
+        )
+        popup.show(anchor)
+        val content = popupWindowField(popup).contentView as ScrollView
+        val list = content.findViewById<LinearLayout>(R.id.command_list)
+
+        list.getChildAt(0).performClick()
+
+        verify(haptics).confirm()
     }
 
     private fun assertPopupThemed(theme: KeyboardTheme) {


### PR DESCRIPTION
## What changed

- route Android keyboard feedback through one semantic `KeyboardHaptics` dispatcher
- give Enter a distinct guarded `CONFIRM` feedback on API 30+, with `KEYBOARD_TAP` fallback
- make backspace and arrow holds emit one initial tick and stay silent through repeat acceleration
- acknowledge successful slash-command, clipboard, and alt-key selections with confirm-style feedback
- keep every event behind the live haptics preference and on `performHapticFeedback`

## Why

The previous Enter branch mapped to the same platform value as a normal key, held backspace could vibrate on every accelerated repeat tick, arrow behavior was asymmetric, and successful picker commits had no acknowledgement.

This removes those defects without adding a vibrator permission, constructing custom vibration effects, or expanding into the later per-event haptics phases.

## User impact

Enter and successful picks now feel distinct, held deletion no longer becomes a continuous buzz, and arrow/backspace holds follow the same feedback rule. Disabling haptics continues to suppress all of these events.

## Validation

- `./gradlew testFullDebugUnitTest` — 436 tests passed
- `./gradlew testLiteDebugUnitTest`
- `./gradlew lintFullDebug lintLiteDebug`
- `./gradlew assembleDebug`
- local Codex 5.5 low review — clean
- local Codex 5.6-sol xhigh review — clean; independently reran both flavor test suites and lint

Closes #54

Refs #26