### PR TITLE
Terminate worker subprocess trees

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,29 @@ on:
     branches: [main]
 
 jobs:
+  worker-tests:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: worker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: worker/pyproject.toml
+
+      - name: Install worker test dependencies
+        run: python -m pip install -e '.[dev]'
+
+      - name: Run worker tests
+        run: python -m pytest tests/ -q
+
   build:
     runs-on: ubuntu-latest
 

--- a/docs/handoffs/2026-07-25-two-milestone-release.md
+++ b/docs/handoffs/2026-07-25-two-milestone-release.md
@@ -1,0 +1,107 @@
+# Two-milestone release handoff
+
+Last updated from landofjawn on 2026-07-25.
+
+No pull request has been merged and no release has been built or deployed. Joe
+has not given explicit approval for any pull request listed here. Approval must
+name the specific pull request; this handoff is not merge approval.
+
+## Release scope
+
+Milestone 1 covers reliability and security:
+
+- #28: replace the Android QWERTY grid with one custom view
+- #54: phase-one keyboard haptics
+- #64: worker subprocess cleanup
+- #67: iOS SSH host-key trust
+- #68: shared iOS Keychain identity
+
+Milestone 2 covers interaction foundations:
+
+- #51: per-app Send slot
+- #52: keyboard-wide touch trace
+- #53: offline voice recognition
+- #55: macro model and store
+
+Keep roadmap parents #23 through #27 open as umbrellas. Update their progress
+when child work ships.
+
+## Published pull requests
+
+| Issue | Pull request | Branch | State and remaining gate |
+|---|---|---|---|
+| #54 | [#69](https://github.com/jamditis/keyjawn/pull/69) | `fix/54-haptics-phase-1` | Review fix pushed and its thread resolved. Recheck CI, then obtain Joe's approval. |
+| #64 | [#70](https://github.com/jamditis/keyjawn/pull/70) | `fix/64-worker-subprocess-cleanup` | Worker suite and Ruff pass. Recheck CI and review-thread resolution, then obtain Joe's approval. |
+| #67 | [#71](https://github.com/jamditis/keyjawn/pull/71) | `fix/67-ios-tofu` | Run Xcode tests and a signed build on macOS, verify trust flows, then obtain Joe's approval. |
+| #68 | [#72](https://github.com/jamditis/keyjawn/pull/72) | `fix/68-shared-keychain` | Enable the shared Keychain capability, regenerate profiles, verify signed entitlements and an upgrade, then obtain Joe's approval. |
+| #28 | [#73](https://github.com/jamditis/keyjawn/pull/73) | `fix/28-qwerty-custom-view` | Run the instrumentation touch-path test on a device or emulator, then obtain Joe's approval. |
+| #55 | [#74](https://github.com/jamditis/keyjawn/pull/74) | `fix/55-macro-store` | Obtain Joe's approval. |
+| #51 | [#75](https://github.com/jamditis/keyjawn/pull/75) | `fix/51-send-slot` | Hand-test one terminal or SSH app and one chat app, then obtain Joe's approval. |
+| #53 | [#76](https://github.com/jamditis/keyjawn/pull/76) | `fix/53-offline-voice` | Hand-test API 33 or later with installed and missing offline models, then obtain Joe's approval. |
+| #52 | [#77](https://github.com/jamditis/keyjawn/pull/77) | `fix/52-glide-trace` | Stacked on #73. Hand-test trace and existing gestures, merge #73 first, retarget to `main`, run CI, then obtain Joe's approval. |
+
+PRs #71 through #77 are drafts. PRs #69 and #70 are open for review. Do not
+mark a draft ready until its listed platform gate passes.
+
+## PR #70 verification note
+
+The final review cycle addressed six inline findings plus three local
+high-depth findings:
+
+- preserve output when supervisor status and communication complete together
+- survive repeated cancellation during spawn and cleanup
+- bound root-status reader shutdown
+- kill and reap timed-out Windows `taskkill` helpers
+- terminate descendants when supervisor status fails
+- restore `SIGPIPE` and `SIGXFSZ` before Linux `exec`
+- stop a shared status reader without failing shutdown or active waiters
+- use `poll()` for descriptors above `FD_SETSIZE`
+- avoid importing the Linux supervisor during Windows test collection
+
+Verification after the final fixes:
+
+```text
+worker tests: 170 passed, 215 warnings
+Ruff: all checks passed
+```
+
+Four local review passes were used, which is the configured cap. The fourth
+pass found the final three items above; they were fixed test-first and the full
+suite was rerun. No fifth review pass was started.
+
+## External and hardware gates
+
+- `adb devices -l` found no connected Android device on landofjawn.
+- The Android SDK used in this session is
+  `/home/jamditis/.cache/keyjawn-android-sdk`.
+- This Linux host has no Xcode or Swift toolchain for the iOS builds.
+- The available App Store Connect key returned HTTP 403 for provisioning
+  resources. No Apple capability or profile mutation was attempted.
+- PR #77 has no pull-request workflow run while its base is
+  `fix/28-qwerty-custom-view`; the workflow watches `main`. Its full local
+  Android unit, lint, APK, and instrumentation-APK build matrix passed.
+
+## Restart checklist
+
+1. Fetch the nine PR heads and recheck current CI, draft state, approvals, and
+   unresolved review conversations. Leave any unverified conversation open.
+2. Complete the Android device gates for #73, #75, #76, and #77.
+3. Complete the macOS signing, test, entitlement, migration, and trust gates
+   for #71 and #72.
+4. Ask Joe for explicit approval of each specific PR only after its gates pass.
+5. Merge approved milestone 1 PRs. Merge #73 before retargeting #77 to `main`.
+6. After all milestone 1 changes are merged, update versions, release notes,
+   and `SOCIAL.md`; build and sign both Android flavors; publish lite to the
+   GitHub release and Google Play internal track; publish full through R2 and
+   the store flow; notify purchasers only after download verification; upload
+   applicable iOS changes to TestFlight after signed-build verification.
+7. Verify production health and retain the prior artifacts and deployment as
+   rollback points.
+8. Repeat the release process after all milestone 2 changes are merged, then
+   update roadmap-parent progress.
+
+## Local recovery note
+
+`stash@{0}` is an intentionally preserved, rejected Option B experiment for
+#28 from branch `fix/28-qwerty-grid-reuse`. Do not pop or delete it as part of
+normal release work.

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -16,5 +16,5 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
-    "pytest-asyncio>=0.24.0",
+    "pytest-asyncio>=0.24.0,<1.0",
 ]

--- a/worker/tests/test_runner_shutdown.py
+++ b/worker/tests/test_runner_shutdown.py
@@ -1,0 +1,39 @@
+"""Worker shutdown tests."""
+
+import signal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from worker.main import _install_shutdown_handlers
+from worker.runner import WorkerRunner
+
+
+@pytest.mark.asyncio
+async def test_runner_shutdown_reaps_owned_subprocesses() -> None:
+    runner = WorkerRunner.__new__(WorkerRunner)
+    runner.subprocesses = AsyncMock()
+    runner._redis_sub = None
+    runner.db = None
+
+    await runner.stop()
+
+    runner.subprocesses.shutdown.assert_awaited_once_with()
+
+
+def test_systemd_sigterm_requests_async_shutdown() -> None:
+    callbacks = {}
+
+    class RecordingLoop:
+        def add_signal_handler(self, signum, callback):
+            callbacks[signum] = callback
+
+    shutdown_requested = MagicMock()
+
+    installed = _install_shutdown_handlers(
+        RecordingLoop(),
+        shutdown_requested,
+    )
+
+    assert signal.SIGTERM in installed
+    callbacks[signal.SIGTERM]()
+    shutdown_requested.set.assert_called_once_with()

--- a/worker/tests/test_subprocesses.py
+++ b/worker/tests/test_subprocesses.py
@@ -9,6 +9,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -38,6 +39,170 @@ async def test_input_bytes_reach_the_child_process() -> None:
 
     assert result.returncode == 0
     assert result.stdout == b"curation prompt"
+
+
+async def test_completed_linux_supervisor_output_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def completed(value):
+        return value
+
+    communication = asyncio.create_task(completed((b"stdout", b"stderr")))
+    root_status = asyncio.create_task(completed(0))
+    await asyncio.gather(communication, root_status)
+    entry = _ProcessEntry(
+        process=SimpleNamespace(pid=4321, returncode=0),
+        communication=communication,
+        root_status=root_status,
+    )
+    owner = SubprocessOwner(platform="linux")
+    monkeypatch.setattr(
+        owner,
+        "_spawn_and_register",
+        AsyncMock(return_value=entry),
+    )
+    monkeypatch.setattr(owner, "_tree_is_alive", lambda _entry: False)
+
+    result = await owner._run(
+        AsyncMock(),
+        "fake-command",
+        timeout=1,
+        input=None,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == b"stdout"
+    assert result.stderr == b"stderr"
+
+
+async def test_forced_cleanup_bounds_unresponsive_root_status() -> None:
+    blocker = asyncio.Event()
+    communication = asyncio.create_task(
+        asyncio.sleep(0, result=(b"", b""))
+    )
+    await communication
+    root_status = asyncio.create_task(blocker.wait())
+    entry = _ProcessEntry(
+        process=SimpleNamespace(pid=4321, returncode=0),
+        communication=communication,
+        root_status=root_status,
+    )
+    owner = SubprocessOwner(grace_period=0.01, force_wait=0.02)
+    owner._entries[4321] = entry
+
+    await asyncio.wait_for(owner._release_entry(entry), timeout=0.2)
+
+    assert root_status.done()
+    assert owner.active_count == 0
+
+
+async def test_release_stops_status_reader_without_failing_waiters() -> None:
+    status_read_fd, status_write_fd = os.pipe()
+    stop = threading.Event()
+    owner = SubprocessOwner(grace_period=0.01, force_wait=0.2)
+    communication = asyncio.create_task(asyncio.sleep(0, result=(b"", b"")))
+    await communication
+    root_status = asyncio.create_task(
+        asyncio.to_thread(
+            owner._read_root_status,
+            status_read_fd,
+            stop,
+        )
+    )
+    entry = _ProcessEntry(
+        process=SimpleNamespace(pid=4321, returncode=-signal.SIGTERM),
+        communication=communication,
+        root_status=root_status,
+        root_status_stop=stop,
+    )
+    owner._entries[4321] = entry
+
+    try:
+        await asyncio.wait_for(owner._release_entry(entry), timeout=0.5)
+        assert await root_status is None
+        assert owner.active_count == 0
+    finally:
+        os.close(status_write_fd)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux descriptors above FD_SETSIZE",
+)
+async def test_status_reader_accepts_high_numbered_file_descriptor() -> None:
+    import resource
+
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
+    status_read_fd, status_write_fd = os.pipe()
+    high_fd = 2048
+    resource.setrlimit(
+        resource.RLIMIT_NOFILE,
+        (max(soft_limit, high_fd + 1), hard_limit),
+    )
+    try:
+        os.dup2(status_read_fd, high_fd)
+        os.close(status_read_fd)
+        os.write(status_write_fd, b"0\n")
+        os.close(status_write_fd)
+
+        assert SubprocessOwner._read_root_status(high_fd) == 0
+    finally:
+        resource.setrlimit(
+            resource.RLIMIT_NOFILE,
+            (soft_limit, hard_limit),
+        )
+
+
+async def test_supervisor_status_failure_cleans_up_the_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_status() -> int:
+        raise RuntimeError("subprocess supervisor exited without root status")
+
+    communication_blocker = asyncio.Event()
+
+    async def communicate() -> tuple[bytes, bytes]:
+        await communication_blocker.wait()
+        return b"", b""
+
+    communication = asyncio.create_task(communicate())
+    root_status = asyncio.create_task(fail_status())
+    entry = _ProcessEntry(
+        process=SimpleNamespace(pid=4321, returncode=None),
+        communication=communication,
+        root_status=root_status,
+    )
+    owner = SubprocessOwner(
+        platform="linux",
+        grace_period=0.01,
+        force_wait=0.02,
+    )
+
+    async def register(*_args, **_kwargs):
+        owner._entries[4321] = entry
+        return entry
+
+    monkeypatch.setattr(owner, "_spawn_and_register", register)
+    monkeypatch.setattr(owner, "_tree_is_alive", lambda _entry: True)
+    owner._signal_tree = AsyncMock()
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="subprocess supervisor exited without root status",
+        ):
+            await owner._run(
+                AsyncMock(),
+                "fake-command",
+                timeout=1,
+                input=None,
+            )
+        assert owner._signal_tree.await_count == 2
+        assert communication.done()
+        assert owner.active_count == 0
+    finally:
+        communication.cancel()
+        await asyncio.gather(communication, return_exceptions=True)
 
 
 def _is_running(pid: int) -> bool:
@@ -295,7 +460,7 @@ async def test_cancellation_stops_child_and_grandchild(tmp_path: Path) -> None:
     not sys.platform.startswith("linux"),
     reason="Linux subreaper integration test",
 )
-async def test_cancellation_waits_for_spawn_registration(
+async def test_repeated_cancellation_waits_for_spawn_registration(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -323,6 +488,8 @@ async def test_cancellation_waits_for_spawn_registration(
     await spawned.wait()
     pids = await _wait_for_file(pid_file)
 
+    run_task.cancel()
+    await asyncio.sleep(0)
     run_task.cancel()
     release_spawn.set()
 
@@ -568,3 +735,84 @@ async def test_windows_job_setup_failure_has_bounded_cleanup() -> None:
             ),
             timeout=0.5,
         )
+
+
+async def test_timed_out_taskkill_helper_is_killed_and_reaped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stopped = asyncio.Event()
+
+    class FakeHelper:
+        returncode = None
+        killed = False
+
+        async def communicate(self):
+            await stopped.wait()
+            self.returncode = -9
+            return b"", b""
+
+        def kill(self) -> None:
+            self.killed = True
+            stopped.set()
+
+    class FakeTarget:
+        pid = 4321
+        returncode = None
+        terminated = False
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.terminated = True
+
+    helper = FakeHelper()
+
+    async def spawn_helper(*_args, **_kwargs):
+        return helper
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn_helper)
+    owner = SubprocessOwner(
+        platform="win32",
+        grace_period=0.01,
+        force_wait=0.05,
+    )
+    target = FakeTarget()
+
+    await owner._signal_windows_tree(target, force=False)
+
+    assert helper.killed is True
+    assert stopped.is_set()
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subprocess supervisor",
+)
+async def test_supervisor_restores_python_ignored_signals_before_exec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from worker import subprocess_supervisor
+
+    restored: list[tuple[int, object]] = []
+
+    class ExecCalled(BaseException):
+        pass
+
+    monkeypatch.setattr(
+        subprocess_supervisor.signal,
+        "signal",
+        lambda signum, handler: restored.append((signum, handler)),
+    )
+    monkeypatch.setattr(subprocess_supervisor.os, "close", lambda _fd: None)
+    monkeypatch.setattr(
+        subprocess_supervisor.os,
+        "execvp",
+        lambda *_args: (_ for _ in ()).throw(ExecCalled()),
+    )
+
+    with pytest.raises(ExecCalled):
+        subprocess_supervisor._exec_child("exec", ("fake-command",), 9)
+
+    assert (signal.SIGPIPE, signal.SIG_DFL) in restored
+    assert (signal.SIGXFSZ, signal.SIG_DFL) in restored

--- a/worker/tests/test_subprocesses.py
+++ b/worker/tests/test_subprocesses.py
@@ -95,19 +95,24 @@ def _tree_script(pid_file: Path, ignore_term: bool = False) -> str:
 
 def _stubborn_redirected_child_script(pid_file: Path, parent_sleeps: bool) -> str:
     child_setup = (
-        "import signal,time;"
+        "import json,os,signal,time;"
         "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        f"open({str(pid_file)!r},'w').write("
+        "json.dumps({'parent':os.getppid(),'child':os.getpid()}));"
         "time.sleep(60)"
     )
     parent_tail = "time.sleep(60)" if parent_sleeps else ""
     return (
-        "import json,os,subprocess,sys,time;"
+        "import os,subprocess,sys,time\n"
         f"child=subprocess.Popen([sys.executable,'-c',{child_setup!r}],"
         "stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,"
-        "stderr=subprocess.DEVNULL);"
-        f"open({str(pid_file)!r},'w').write("
-        "json.dumps({'parent':os.getpid(),'child':child.pid}));"
-        f"{parent_tail}"
+        "stderr=subprocess.DEVNULL)\n"
+        "deadline=time.monotonic()+3\n"
+        f"while not os.path.exists({str(pid_file)!r}):\n"
+        "    if time.monotonic() >= deadline:\n"
+        "        raise RuntimeError('child did not become ready')\n"
+        "    time.sleep(0.005)\n"
+        f"{parent_tail}\n"
     )
 
 

--- a/worker/tests/test_subprocesses.py
+++ b/worker/tests/test_subprocesses.py
@@ -1,0 +1,565 @@
+"""Process-tree ownership tests for worker CLI calls."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from worker.subprocesses import (
+    SubprocessOwner,
+    _ProcessEntry,
+    _spawn_group_kwargs,
+    _windows_taskkill_command,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_input_bytes_reach_the_child_process() -> None:
+    owner = SubprocessOwner()
+
+    result = await owner.run_exec(
+        sys.executable,
+        "-c",
+        "import sys;sys.stdout.buffer.write(sys.stdin.buffer.read())",
+        input=b"curation prompt",
+        timeout=3,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == b"curation prompt"
+
+
+def _is_running(pid: int) -> bool:
+    """Return false for absent processes and Linux zombies."""
+    stat = Path(f"/proc/{pid}/stat")
+    if stat.exists():
+        fields = stat.read_text().split()
+        if len(fields) > 2 and fields[2] == "Z":
+            return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+async def _wait_for_file(path: Path, timeout: float = 3.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return json.loads(path.read_text())
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"process fixture did not write {path}")
+
+
+async def _wait_stopped(*pids: int, timeout: float = 3.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if all(not _is_running(pid) for pid in pids):
+            return
+        await asyncio.sleep(0.01)
+    running = [pid for pid in pids if _is_running(pid)]
+    raise AssertionError(f"processes still running: {running}")
+
+
+def _tree_script(pid_file: Path, ignore_term: bool = False) -> str:
+    child_setup = (
+        "import signal,time;"
+        + ("signal.signal(signal.SIGTERM, signal.SIG_IGN);" if ignore_term else "")
+        + "time.sleep(60)"
+    )
+    parent_setup = (
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);" if ignore_term else ""
+    )
+    return (
+        "import json,os,signal,subprocess,sys,time;"
+        f"{parent_setup}"
+        f"child=subprocess.Popen([sys.executable,'-c',{child_setup!r}]);"
+        f"open({str(pid_file)!r},'w').write("
+        "json.dumps({'parent':os.getpid(),'child':child.pid}));"
+        "sys.stdout.write(str(child.pid)+'\\n');sys.stdout.flush();"
+        "time.sleep(60)"
+    )
+
+
+def _stubborn_redirected_child_script(pid_file: Path, parent_sleeps: bool) -> str:
+    child_setup = (
+        "import signal,time;"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        "time.sleep(60)"
+    )
+    parent_tail = "time.sleep(60)" if parent_sleeps else ""
+    return (
+        "import json,os,subprocess,sys,time;"
+        f"child=subprocess.Popen([sys.executable,'-c',{child_setup!r}],"
+        "stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,"
+        "stderr=subprocess.DEVNULL);"
+        f"open({str(pid_file)!r},'w').write("
+        "json.dumps({'parent':os.getpid(),'child':child.pid}));"
+        f"{parent_tail}"
+    )
+
+
+def _detached_redirected_child_script(pid_file: Path) -> str:
+    child_setup = (
+        "import json,os,signal,time;"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+        f"open({str(pid_file)!r},'w').write(json.dumps({{'child':os.getpid()}}));"
+        "time.sleep(60)"
+    )
+    return (
+        "import subprocess,sys;"
+        f"subprocess.Popen([sys.executable,'-c',{child_setup!r}],"
+        "start_new_session=True,stdin=subprocess.DEVNULL,"
+        "stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)"
+    )
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_timeout_stops_child_and_grandchild_without_pipe_deadlock(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "timeout-tree.json"
+    owner = SubprocessOwner(grace_period=0.2)
+
+    result = await owner.run_exec(
+        sys.executable,
+        "-c",
+        _tree_script(pid_file),
+        timeout=0.2,
+    )
+
+    pids = json.loads(pid_file.read_text())
+    assert result.timed_out is True
+    assert str(pids["child"]).encode() in result.stdout
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_timeout_escalates_when_only_descendant_ignores_term(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "split-tree.json"
+    owner = SubprocessOwner(grace_period=0.1)
+
+    result = await owner.run_exec(
+        sys.executable,
+        "-c",
+        _stubborn_redirected_child_script(pid_file, parent_sleeps=True),
+        timeout=0.2,
+    )
+
+    pids = json.loads(pid_file.read_text())
+    assert result.timed_out is True
+    assert result.forced is True
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_successful_parent_cannot_leave_a_descendant_owned(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "successful-parent-tree.json"
+    owner = SubprocessOwner(grace_period=0.1)
+
+    result = await owner.run_exec(
+        sys.executable,
+        "-c",
+        _stubborn_redirected_child_script(pid_file, parent_sleeps=False),
+        timeout=3,
+    )
+
+    pids = json.loads(pid_file.read_text())
+    assert result.returncode == 0
+    assert result.forced is True
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_successful_parent_stops_detached_descendant_holding_output_pipe(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "detached-child.json"
+    child_setup = (
+        "import json,os,time;"
+        f"open({str(pid_file)!r},'w').write(json.dumps({{'child':os.getpid()}}));"
+        "time.sleep(60)"
+    )
+    parent_setup = (
+        "import subprocess,sys;"
+        f"subprocess.Popen([sys.executable,'-c',{child_setup!r}],"
+        "start_new_session=True)"
+    )
+    owner = SubprocessOwner(grace_period=0.1, force_wait=0.2)
+
+    result = await asyncio.wait_for(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            parent_setup,
+            timeout=0.2,
+        ),
+        timeout=2,
+    )
+
+    pids = await _wait_for_file(pid_file)
+    assert result.timed_out is False
+    await _wait_stopped(pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_successful_parent_cannot_leave_detached_descendant_without_pipes(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "detached-redirected-child.json"
+    owner = SubprocessOwner(grace_period=0.1, force_wait=0.2)
+
+    result = await asyncio.wait_for(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            _detached_redirected_child_script(pid_file),
+            timeout=2,
+        ),
+        timeout=3,
+    )
+
+    pids = await _wait_for_file(pid_file)
+    assert result.returncode == 0
+    assert result.forced is True
+    await _wait_stopped(pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_cancellation_stops_child_and_grandchild(tmp_path: Path) -> None:
+    pid_file = tmp_path / "cancel-tree.json"
+    owner = SubprocessOwner(grace_period=0.2)
+    task = asyncio.create_task(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            _tree_script(pid_file),
+            timeout=60,
+        )
+    )
+    pids = await _wait_for_file(pid_file)
+
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_cancellation_waits_for_spawn_registration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pid_file = tmp_path / "spawn-cancellation-tree.json"
+    spawned = asyncio.Event()
+    release_spawn = asyncio.Event()
+    real_spawn = asyncio.create_subprocess_exec
+
+    async def delayed_spawn(*args, **kwargs):
+        process = await real_spawn(*args, **kwargs)
+        spawned.set()
+        await release_spawn.wait()
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", delayed_spawn)
+    owner = SubprocessOwner(grace_period=0.1)
+    run_task = asyncio.create_task(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            _tree_script(pid_file),
+            timeout=60,
+        )
+    )
+    await spawned.wait()
+    pids = await _wait_for_file(pid_file)
+
+    run_task.cancel()
+    release_spawn.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run_task, timeout=2)
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_cancellation_during_timeout_cleanup_waits_for_termination(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "timeout-cancellation-tree.json"
+    owner = SubprocessOwner(grace_period=0.3, force_wait=0.2)
+    run_task = asyncio.create_task(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            _tree_script(pid_file, ignore_term=True),
+            timeout=0.05,
+        )
+    )
+    pids = await _wait_for_file(pid_file)
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        entries = list(owner._entries.values())
+        if entries and entries[0].termination is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise AssertionError("timeout cleanup did not start")
+
+    run_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run_task, timeout=2)
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_shutdown_escalates_and_reports_forced_tree_kill(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "shutdown-tree.json"
+    owner = SubprocessOwner(grace_period=0.1)
+    run_task = asyncio.create_task(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            _tree_script(pid_file, ignore_term=True),
+            timeout=60,
+        )
+    )
+    pids = await _wait_for_file(pid_file)
+
+    report = await owner.shutdown()
+    result = await run_task
+
+    assert report.terminated == 1
+    assert report.forced == 1
+    assert result.timed_out is False
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="Linux subreaper integration test",
+)
+async def test_shutdown_checks_descendants_after_parent_exits(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "shutdown-split-tree.json"
+    owner = SubprocessOwner(grace_period=0.1)
+    run_task = asyncio.create_task(
+        owner.run_exec(
+            sys.executable,
+            "-c",
+            _stubborn_redirected_child_script(pid_file, parent_sleeps=True),
+            timeout=60,
+        )
+    )
+    pids = await _wait_for_file(pid_file)
+
+    report = await owner.shutdown()
+    await run_task
+
+    assert report.terminated == 1
+    assert report.forced == 1
+    await _wait_stopped(pids["parent"], pids["child"])
+    assert owner.active_count == 0
+
+
+async def test_windows_process_tree_commands_are_explicit() -> None:
+    creation_flags = getattr(
+        subprocess,
+        "CREATE_NEW_PROCESS_GROUP",
+        0x00000200,
+    )
+
+    assert _spawn_group_kwargs("win32") == {
+        "creationflags": creation_flags | 0x00000004,
+    }
+    assert _windows_taskkill_command(4321, force=False) == (
+        "taskkill",
+        "/PID",
+        "4321",
+        "/T",
+    )
+    assert _windows_taskkill_command(4321, force=True) == (
+        "taskkill",
+        "/PID",
+        "4321",
+        "/T",
+        "/F",
+    )
+
+
+async def test_windows_import_does_not_require_sigusr1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "worker._subprocesses_without_sigusr1"
+    module_path = Path(__file__).parents[1] / "worker" / "subprocesses.py"
+    monkeypatch.delattr(signal, "SIGUSR1")
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert module._LINUX_FORCE_SIGNAL is None
+
+
+async def test_windows_job_is_attached_before_process_resumes() -> None:
+    events: list[str] = []
+
+    class FakeProcess:
+        pid = 4321
+        returncode = 0
+
+        async def communicate(self, input=None):
+            return b"", b""
+
+    class FakeJob:
+        def active_processes(self) -> int:
+            return 0
+
+        def close(self) -> None:
+            events.append("close")
+
+    async def spawn(*args, **kwargs):
+        assert kwargs["creationflags"] & 0x00000004
+        events.append("spawn-suspended")
+        return FakeProcess()
+
+    def attach_job(pid: int):
+        events.append("attach-job")
+        return FakeJob()
+
+    def resume(pid: int) -> None:
+        events.append("resume")
+
+    owner = SubprocessOwner(
+        platform="win32",
+        windows_job_factory=attach_job,
+        windows_resume_factory=resume,
+    )
+
+    result = await owner._run(
+        spawn,
+        "fake-command",
+        timeout=1,
+        input=None,
+    )
+
+    assert result.returncode == 0
+    assert events == ["spawn-suspended", "attach-job", "resume", "close"]
+
+
+async def test_windows_job_tracks_descendants_after_root_exit() -> None:
+    communication = asyncio.create_task(asyncio.sleep(0, result=(b"", b"")))
+    await communication
+
+    class FakeJob:
+        def active_processes(self) -> int:
+            return 1
+
+    entry = _ProcessEntry(
+        process=SimpleNamespace(pid=4321, returncode=0),
+        communication=communication,
+        windows_job=FakeJob(),
+    )
+    owner = SubprocessOwner(platform="win32")
+
+    assert owner._tree_is_alive(entry) is True
+
+
+async def test_windows_job_setup_failure_has_bounded_cleanup() -> None:
+    never_finishes = asyncio.Event()
+
+    class FakeProcess:
+        pid = 4321
+        returncode = None
+
+        async def communicate(self, input=None):
+            await never_finishes.wait()
+            return b"", b""
+
+    async def spawn(*args, **kwargs):
+        return FakeProcess()
+
+    def fail_job_setup(pid: int):
+        raise OSError("job setup failed")
+
+    owner = SubprocessOwner(
+        platform="win32",
+        grace_period=0.01,
+        force_wait=0.05,
+        windows_job_factory=fail_job_setup,
+    )
+    owner._signal_windows_tree = AsyncMock()
+
+    with pytest.raises(OSError, match="job setup failed"):
+        await asyncio.wait_for(
+            owner._run(
+                spawn,
+                "fake-command",
+                timeout=1,
+                input=None,
+            ),
+            timeout=0.5,
+        )

--- a/worker/worker/content.py
+++ b/worker/worker/content.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 from dataclasses import dataclass
 from typing import Optional
+
+from worker.subprocesses import SubprocessOwner
 
 log = logging.getLogger(__name__)
 
@@ -169,26 +170,23 @@ def validate_generated_content(text: str, platform: str) -> list[str]:
     return violations
 
 
-async def generate_content(req: ContentRequest) -> Optional[str]:
+async def generate_content(
+    req: ContentRequest,
+    subprocesses: SubprocessOwner | None = None,
+) -> Optional[str]:
     """Generate content using Gemini CLI. Returns None on failure."""
     prompt = build_generation_prompt(req)
+    owner = subprocesses or SubprocessOwner(logger=log)
 
     try:
-        process = await asyncio.create_subprocess_exec(
+        result = await owner.run_exec(
             "gemini",
             "-p",
             prompt,
             "--output-format",
             "text",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            timeout=60,
         )
-        stdout, stderr = await asyncio.wait_for(
-            process.communicate(), timeout=60
-        )
-    except asyncio.TimeoutError:
-        log.warning("Gemini CLI timed out after 60s")
-        return None
     except FileNotFoundError:
         log.error("Gemini CLI not found")
         return None
@@ -196,15 +194,18 @@ async def generate_content(req: ContentRequest) -> Optional[str]:
         log.exception("Failed to run Gemini CLI")
         return None
 
-    if process.returncode != 0:
+    if result.timed_out:
+        log.warning("Gemini CLI timed out after 60s")
+        return None
+    if result.returncode != 0:
         log.warning(
             "Gemini CLI returned %d: %s",
-            process.returncode,
-            stderr.decode().strip(),
+            result.returncode,
+            result.stderr.decode().strip(),
         )
         return None
 
-    text = stdout.decode().strip()
+    text = result.stdout.decode().strip()
 
     # Strip surrounding quotes if present
     if len(text) >= 2 and text[0] == '"' and text[-1] == '"':

--- a/worker/worker/curation/evaluate.py
+++ b/worker/worker/curation/evaluate.py
@@ -8,51 +8,47 @@ parallel subagents via asyncio.gather() for concurrent evaluation.
 from __future__ import annotations
 
 import asyncio
-import base64
 import logging
 import os
 import re
 
 from worker.curation.models import CurationCandidate
+from worker.subprocesses import SubprocessOwner
 
 log = logging.getLogger(__name__)
 
 CLI_TIMEOUT = 120  # seconds per CLI call
 
 
-async def _run_claude(prompt: str, model: str = "sonnet") -> str:
+async def _run_claude(
+    prompt: str,
+    model: str = "sonnet",
+    subprocesses: SubprocessOwner | None = None,
+) -> str:
     """Run a Claude Code CLI prompt and return the response text.
 
-    Follows claude-scheduler.py pattern: base64-encode the prompt for
-    safe shell transmission, pipe it into claude -p, and use shell-level
-    timeout (timeout --foreground) instead of asyncio.wait_for which
-    can prevent the CLI from initializing properly.
+    The prompt is sent on stdin so it never crosses a shell boundary.
+    SubprocessOwner supplies the bounded timeout and full-tree cleanup.
     """
-    encoded = base64.b64encode(prompt.encode()).decode()
-
-    # Base64 pipe -> timeout wrapper -> claude -p
-    # Same pattern as claude-scheduler.py bash wrapper scripts
-    cmd = (
-        f"echo '{encoded}' | base64 -d | "
-        f"timeout --foreground --kill-after=30 {CLI_TIMEOUT} "
-        f"claude --dangerously-skip-permissions -p --model {model}"
-    )
-
     # Strip nesting-detection env vars so claude -p doesn't refuse to run
     # when invoked from within a Claude Code session.
     clean_env = {
         k: v for k, v in os.environ.items()
         if k not in ("CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
     }
+    owner = subprocesses or SubprocessOwner(logger=log)
 
     try:
-        process = await asyncio.create_subprocess_shell(
-            cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        result = await owner.run_exec(
+            "claude",
+            "--dangerously-skip-permissions",
+            "-p",
+            "--model",
+            model,
+            input=prompt.encode(),
+            timeout=CLI_TIMEOUT,
             env=clean_env,
         )
-        stdout, stderr = await process.communicate()
     except FileNotFoundError:
         log.error("claude CLI not found")
         return ""
@@ -60,18 +56,18 @@ async def _run_claude(prompt: str, model: str = "sonnet") -> str:
         log.exception("claude CLI subprocess failed")
         return ""
 
-    if process.returncode == 124:
+    if result.timed_out:
         log.warning("claude CLI timed out after %ds", CLI_TIMEOUT)
         return ""
-    if process.returncode != 0:
+    if result.returncode != 0:
         log.warning(
             "claude CLI returned %d: %s",
-            process.returncode,
-            stderr.decode()[:200],
+            result.returncode,
+            result.stderr.decode()[:200],
         )
         return ""
 
-    return stdout.decode().strip()
+    return result.stdout.decode().strip()
 
 
 # --- Evaluation prompt (quick-check + investigation in one call) ---
@@ -325,7 +321,9 @@ def parse_batch_draft_response(text: str) -> dict:
 
 
 async def evaluate_candidate(
-    candidate: CurationCandidate, platform: str = "twitter"
+    candidate: CurationCandidate,
+    platform: str = "twitter",
+    subprocesses: SubprocessOwner | None = None,
 ) -> dict:
     """Full evaluation of a single candidate using Claude Code CLI.
 
@@ -337,7 +335,11 @@ async def evaluate_candidate(
     """
     # Step 1: Evaluate
     eval_prompt = build_evaluate_prompt(candidate)
-    eval_text = await _run_claude(eval_prompt, model="haiku")
+    eval_text = await _run_claude(
+        eval_prompt,
+        model="haiku",
+        subprocesses=subprocesses,
+    )
     if not eval_text:
         return {"relevant": False, "reasoning": "CLI evaluation failed"}
 
@@ -351,7 +353,11 @@ async def evaluate_candidate(
 
     # Step 2: Batch draft (4 variants via Opus)
     draft_prompt = build_batch_draft_prompt(candidate, evaluation, platform)
-    draft_text = await _run_claude(draft_prompt, model="opus")
+    draft_text = await _run_claude(
+        draft_prompt,
+        model="opus",
+        subprocesses=subprocesses,
+    )
     if not draft_text:
         evaluation["share"] = False
         return evaluation
@@ -369,6 +375,7 @@ async def evaluate_batch(
     candidates: list[CurationCandidate],
     platform: str = "twitter",
     max_parallel: int = 5,
+    subprocesses: SubprocessOwner | None = None,
 ) -> list[tuple[CurationCandidate, dict]]:
     """Evaluate multiple candidates in parallel using Claude Code CLI subagents.
 
@@ -379,7 +386,11 @@ async def evaluate_batch(
 
     async def _eval_one(c: CurationCandidate) -> tuple[CurationCandidate, dict]:
         async with semaphore:
-            result = await evaluate_candidate(c, platform)
+            result = await evaluate_candidate(
+                c,
+                platform,
+                subprocesses=subprocesses,
+            )
             return (c, result)
 
     tasks = [_eval_one(c) for c in candidates]

--- a/worker/worker/curation/monitor.py
+++ b/worker/worker/curation/monitor.py
@@ -13,12 +13,18 @@ from worker.curation.sources.news import NewsSource
 from worker.curation.sources.twitch import TwitchSource
 from worker.curation.sources.youtube import YouTubeSource
 from worker.db import Database
+from worker.subprocesses import SubprocessOwner
 
 log = logging.getLogger(__name__)
 
 
 class CurationMonitor:
-    def __init__(self, config: CurationConfig, db: Database):
+    def __init__(
+        self,
+        config: CurationConfig,
+        db: Database,
+        subprocesses: SubprocessOwner | None = None,
+    ):
         self.config = config
         self.db = db
 
@@ -32,7 +38,9 @@ class CurationMonitor:
         if config.twitch_client_id and config.twitch_client_secret:
             self.twitch = TwitchSource(config.twitch_client_id, config.twitch_client_secret)
         self.pipeline = CurationPipeline(
-            db=db, max_parallel=config.max_parallel_evaluations
+            db=db,
+            max_parallel=config.max_parallel_evaluations,
+            subprocesses=subprocesses,
         )
 
     async def scan_sources(self, include_twitch: bool = False) -> list[CurationCandidate]:

--- a/worker/worker/curation/pipeline.py
+++ b/worker/worker/curation/pipeline.py
@@ -16,6 +16,7 @@ from worker.curation.evaluate import evaluate_batch
 from worker.curation.keywords import score_keywords
 from worker.curation.models import CurationCandidate
 from worker.db import Database
+from worker.subprocesses import SubprocessOwner
 
 log = logging.getLogger(__name__)
 
@@ -23,9 +24,15 @@ KEYWORD_THRESHOLD = 0.3
 
 
 class CurationPipeline:
-    def __init__(self, db: Optional[Database] = None, max_parallel: int = 5):
+    def __init__(
+        self,
+        db: Optional[Database] = None,
+        max_parallel: int = 5,
+        subprocesses: SubprocessOwner | None = None,
+    ):
         self.db = db
         self.max_parallel = max_parallel
+        self.subprocesses = subprocesses
 
     def _keyword_filter(self, candidates: list[CurationCandidate]) -> list[CurationCandidate]:
         """Stage 1: Local keyword scoring. Drop candidates below threshold."""
@@ -58,7 +65,10 @@ class CurationPipeline:
         to_evaluate = filtered[:20]
 
         approved_pairs = await evaluate_batch(
-            to_evaluate, platform=platform, max_parallel=self.max_parallel
+            to_evaluate,
+            platform=platform,
+            max_parallel=self.max_parallel,
+            subprocesses=self.subprocesses,
         )
 
         # Update candidate fields from evaluation results

--- a/worker/worker/main.py
+++ b/worker/worker/main.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-import sys
+import signal
 from zoneinfo import ZoneInfo
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -17,6 +17,21 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 ET = ZoneInfo("America/New_York")
+
+
+def _install_shutdown_handlers(
+    loop: asyncio.AbstractEventLoop,
+    shutdown_requested: asyncio.Event,
+) -> tuple[signal.Signals, ...]:
+    """Route service and terminal signals through the async shutdown path."""
+    installed = []
+    for signum in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(signum, shutdown_requested.set)
+        except (NotImplementedError, RuntimeError):
+            continue
+        installed.append(signum)
+    return tuple(installed)
 
 
 async def main():
@@ -76,20 +91,25 @@ async def main():
     scheduler.start()
 
     # Start Redis listener for approval decisions
-    listener_task = asyncio.create_task(
-        runner.listen_for_decisions()
-    )
+    listener_task = asyncio.create_task(runner.listen_for_decisions())
 
     logger.info("keyjawn-worker running (Ctrl+C to stop)")
 
+    shutdown_requested = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    installed_handlers = _install_shutdown_handlers(loop, shutdown_requested)
+
     try:
-        await asyncio.Event().wait()
-    except (KeyboardInterrupt, SystemExit):
+        await shutdown_requested.wait()
+    except (asyncio.CancelledError, KeyboardInterrupt, SystemExit):
         pass
     finally:
         listener_task.cancel()
         scheduler.shutdown()
+        await asyncio.gather(listener_task, return_exceptions=True)
         await runner.stop()
+        for signum in installed_handlers:
+            loop.remove_signal_handler(signum)
 
 
 if __name__ == "__main__":

--- a/worker/worker/platforms/social_scroller.py
+++ b/worker/worker/platforms/social_scroller.py
@@ -10,18 +10,23 @@ Two capabilities:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 
 from worker.config import SocialScrollerConfig
+from worker.subprocesses import SubprocessOwner
 
 log = logging.getLogger(__name__)
 
 
 class SocialScrollerClient:
-    def __init__(self, config: SocialScrollerConfig):
+    def __init__(
+        self,
+        config: SocialScrollerConfig,
+        subprocesses: SubprocessOwner | None = None,
+    ):
         self.config = config
+        self.subprocesses = subprocesses or SubprocessOwner(logger=log)
 
     async def _run_cmd(self, cmd: str, timeout: int = 120) -> str | None:
         """Run a social-scroller command, locally or via SSH.
@@ -37,26 +42,21 @@ class SocialScrollerClient:
         else:
             full_cmd = cmd
         try:
-            proc = await asyncio.create_subprocess_shell(
+            result = await self.subprocesses.run_shell(
                 full_cmd,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+                timeout=timeout,
             )
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=timeout,
-            )
-            if proc.returncode != 0:
+            if result.timed_out:
+                log.warning("social-scroller timed out after %ds", timeout)
+                return None
+            if result.returncode != 0:
                 log.warning(
                     "social-scroller exited %d: %s",
-                    proc.returncode,
-                    stderr.decode().strip()[:200],
+                    result.returncode,
+                    result.stderr.decode().strip()[:200],
                 )
                 return None
-            return stdout.decode()
-        except asyncio.TimeoutError:
-            log.warning("social-scroller timed out after %ds", timeout)
-            proc.kill()
-            return None
+            return result.stdout.decode()
         except Exception:
             log.exception("social-scroller run failed")
             return None

--- a/worker/worker/runner.py
+++ b/worker/worker/runner.py
@@ -1,8 +1,6 @@
 """Main runner -- orchestrates monitor and action loops."""
 
-import asyncio
 import logging
-from datetime import datetime, timezone
 
 import redis.asyncio as aioredis
 
@@ -20,6 +18,7 @@ from worker.platforms.bluesky import BlueskyClient
 from worker.platforms.producthunt import ProductHuntClient
 from worker.platforms.social_scroller import SocialScrollerClient
 from worker.platforms.twitter import TwitterClient
+from worker.subprocesses import SubprocessOwner
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +36,7 @@ class WorkerRunner:
         self.approvals: ApprovalManager = None
         self.curation_monitor = None
         self._redis_sub: aioredis.Redis = None
+        self.subprocesses = SubprocessOwner(logger=logger)
 
     async def start(self):
         """Initialize all components."""
@@ -52,6 +52,7 @@ class WorkerRunner:
         if self.config.social_scroller.enabled:
             self.social_scroller = SocialScrollerClient(
                 self.config.social_scroller,
+                subprocesses=self.subprocesses,
             )
         self.monitor = Monitor(self.config, self.db)
         self.picker = ActionPicker(self.config, self.db)
@@ -66,12 +67,22 @@ class WorkerRunner:
         )
 
         from worker.curation.monitor import CurationMonitor
-        self.curation_monitor = CurationMonitor(self.config.curation, self.db)
+        self.curation_monitor = CurationMonitor(
+            self.config.curation,
+            self.db,
+            subprocesses=self.subprocesses,
+        )
 
         logger.info("keyjawn-worker started")
 
     async def stop(self):
         """Clean shutdown."""
+        report = await self.subprocesses.shutdown()
+        if report.forced:
+            logger.warning(
+                "worker shutdown force-killed %d subprocess tree(s)",
+                report.forced,
+            )
         if self._redis_sub:
             await self._redis_sub.close()
         if self.db:
@@ -127,22 +138,28 @@ class WorkerRunner:
 
         # Generate content if it's a calendar post
         if action["source"] == "calendar":
-            generated = await generate_content(ContentRequest(
-                pillar=action.get("pillar", "demo"),
-                platform=action["platform"],
-                topic=content,
-            ))
+            generated = await generate_content(
+                ContentRequest(
+                    pillar=action.get("pillar", "demo"),
+                    platform=action["platform"],
+                    topic=content,
+                ),
+                subprocesses=self.subprocesses,
+            )
             if generated:
                 errors = validate_generated_content(
                     generated, action["platform"]
                 )
                 if errors:
                     logger.warning("generated content has issues: %s", errors)
-                    generated = await generate_content(ContentRequest(
-                        pillar=action.get("pillar", "demo"),
-                        platform=action["platform"],
-                        topic=content,
-                    ))
+                    generated = await generate_content(
+                        ContentRequest(
+                            pillar=action.get("pillar", "demo"),
+                            platform=action["platform"],
+                            topic=content,
+                        ),
+                        subprocesses=self.subprocesses,
+                    )
                     if generated:
                         errors = validate_generated_content(
                             generated, action["platform"]
@@ -171,12 +188,17 @@ class WorkerRunner:
         content = action["content"]
 
         if action["action_type"] == "reply":
-            generated = await generate_content(ContentRequest(
-                pillar="engagement",
-                platform=action["platform"],
-                topic=f"reply to: {content[:100]}",
-                context=f"@{action.get('source_user', 'user')} said: {content}",
-            ))
+            generated = await generate_content(
+                ContentRequest(
+                    pillar="engagement",
+                    platform=action["platform"],
+                    topic=f"reply to: {content[:100]}",
+                    context=(
+                        f"@{action.get('source_user', 'user')} said: {content}"
+                    ),
+                ),
+                subprocesses=self.subprocesses,
+            )
             if generated:
                 errors = validate_generated_content(
                     generated, action["platform"]

--- a/worker/worker/subprocess_supervisor.py
+++ b/worker/worker/subprocess_supervisor.py
@@ -1,0 +1,147 @@
+"""Linux subreaper used by :mod:`worker.subprocesses`.
+
+The worker process group is not a sufficient ownership boundary because a
+descendant can call ``setsid()``. This helper stays alive as a Linux child
+subreaper until every descendant has exited, including reparented daemons.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import signal
+import sys
+import time
+from collections.abc import Sequence
+
+_PR_SET_CHILD_SUBREAPER = 36
+_FORCE_SIGNAL = signal.SIGUSR1
+_requested_signal: int | None = None
+
+
+def _become_subreaper() -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, os.strerror(error))
+
+
+def _record_signal(signum: int, _frame: object) -> None:
+    global _requested_signal
+    if signum == _FORCE_SIGNAL:
+        _requested_signal = signal.SIGKILL
+    elif _requested_signal != signal.SIGKILL:
+        _requested_signal = signum
+
+
+def _direct_children(pid: int) -> list[int]:
+    try:
+        children = open(  # noqa: SIM115 - close explicitly around procfs races
+            f"/proc/{pid}/task/{pid}/children",
+            encoding="ascii",
+        )
+    except OSError:
+        return []
+    try:
+        return [int(child) for child in children.read().split()]
+    finally:
+        children.close()
+
+
+def _descendants(pid: int) -> list[int]:
+    found: list[int] = []
+    pending = _direct_children(pid)
+    while pending:
+        child = pending.pop()
+        found.append(child)
+        pending.extend(_direct_children(child))
+    return found
+
+
+def _signal_descendants(signum: int) -> None:
+    for pid in reversed(_descendants(os.getpid())):
+        try:
+            os.kill(pid, signum)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            os.write(
+                2,
+                f"cannot signal supervised descendant {pid}\n".encode(),
+            )
+
+
+def _exit_code(status: int) -> int:
+    if os.WIFEXITED(status):
+        return os.WEXITSTATUS(status)
+    if os.WIFSIGNALED(status):
+        return 128 + os.WTERMSIG(status)
+    return 1
+
+
+def _exec_child(mode: str, command: Sequence[str], status_fd: int) -> None:
+    for signum in (signal.SIGTERM, signal.SIGINT, _FORCE_SIGNAL):
+        signal.signal(signum, signal.SIG_DFL)
+    os.close(status_fd)
+
+    try:
+        if mode == "exec":
+            os.execvp(command[0], list(command))
+        os.execl("/bin/sh", "sh", "-c", command[0])
+    except OSError as error:
+        os.write(2, f"cannot execute {command[0]}: {error}\n".encode())
+        os._exit(127)
+
+
+def supervise(mode: str, status_fd: int, command: Sequence[str]) -> int:
+    """Run one command and remain its subreaper until its tree is gone."""
+    _become_subreaper()
+    for signum in (signal.SIGTERM, signal.SIGINT, _FORCE_SIGNAL):
+        signal.signal(signum, _record_signal)
+
+    root_pid = os.fork()
+    if root_pid == 0:
+        _exec_child(mode, command, status_fd)
+
+    root_status: int | None = None
+    status_reported = False
+    while True:
+        if _requested_signal is not None:
+            _signal_descendants(_requested_signal)
+
+        try:
+            waited_pid, waited_status = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            break
+
+        if waited_pid == 0:
+            time.sleep(0.02)
+            continue
+
+        if waited_pid == root_pid:
+            root_status = waited_status
+            os.write(status_fd, f"{_exit_code(waited_status)}\n".encode())
+            os.close(status_fd)
+            status_reported = True
+
+    if not status_reported:
+        os.close(status_fd)
+    return _exit_code(root_status) if root_status is not None else 1
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(argv if argv is not None else sys.argv[1:])
+    if len(args) < 3 or args[0] not in {"exec", "shell"}:
+        raise SystemExit(
+            "usage: subprocess_supervisor.py (exec|shell) STATUS_FD COMMAND..."
+        )
+    mode = args[0]
+    status_fd = int(args[1])
+    command = args[2:]
+    if mode == "shell" and len(command) != 1:
+        raise SystemExit("shell mode accepts exactly one command")
+    return supervise(mode, status_fd, command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worker/worker/subprocess_supervisor.py
+++ b/worker/worker/subprocess_supervisor.py
@@ -80,7 +80,13 @@ def _exit_code(status: int) -> int:
 
 
 def _exec_child(mode: str, command: Sequence[str], status_fd: int) -> None:
-    for signum in (signal.SIGTERM, signal.SIGINT, _FORCE_SIGNAL):
+    for signum in (
+        signal.SIGTERM,
+        signal.SIGINT,
+        _FORCE_SIGNAL,
+        signal.SIGPIPE,
+        signal.SIGXFSZ,
+    ):
         signal.signal(signum, signal.SIG_DFL)
     os.close(status_fd)
 

--- a/worker/worker/subprocesses.py
+++ b/worker/worker/subprocesses.py
@@ -1,0 +1,809 @@
+"""Bounded ownership for subprocess trees launched by the worker."""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import logging
+import os
+import signal
+import subprocess
+import sys
+from collections.abc import Awaitable, Callable
+from ctypes import wintypes
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_WINDOWS_NEW_PROCESS_GROUP = getattr(
+    subprocess,
+    "CREATE_NEW_PROCESS_GROUP",
+    0x00000200,
+)
+_WINDOWS_CREATE_SUSPENDED = getattr(
+    subprocess,
+    "CREATE_SUSPENDED",
+    0x00000004,
+)
+_LINUX_FORCE_SIGNAL = getattr(signal, "SIGUSR1", None)
+_SUPERVISOR = Path(__file__).with_name("subprocess_supervisor.py")
+
+
+def _spawn_group_kwargs(platform: str = sys.platform) -> dict[str, Any]:
+    """Return platform settings that isolate a spawned process tree."""
+    if platform == "win32":
+        return {
+            "creationflags": (_WINDOWS_NEW_PROCESS_GROUP | _WINDOWS_CREATE_SUSPENDED)
+        }
+    return {"start_new_session": True}
+
+
+def _windows_taskkill_command(pid: int, *, force: bool) -> tuple[str, ...]:
+    command = ("taskkill", "/PID", str(pid), "/T")
+    return command + (("/F",) if force else ())
+
+
+class _ThreadEntry32(ctypes.Structure):
+    _fields_ = [
+        ("dwSize", wintypes.DWORD),
+        ("cntUsage", wintypes.DWORD),
+        ("th32ThreadID", wintypes.DWORD),
+        ("th32OwnerProcessID", wintypes.DWORD),
+        ("tpBasePri", ctypes.c_long),
+        ("tpDeltaPri", ctypes.c_long),
+        ("dwFlags", wintypes.DWORD),
+    ]
+
+
+def _resume_windows_process(pid: int) -> None:
+    """Resume a process only after its Job Object owns the suspended root."""
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    snapshot_flag = 0x00000004
+    thread_suspend_resume = 0x0002
+    invalid_handle = ctypes.c_void_p(-1).value
+
+    kernel32.CreateToolhelp32Snapshot.argtypes = [
+        wintypes.DWORD,
+        wintypes.DWORD,
+    ]
+    kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    kernel32.Thread32First.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ThreadEntry32),
+    ]
+    kernel32.Thread32First.restype = wintypes.BOOL
+    kernel32.Thread32Next.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(_ThreadEntry32),
+    ]
+    kernel32.Thread32Next.restype = wintypes.BOOL
+    kernel32.OpenThread.argtypes = [
+        wintypes.DWORD,
+        wintypes.BOOL,
+        wintypes.DWORD,
+    ]
+    kernel32.OpenThread.restype = wintypes.HANDLE
+    kernel32.ResumeThread.argtypes = [wintypes.HANDLE]
+    kernel32.ResumeThread.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    snapshot = kernel32.CreateToolhelp32Snapshot(snapshot_flag, 0)
+    if snapshot == invalid_handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        entry = _ThreadEntry32()
+        entry.dwSize = ctypes.sizeof(entry)
+        has_entry = kernel32.Thread32First(snapshot, ctypes.byref(entry))
+        while has_entry:
+            if entry.th32OwnerProcessID == pid:
+                thread = kernel32.OpenThread(
+                    thread_suspend_resume,
+                    False,
+                    entry.th32ThreadID,
+                )
+                if not thread:
+                    raise ctypes.WinError(ctypes.get_last_error())
+                try:
+                    if kernel32.ResumeThread(thread) == 0xFFFFFFFF:
+                        raise ctypes.WinError(ctypes.get_last_error())
+                finally:
+                    kernel32.CloseHandle(thread)
+                return
+            has_entry = kernel32.Thread32Next(snapshot, ctypes.byref(entry))
+    finally:
+        kernel32.CloseHandle(snapshot)
+    raise ProcessLookupError(f"no thread found for suspended process {pid}")
+
+
+class _JobObjectBasicLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_longlong),
+        ("PerJobUserTimeLimit", ctypes.c_longlong),
+        ("LimitFlags", wintypes.DWORD),
+        ("MinimumWorkingSetSize", ctypes.c_size_t),
+        ("MaximumWorkingSetSize", ctypes.c_size_t),
+        ("ActiveProcessLimit", wintypes.DWORD),
+        ("Affinity", ctypes.c_size_t),
+        ("PriorityClass", wintypes.DWORD),
+        ("SchedulingClass", wintypes.DWORD),
+    ]
+
+
+class _IoCounters(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_ulonglong),
+        ("WriteOperationCount", ctypes.c_ulonglong),
+        ("OtherOperationCount", ctypes.c_ulonglong),
+        ("ReadTransferCount", ctypes.c_ulonglong),
+        ("WriteTransferCount", ctypes.c_ulonglong),
+        ("OtherTransferCount", ctypes.c_ulonglong),
+    ]
+
+
+class _JobObjectExtendedLimitInformation(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JobObjectBasicLimitInformation),
+        ("IoInfo", _IoCounters),
+        ("ProcessMemoryLimit", ctypes.c_size_t),
+        ("JobMemoryLimit", ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed", ctypes.c_size_t),
+    ]
+
+
+class _JobObjectBasicAccountingInformation(ctypes.Structure):
+    _fields_ = [
+        ("TotalUserTime", ctypes.c_longlong),
+        ("TotalKernelTime", ctypes.c_longlong),
+        ("ThisPeriodTotalUserTime", ctypes.c_longlong),
+        ("ThisPeriodTotalKernelTime", ctypes.c_longlong),
+        ("TotalPageFaultCount", wintypes.DWORD),
+        ("TotalProcesses", wintypes.DWORD),
+        ("ActiveProcesses", wintypes.DWORD),
+        ("TotalTerminatedProcesses", wintypes.DWORD),
+    ]
+
+
+class _WindowsJob:
+    """Own a Windows process tree independently of its root process."""
+
+    _BASIC_ACCOUNTING_INFORMATION = 1
+    _EXTENDED_LIMIT_INFORMATION = 9
+    _LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+    _PROCESS_TERMINATE = 0x0001
+    _PROCESS_SET_QUOTA = 0x0100
+    _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+    def __init__(self, pid: int) -> None:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self._kernel32 = kernel32
+        self._handle = None
+        self._configure_signatures()
+
+        handle = kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            self._raise_last_error()
+        self._handle = handle
+
+        limits = _JobObjectExtendedLimitInformation()
+        limits.BasicLimitInformation.LimitFlags = self._LIMIT_KILL_ON_JOB_CLOSE
+        if not kernel32.SetInformationJobObject(
+            handle,
+            self._EXTENDED_LIMIT_INFORMATION,
+            ctypes.byref(limits),
+            ctypes.sizeof(limits),
+        ):
+            self.close()
+            self._raise_last_error()
+
+        process_handle = kernel32.OpenProcess(
+            self._PROCESS_TERMINATE
+            | self._PROCESS_SET_QUOTA
+            | self._PROCESS_QUERY_LIMITED_INFORMATION,
+            False,
+            pid,
+        )
+        if not process_handle:
+            self.close()
+            self._raise_last_error()
+        try:
+            if not kernel32.AssignProcessToJobObject(handle, process_handle):
+                self.close()
+                self._raise_last_error()
+        finally:
+            kernel32.CloseHandle(process_handle)
+
+    def _configure_signatures(self) -> None:
+        kernel32 = self._kernel32
+        kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        kernel32.SetInformationJobObject.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        kernel32.SetInformationJobObject.restype = wintypes.BOOL
+        kernel32.OpenProcess.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.AssignProcessToJobObject.argtypes = [
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+        ]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.QueryInformationJobObject.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+            ctypes.c_void_p,
+        ]
+        kernel32.QueryInformationJobObject.restype = wintypes.BOOL
+        kernel32.TerminateJobObject.argtypes = [
+            wintypes.HANDLE,
+            wintypes.UINT,
+        ]
+        kernel32.TerminateJobObject.restype = wintypes.BOOL
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+
+    @staticmethod
+    def _raise_last_error() -> None:
+        raise ctypes.WinError(ctypes.get_last_error())
+
+    def active_processes(self) -> int:
+        if self._handle is None:
+            return 0
+        accounting = _JobObjectBasicAccountingInformation()
+        if not self._kernel32.QueryInformationJobObject(
+            self._handle,
+            self._BASIC_ACCOUNTING_INFORMATION,
+            ctypes.byref(accounting),
+            ctypes.sizeof(accounting),
+            None,
+        ):
+            self._raise_last_error()
+        return accounting.ActiveProcesses
+
+    def terminate(self) -> None:
+        if self._handle is None:
+            return
+        if not self._kernel32.TerminateJobObject(self._handle, 1):
+            self._raise_last_error()
+
+    def close(self) -> None:
+        if self._handle is None:
+            return
+        handle, self._handle = self._handle, None
+        if not self._kernel32.CloseHandle(handle):
+            self._raise_last_error()
+
+
+@dataclass(frozen=True)
+class ProcessResult:
+    returncode: int | None
+    stdout: bytes
+    stderr: bytes
+    timed_out: bool = False
+    forced: bool = False
+
+
+@dataclass(frozen=True)
+class ShutdownReport:
+    terminated: int
+    forced: int
+
+
+@dataclass
+class _ProcessEntry:
+    process: asyncio.subprocess.Process
+    communication: asyncio.Task[tuple[bytes, bytes]]
+    root_status: asyncio.Task[int] | None = None
+    windows_job: Any | None = None
+    termination: asyncio.Task[tuple[bytes, bytes, bool]] | None = None
+
+
+class SubprocessOwner:
+    """Launch CLI calls in OS ownership boundaries and reap them as one unit."""
+
+    def __init__(
+        self,
+        *,
+        grace_period: float = 5.0,
+        force_wait: float = 5.0,
+        platform: str = sys.platform,
+        logger: logging.Logger | None = None,
+        windows_job_factory: Callable[[int], Any] | None = None,
+        windows_resume_factory: Callable[[int], None] | None = None,
+    ) -> None:
+        self.grace_period = grace_period
+        self.force_wait = force_wait
+        self.platform = platform
+        self.logger = logger or log
+        self._windows_job_factory = windows_job_factory or _WindowsJob
+        self._windows_resume_factory = windows_resume_factory or _resume_windows_process
+        self._entries: dict[int, _ProcessEntry] = {}
+        self._guard = asyncio.Lock()
+        self._closing = False
+
+    @property
+    def active_count(self) -> int:
+        return len(self._entries)
+
+    async def run_exec(
+        self,
+        *program_and_args: str,
+        timeout: float | None = None,
+        input: bytes | None = None,
+        **kwargs: Any,
+    ) -> ProcessResult:
+        if self.platform.startswith("linux"):
+            return await self._run(
+                asyncio.create_subprocess_exec,
+                *program_and_args,
+                timeout=timeout,
+                input=input,
+                linux_supervision_mode="exec",
+                **kwargs,
+            )
+        return await self._run(
+            asyncio.create_subprocess_exec,
+            *program_and_args,
+            timeout=timeout,
+            input=input,
+            **kwargs,
+        )
+
+    async def run_shell(
+        self,
+        command: str,
+        *,
+        timeout: float | None = None,
+        input: bytes | None = None,
+        **kwargs: Any,
+    ) -> ProcessResult:
+        if self.platform.startswith("linux"):
+            return await self._run(
+                asyncio.create_subprocess_exec,
+                command,
+                timeout=timeout,
+                input=input,
+                linux_supervision_mode="shell",
+                **kwargs,
+            )
+        return await self._run(
+            asyncio.create_subprocess_shell,
+            command,
+            timeout=timeout,
+            input=input,
+            **kwargs,
+        )
+
+    async def _run(
+        self,
+        spawn: Callable[..., Awaitable[asyncio.subprocess.Process]],
+        *args: str,
+        timeout: float | None,
+        input: bytes | None,
+        linux_supervision_mode: str | None = None,
+        **kwargs: Any,
+    ) -> ProcessResult:
+        status_read_fd: int | None = None
+        status_write_fd: int | None = None
+        if linux_supervision_mode is not None:
+            status_read_fd, status_write_fd = os.pipe()
+            inherited_fds = tuple(kwargs.pop("pass_fds", ()))
+            kwargs["pass_fds"] = (*inherited_fds, status_write_fd)
+            args = (
+                sys.executable,
+                str(_SUPERVISOR),
+                linux_supervision_mode,
+                str(status_write_fd),
+                *args,
+            )
+        if input is not None:
+            kwargs.setdefault("stdin", asyncio.subprocess.PIPE)
+        kwargs.setdefault("stdout", asyncio.subprocess.PIPE)
+        kwargs.setdefault("stderr", asyncio.subprocess.PIPE)
+        self._apply_process_group(kwargs)
+
+        registration = asyncio.create_task(
+            self._spawn_and_register(
+                spawn,
+                args,
+                kwargs,
+                input,
+                status_read_fd=status_read_fd,
+                status_write_fd=status_write_fd,
+            )
+        )
+        try:
+            entry = await asyncio.shield(registration)
+        except asyncio.CancelledError as cancellation:
+            try:
+                entry = await asyncio.shield(registration)
+            except BaseException:
+                raise cancellation
+            cleanup = asyncio.create_task(
+                self._terminate(entry, reason="task cancellation during spawn")
+            )
+            await asyncio.shield(cleanup)
+            raise cancellation
+
+        process = entry.process
+        communication = entry.communication
+        try:
+            wait_target = entry.root_status or communication
+            try:
+                if timeout is None:
+                    command_result = await asyncio.shield(wait_target)
+                else:
+                    command_result = await asyncio.wait_for(
+                        asyncio.shield(wait_target),
+                        timeout=timeout,
+                    )
+            except asyncio.TimeoutError:
+                stdout, stderr, forced = await self._terminate(
+                    entry,
+                    reason=f"timeout after {timeout}s",
+                )
+                return ProcessResult(
+                    self._resolved_returncode(entry),
+                    stdout,
+                    stderr,
+                    timed_out=True,
+                    forced=forced,
+                )
+            except asyncio.CancelledError:
+                cleanup = asyncio.create_task(
+                    self._terminate(entry, reason="task cancellation")
+                )
+                await asyncio.shield(cleanup)
+                raise
+
+            if entry.root_status is None:
+                stdout, stderr = command_result
+                root_returncode = process.returncode
+            else:
+                root_returncode = command_result
+                stdout = stderr = b""
+            forced = False
+            if self._tree_is_alive(entry) or not communication.done():
+                stdout, stderr, forced = await self._terminate(
+                    entry,
+                    reason="root process exit",
+                )
+            return ProcessResult(
+                root_returncode,
+                stdout,
+                stderr,
+                forced=forced,
+            )
+        finally:
+            if communication.done() and not self._tree_is_alive(entry):
+                await self._release_entry(entry)
+
+    async def _spawn_and_register(
+        self,
+        spawn: Callable[..., Awaitable[asyncio.subprocess.Process]],
+        args: tuple[str, ...],
+        kwargs: dict[str, Any],
+        input: bytes | None,
+        *,
+        status_read_fd: int | None,
+        status_write_fd: int | None,
+    ) -> _ProcessEntry:
+        async with self._guard:
+            try:
+                if self._closing:
+                    raise RuntimeError("subprocess owner is shutting down")
+                process = await spawn(*args, **kwargs)
+            except BaseException:
+                if status_read_fd is not None:
+                    os.close(status_read_fd)
+                raise
+            finally:
+                if status_write_fd is not None:
+                    os.close(status_write_fd)
+
+            communication = asyncio.create_task(process.communicate(input))
+            root_status = None
+            if status_read_fd is not None:
+                root_status = asyncio.create_task(
+                    asyncio.to_thread(self._read_root_status, status_read_fd)
+                )
+            windows_job = None
+            if self.platform == "win32":
+                try:
+                    windows_job = self._windows_job_factory(process.pid)
+                    self._windows_resume_factory(process.pid)
+                except BaseException:
+                    if windows_job is not None:
+                        windows_job.close()
+                    await self._cleanup_failed_windows_spawn(
+                        process,
+                        communication,
+                    )
+                    raise
+            entry = _ProcessEntry(
+                process=process,
+                communication=communication,
+                root_status=root_status,
+                windows_job=windows_job,
+            )
+            self._entries[process.pid] = entry
+            return entry
+
+    @staticmethod
+    def _read_root_status(status_fd: int) -> int:
+        try:
+            chunks = []
+            while True:
+                chunk = os.read(status_fd, 32)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                if b"\n" in chunk:
+                    break
+        finally:
+            os.close(status_fd)
+        status = b"".join(chunks).strip()
+        if not status:
+            raise RuntimeError("subprocess supervisor exited without root status")
+        return int(status)
+
+    @staticmethod
+    def _resolved_returncode(entry: _ProcessEntry) -> int | None:
+        if entry.root_status is not None and entry.root_status.done():
+            try:
+                return entry.root_status.result()
+            except (asyncio.CancelledError, Exception):
+                pass
+        return entry.process.returncode
+
+    async def _cleanup_failed_windows_spawn(
+        self,
+        process: asyncio.subprocess.Process,
+        communication: asyncio.Task[tuple[bytes, bytes]],
+    ) -> None:
+        await self._signal_windows_tree(process, force=True)
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(communication),
+                timeout=self.force_wait,
+            )
+        except asyncio.TimeoutError:
+            communication.cancel()
+            await asyncio.gather(communication, return_exceptions=True)
+
+    async def shutdown(self) -> ShutdownReport:
+        """Stop every active tree within two bounded wait periods."""
+        async with self._guard:
+            self._closing = True
+            entries = list(self._entries.values())
+
+        outcomes = await asyncio.gather(
+            *(self._terminate(entry, reason="worker shutdown") for entry in entries)
+        )
+        return ShutdownReport(
+            terminated=len(entries),
+            forced=sum(1 for _, _, forced in outcomes if forced),
+        )
+
+    def _apply_process_group(self, kwargs: dict[str, Any]) -> None:
+        if self.platform == "win32":
+            kwargs["creationflags"] = (
+                kwargs.get("creationflags", 0)
+                | _WINDOWS_NEW_PROCESS_GROUP
+                | _WINDOWS_CREATE_SUSPENDED
+            )
+        else:
+            kwargs.setdefault("start_new_session", True)
+
+    async def _terminate(
+        self,
+        entry: _ProcessEntry,
+        *,
+        reason: str,
+    ) -> tuple[bytes, bytes, bool]:
+        async with self._guard:
+            if entry.termination is None:
+                entry.termination = asyncio.create_task(
+                    self._terminate_tree(entry, reason=reason)
+                )
+            termination = entry.termination
+
+        cancellation: asyncio.CancelledError | None = None
+        try:
+            while True:
+                try:
+                    result = await asyncio.shield(termination)
+                    break
+                except asyncio.CancelledError as error:
+                    if termination.cancelled():
+                        raise
+                    cancellation = cancellation or error
+            if cancellation is not None:
+                raise cancellation
+            return result
+        finally:
+            if termination.done():
+                await self._release_entry(entry)
+
+    async def _terminate_tree(
+        self,
+        entry: _ProcessEntry,
+        *,
+        reason: str,
+    ) -> tuple[bytes, bytes, bool]:
+        if not self._tree_is_alive(entry) and entry.communication.done():
+            return (*await self._read_output(entry), False)
+
+        await self._signal_tree(entry, force=False)
+        if await self._wait_stopped(entry, timeout=self.grace_period):
+            return (*await self._read_output(entry), False)
+
+        self.logger.warning(
+            "forcing subprocess tree %d to stop after %s",
+            entry.process.pid,
+            reason,
+        )
+
+        await self._signal_tree(entry, force=True)
+        if not await self._wait_stopped(entry, timeout=self.force_wait):
+            self.logger.error(
+                "subprocess tree %d survived forced termination or kept pipes open",
+                entry.process.pid,
+            )
+            entry.communication.cancel()
+            await asyncio.gather(entry.communication, return_exceptions=True)
+            return b"", b"", True
+        return (*await self._read_output(entry), True)
+
+    async def _wait_stopped(
+        self,
+        entry: _ProcessEntry,
+        *,
+        timeout: float,
+    ) -> bool:
+        deadline = asyncio.get_running_loop().time() + timeout
+        while self._tree_is_alive(entry) or not entry.communication.done():
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(0.05, remaining))
+        return True
+
+    async def _read_output(
+        self,
+        entry: _ProcessEntry,
+    ) -> tuple[bytes, bytes]:
+        if not entry.communication.done():
+            await entry.communication
+        if entry.communication.cancelled():
+            return b"", b""
+        exception = entry.communication.exception()
+        if exception is not None:
+            raise exception
+        return entry.communication.result()
+
+    def _tree_is_alive(self, entry: _ProcessEntry) -> bool:
+        process = entry.process
+        if self.platform == "win32":
+            if entry.windows_job is not None:
+                return entry.windows_job.active_processes() > 0
+            return process.returncode is None
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+        if self.platform.startswith("linux"):
+            return self._linux_group_has_live_members(process.pid)
+        return True
+
+    @staticmethod
+    def _linux_group_has_live_members(group_id: int) -> bool:
+        for stat_path in Path("/proc").glob("[0-9]*/stat"):
+            try:
+                stat = stat_path.read_text()
+                fields = stat[stat.rfind(")") + 2 :].split()
+                state = fields[0]
+                process_group = int(fields[2])
+            except (OSError, ValueError, IndexError):
+                continue
+            if process_group == group_id and state != "Z":
+                return True
+        return False
+
+    async def _signal_tree(
+        self,
+        entry: _ProcessEntry,
+        *,
+        force: bool,
+    ) -> None:
+        process = entry.process
+        if self.platform == "win32":
+            if force and entry.windows_job is not None:
+                entry.windows_job.terminate()
+                return
+            await self._signal_windows_tree(process, force=force)
+            return
+
+        if self.platform.startswith("linux"):
+            if force and _LINUX_FORCE_SIGNAL is None:
+                raise RuntimeError("SIGUSR1 is required for Linux force cleanup")
+            supervisor_signal = _LINUX_FORCE_SIGNAL if force else signal.SIGTERM
+            try:
+                os.kill(process.pid, supervisor_signal)
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                self.logger.exception(
+                    "cannot signal subprocess supervisor %d",
+                    process.pid,
+                )
+            return
+
+        group_signal = signal.SIGKILL if force else signal.SIGTERM
+        try:
+            os.killpg(process.pid, group_signal)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            self.logger.exception(
+                "cannot signal subprocess group %d",
+                process.pid,
+            )
+            if process.returncode is None:
+                process.kill() if force else process.terminate()
+
+    async def _release_entry(self, entry: _ProcessEntry) -> None:
+        windows_job = None
+        async with self._guard:
+            if self._entries.get(entry.process.pid) is entry:
+                self._entries.pop(entry.process.pid, None)
+            windows_job, entry.windows_job = entry.windows_job, None
+        if windows_job is not None:
+            windows_job.close()
+        if entry.root_status is not None and entry.communication.done():
+            await asyncio.gather(entry.root_status, return_exceptions=True)
+
+    async def _signal_windows_tree(
+        self,
+        process: asyncio.subprocess.Process,
+        *,
+        force: bool,
+    ) -> None:
+        try:
+            helper = await asyncio.create_subprocess_exec(
+                *_windows_taskkill_command(process.pid, force=force),
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(
+                helper.communicate(),
+                timeout=self.grace_period,
+            )
+            if helper.returncode not in (0, 128):
+                self.logger.warning(
+                    "taskkill failed for subprocess tree %d: %s",
+                    process.pid,
+                    stderr.decode(errors="replace").strip(),
+                )
+        except (FileNotFoundError, asyncio.TimeoutError):
+            self.logger.exception(
+                "could not run taskkill for subprocess tree %d",
+                process.pid,
+            )
+            if process.returncode is None:
+                process.kill() if force else process.terminate()

--- a/worker/worker/subprocesses.py
+++ b/worker/worker/subprocesses.py
@@ -6,9 +6,11 @@ import asyncio
 import ctypes
 import logging
 import os
+import select
 import signal
 import subprocess
 import sys
+import threading
 from collections.abc import Awaitable, Callable
 from ctypes import wintypes
 from dataclasses import dataclass
@@ -305,7 +307,8 @@ class ShutdownReport:
 class _ProcessEntry:
     process: asyncio.subprocess.Process
     communication: asyncio.Task[tuple[bytes, bytes]]
-    root_status: asyncio.Task[int] | None = None
+    root_status: asyncio.Task[int | None] | None = None
+    root_status_stop: threading.Event | None = None
     windows_job: Any | None = None
     termination: asyncio.Task[tuple[bytes, bytes, bool]] | None = None
 
@@ -427,14 +430,25 @@ class SubprocessOwner:
         try:
             entry = await asyncio.shield(registration)
         except asyncio.CancelledError as cancellation:
-            try:
-                entry = await asyncio.shield(registration)
-            except BaseException:
-                raise cancellation
+            while True:
+                try:
+                    entry = await asyncio.shield(registration)
+                    break
+                except asyncio.CancelledError:
+                    if registration.cancelled():
+                        raise cancellation
+                except BaseException:
+                    raise cancellation
             cleanup = asyncio.create_task(
                 self._terminate(entry, reason="task cancellation during spawn")
             )
-            await asyncio.shield(cleanup)
+            while True:
+                try:
+                    await asyncio.shield(cleanup)
+                    break
+                except asyncio.CancelledError:
+                    if cleanup.cancelled():
+                        raise cancellation
             raise cancellation
 
         process = entry.process
@@ -461,11 +475,29 @@ class SubprocessOwner:
                     timed_out=True,
                     forced=forced,
                 )
-            except asyncio.CancelledError:
+            except asyncio.CancelledError as cancellation:
                 cleanup = asyncio.create_task(
                     self._terminate(entry, reason="task cancellation")
                 )
-                await asyncio.shield(cleanup)
+                while True:
+                    try:
+                        await asyncio.shield(cleanup)
+                        break
+                    except asyncio.CancelledError:
+                        if cleanup.cancelled():
+                            raise cancellation
+                raise cancellation
+            except Exception:
+                cleanup = asyncio.create_task(
+                    self._terminate(entry, reason="supervisor status failure")
+                )
+                while True:
+                    try:
+                        await asyncio.shield(cleanup)
+                        break
+                    except asyncio.CancelledError:
+                        if cleanup.cancelled():
+                            raise
                 raise
 
             if entry.root_status is None:
@@ -473,6 +505,8 @@ class SubprocessOwner:
                 root_returncode = process.returncode
             else:
                 root_returncode = command_result
+                if root_returncode is None:
+                    root_returncode = process.returncode
                 stdout = stderr = b""
             forced = False
             if self._tree_is_alive(entry) or not communication.done():
@@ -480,6 +514,8 @@ class SubprocessOwner:
                     entry,
                     reason="root process exit",
                 )
+            elif entry.root_status is not None:
+                stdout, stderr = await self._read_output(entry)
             return ProcessResult(
                 root_returncode,
                 stdout,
@@ -515,9 +551,15 @@ class SubprocessOwner:
 
             communication = asyncio.create_task(process.communicate(input))
             root_status = None
+            root_status_stop = None
             if status_read_fd is not None:
+                root_status_stop = threading.Event()
                 root_status = asyncio.create_task(
-                    asyncio.to_thread(self._read_root_status, status_read_fd)
+                    asyncio.to_thread(
+                        self._read_root_status,
+                        status_read_fd,
+                        root_status_stop,
+                    )
                 )
             windows_job = None
             if self.platform == "win32":
@@ -536,16 +578,33 @@ class SubprocessOwner:
                 process=process,
                 communication=communication,
                 root_status=root_status,
+                root_status_stop=root_status_stop,
                 windows_job=windows_job,
             )
             self._entries[process.pid] = entry
             return entry
 
     @staticmethod
-    def _read_root_status(status_fd: int) -> int:
+    def _read_root_status(
+        status_fd: int,
+        stop: threading.Event | None = None,
+    ) -> int | None:
         try:
             chunks = []
+            poller = select.poll()
+            poller.register(
+                status_fd,
+                select.POLLIN | select.POLLHUP | select.POLLERR,
+            )
             while True:
+                if stop is not None and stop.is_set():
+                    return None
+                try:
+                    events = poller.poll(50)
+                except InterruptedError:
+                    continue
+                if not events:
+                    continue
                 chunk = os.read(status_fd, 32)
                 if not chunk:
                     break
@@ -775,7 +834,16 @@ class SubprocessOwner:
             windows_job, entry.windows_job = entry.windows_job, None
         if windows_job is not None:
             windows_job.close()
-        if entry.root_status is not None and entry.communication.done():
+        if entry.root_status is not None:
+            if not entry.root_status.done() and entry.root_status_stop is not None:
+                entry.root_status_stop.set()
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(entry.root_status),
+                    timeout=self.force_wait,
+                )
+            except asyncio.TimeoutError:
+                entry.root_status.cancel()
             await asyncio.gather(entry.root_status, return_exceptions=True)
 
     async def _signal_windows_tree(
@@ -784,14 +852,17 @@ class SubprocessOwner:
         *,
         force: bool,
     ) -> None:
+        helper = None
+        communication = None
         try:
             helper = await asyncio.create_subprocess_exec(
                 *_windows_taskkill_command(process.pid, force=force),
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.PIPE,
             )
+            communication = asyncio.create_task(helper.communicate())
             _, stderr = await asyncio.wait_for(
-                helper.communicate(),
+                asyncio.shield(communication),
                 timeout=self.grace_period,
             )
             if helper.returncode not in (0, 128):
@@ -800,7 +871,28 @@ class SubprocessOwner:
                     process.pid,
                     stderr.decode(errors="replace").strip(),
                 )
-        except (FileNotFoundError, asyncio.TimeoutError):
+        except asyncio.TimeoutError:
+            if helper is not None:
+                try:
+                    helper.kill()
+                except ProcessLookupError:
+                    pass
+            if communication is not None:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(communication),
+                        timeout=self.force_wait,
+                    )
+                except asyncio.TimeoutError:
+                    communication.cancel()
+                await asyncio.gather(communication, return_exceptions=True)
+            self.logger.exception(
+                "taskkill timed out for subprocess tree %d",
+                process.pid,
+            )
+            if process.returncode is None:
+                process.kill() if force else process.terminate()
+        except FileNotFoundError:
             self.logger.exception(
                 "could not run taskkill for subprocess tree %d",
                 process.pid,


### PR DESCRIPTION
## Summary

- add a shared subprocess owner for worker CLI calls
- supervise Linux descendants with a child subreaper, including processes that call `setsid()`
- attach suspended Windows roots to kill-on-close Job Objects before execution
- route Gemini, Claude, and social-scroller calls through bounded timeout, cancellation, and shutdown cleanup
- preserve output across completion races and make timeout, repeated cancellation, supervisor failure, status-reader, and Windows helper cleanup bounded
- restore Python-ignored signals before Linux `exec`
- add worker tests to the pull request build

## Test plan

- `uv run --isolated --project . --extra dev python -m pytest tests/ -q` equivalent isolated run: 170 passed
- changed-file Ruff checks: passed
- focused regressions for output races, repeated cancellation, shutdown bounds, status failure, high-numbered descriptors, Windows helper reaping, Windows collection, and inherited signals: passed
- four local review passes used, the configured cap; findings from the fourth pass were fixed test-first and followed by the full suite
- all six inline review conversations resolved after the verified push

## Handoff

The two-milestone release state, platform gates, merge order, and restart checklist are recorded in [the dated handoff](https://github.com/jamditis/keyjawn/blob/fix/64-worker-subprocess-cleanup/docs/handoffs/2026-07-25-two-milestone-release.md).

## Remaining gate

- wait for the workflow on head `84eb253` and confirm it passes
- obtain Joe's explicit approval for this pull request before merging

Closes #64