### PR TITLE
Add the macro model and JSON store

### DIFF
--- a/app/src/main/java/com/keyjawn/MacroStore.kt
+++ b/app/src/main/java/com/keyjawn/MacroStore.kt
@@ -1,0 +1,100 @@
+package com.keyjawn
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+sealed class MacroStep {
+    data class KeyTap(val keyCode: Int, val ctrl: Boolean = false) : MacroStep()
+    data class Text(val literal: String) : MacroStep()
+    data class Delay(val ms: Int) : MacroStep()
+}
+
+data class Macro(val label: String, val steps: List<MacroStep>)
+
+class MacroStore(context: Context) {
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun load(): Map<String, Macro> {
+        val json = prefs.getString(PREFS_KEY, null) ?: return emptyMap()
+        return try {
+            deserialize(json)
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    fun save(id: String, macro: Macro) {
+        val macros = load().toMutableMap()
+        macros[id] = macro
+        prefs.edit().putString(PREFS_KEY, serialize(macros)).apply()
+    }
+
+    companion object {
+        internal const val PREFS_NAME = "keyjawn_macros"
+        internal const val PREFS_KEY = "macros"
+
+        internal fun serialize(macros: Map<String, Macro>): String {
+            val root = JSONObject()
+            for ((id, macro) in macros) {
+                root.put(
+                    id,
+                    JSONObject().apply {
+                        put("label", macro.label)
+                        put(
+                            "steps",
+                            JSONArray().apply {
+                                macro.steps.forEach { put(serializeStep(it)) }
+                            }
+                        )
+                    }
+                )
+            }
+            return root.toString()
+        }
+
+        internal fun deserialize(json: String): Map<String, Macro> {
+            val root = JSONObject(json)
+            val macros = linkedMapOf<String, Macro>()
+            for (id in root.keys()) {
+                val obj = root.getJSONObject(id)
+                val jsonSteps = obj.getJSONArray("steps")
+                val steps = (0 until jsonSteps.length()).map { index ->
+                    deserializeStep(jsonSteps.getJSONObject(index))
+                }
+                macros[id] = Macro(obj.getString("label"), steps)
+            }
+            return macros
+        }
+
+        private fun serializeStep(step: MacroStep): JSONObject =
+            JSONObject().apply {
+                when (step) {
+                    is MacroStep.KeyTap -> {
+                        put("type", "key")
+                        put("keyCode", step.keyCode)
+                        put("ctrl", step.ctrl)
+                    }
+                    is MacroStep.Text -> {
+                        put("type", "text")
+                        put("literal", step.literal)
+                    }
+                    is MacroStep.Delay -> {
+                        put("type", "delay")
+                        put("ms", step.ms)
+                    }
+                }
+            }
+
+        private fun deserializeStep(obj: JSONObject): MacroStep =
+            when (obj.getString("type")) {
+                "key" -> MacroStep.KeyTap(
+                    keyCode = obj.getInt("keyCode"),
+                    ctrl = obj.getBoolean("ctrl")
+                )
+                "text" -> MacroStep.Text(obj.getString("literal"))
+                "delay" -> MacroStep.Delay(obj.getInt("ms"))
+                else -> error("Unknown macro step type")
+            }
+    }
+}

--- a/app/src/main/java/com/keyjawn/MacroStore.kt
+++ b/app/src/main/java/com/keyjawn/MacroStore.kt
@@ -16,8 +16,8 @@ class MacroStore(context: Context) {
     private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
     fun load(): Map<String, Macro> {
-        val json = prefs.getString(PREFS_KEY, null) ?: return emptyMap()
         return try {
+            val json = prefs.getString(PREFS_KEY, null) ?: return emptyMap()
             deserialize(json)
         } catch (_: Exception) {
             emptyMap()

--- a/app/src/test/java/com/keyjawn/MacroStoreTest.kt
+++ b/app/src/test/java/com/keyjawn/MacroStoreTest.kt
@@ -1,0 +1,79 @@
+package com.keyjawn
+
+import android.content.Context
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MacroStoreTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        context.getSharedPreferences(MacroStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun `save then fresh load round trips every step in order`() {
+        val macro = Macro(
+            label = "Agent prompt",
+            steps = listOf(
+                MacroStep.Text("Review this"),
+                MacroStep.Delay(250),
+                MacroStep.KeyTap(keyCode = 66, ctrl = true)
+            )
+        )
+
+        MacroStore(context).save("agent_prompt", macro)
+
+        assertEquals(macro, MacroStore(context).load()["agent_prompt"])
+    }
+
+    @Test
+    fun `every step type serializes with its discriminator and deserializes equally`() {
+        val macro = Macro(
+            label = "All steps",
+            steps = listOf(
+                MacroStep.KeyTap(keyCode = 61),
+                MacroStep.Text("literal"),
+                MacroStep.Delay(500)
+            )
+        )
+
+        val json = MacroStore.serialize(mapOf("all" to macro))
+        val steps = JSONObject(json).getJSONObject("all").getJSONArray("steps")
+
+        assertEquals("key", steps.getJSONObject(0).getString("type"))
+        assertEquals("text", steps.getJSONObject(1).getString("type"))
+        assertEquals("delay", steps.getJSONObject(2).getString("type"))
+        assertEquals(mapOf("all" to macro), MacroStore.deserialize(json))
+    }
+
+    @Test
+    fun `missing macros load as empty`() {
+        assertTrue(MacroStore(context).load().isEmpty())
+    }
+
+    @Test
+    fun `corrupt macros load as empty without throwing`() {
+        context.getSharedPreferences(MacroStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(MacroStore.PREFS_KEY, "{not json")
+            .commit()
+
+        assertTrue(MacroStore(context).load().isEmpty())
+    }
+}

--- a/app/src/test/java/com/keyjawn/MacroStoreTest.kt
+++ b/app/src/test/java/com/keyjawn/MacroStoreTest.kt
@@ -76,4 +76,14 @@ class MacroStoreTest {
 
         assertTrue(MacroStore(context).load().isEmpty())
     }
+
+    @Test
+    fun `non-string macros load as empty without throwing`() {
+        context.getSharedPreferences(MacroStore.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putInt(MacroStore.PREFS_KEY, 42)
+            .commit()
+
+        assertTrue(MacroStore(context).load().isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary

- add the phase-one `MacroStep` model with only key tap, text, and delay steps
- persist labeled, ordered macro step lists as discriminated JSON in a dedicated SharedPreferences store
- treat missing, malformed, or unknown macro data as empty so corrupt preferences cannot crash the IME
- keep playback, slot binding, recording, and UI out of this phase

Closes #55

## Verification

- `./gradlew testLiteDebugUnitTest testFullDebugUnitTest`
- `./gradlew lintLiteDebug lintFullDebug`
- round-trip coverage for every step type and ordered lists
- missing and corrupt preference coverage

## Data contract

The issue-selected JSON shape is the initial persisted contract. If a later phase needs an incompatible schema, it can read and migrate `macros` into a versioned preference key without changing this phase's on-device data in place.

## Remaining gate

- obtain Joe's explicit approval for this PR before merge