### PR TITLE
Add skippable first-launch keyboard setup

### DIFF
--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -7,38 +7,58 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */; };
+		15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */; };
+		1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */; };
 		1F3BC0FB1DEE09CF9586840D /* HostTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */; };
 		1F6BA06DD660C887B3E1F79C /* KeyJawnApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */; };
 		306C46342B0B52F882443953 /* AppGroupHostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88516F15428436E247E65FD4 /* AppGroupHostStore.swift */; };
 		30FBF6554FC7A6F5548299C1 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B581E797ADEF1572390A6096 /* KeyboardViewController.swift */; };
 		32EB71B5DE76A94E371D71A0 /* SSHSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4B394C56787E8E05B58A1 /* SSHSession.swift */; };
+		348C2A63B6E68B94EE380311 /* InputViewAudioFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */; };
 		35BA636F86655A1E133B3BB2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98623C822345E60C48D7464D /* Assets.xcassets */; };
-		4F7A9D6C2B8E1A305C9F0D12 /* NIOPosix in Frameworks */ = {isa = PBXBuildFile; productRef = 7B3C8E1D4A6F2095D0B7C314 /* NIOPosix */; };
 		5629A0DC0147C9A855D09E0F /* CitadelSCPUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */; };
 		5A4CC73980A76F9DB9E5A5E2 /* TerminalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6FA031277F874D263EF7AD /* TerminalViewController.swift */; };
+		5A51BC905F126948A48544C7 /* KeyboardPrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */; };
+		5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */; };
 		5DF5361C7BE43FB5D0F34CA5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */; };
+		5E5AAF93DC09AC4305BDA08D /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ABDD7F74E5CC85881A5948 /* OnboardingView.swift */; };
 		6350BC0215D4AF763D7B6A6B /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = CB9AD386707E3751FAD823A1 /* Citadel */; };
 		67B39BE35B75861A3813BF5C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF300C5B755C35A8B51FED3 /* SettingsView.swift */; };
+		68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5835AD51EEE0C920DE898BD /* AltKeyMappingsTests.swift */; };
 		68B8A22CEFDB19DE99CA2EB5 /* HostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301482A615F90B93947563BC /* HostListView.swift */; };
+		76503EE687E0F88885DD27DE /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 974D61CF6F7ADA4824D53DC7 /* NIOSSH */; };
 		7E2C29A442AE9E2630A2F301 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5405F0BD516F74C8E0EED5 /* HostStore.swift */; };
 		9DA97D841DD222F4BC99CFC9 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1BD7D5FD852EEF611DFEF3BA /* KeyJawnKit */; };
+		A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */; };
 		A9DB22FF0F4C815305CC6106 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = D3233B073CCE7B0FEFB818EA /* KeyJawnKit */; };
 		AA523563B70682B4341E113C /* SSHKeysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC90B529187AE9DAFC1CDE6 /* SSHKeysView.swift */; };
-		ADF9A4E2708CD41A45004661 /* SharedSSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B8104B916CCC1CDE9400E8 /* SharedSSHKeyStore.swift */; };
 		B958AD522581630C2F77C218 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9319CFF9722F6941701039BF /* NIOCore */; };
 		BB7A5E0F892D8EA9821654B3 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = C5D92697896E36FD6161FB69 /* NIOCore */; };
+		BD84EA7B58CE9D2536EADB34 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = 77314FC70430F6B0FC36684C /* KeyJawnKit */; };
 		BF99261856285D2DA591AEB2 /* KeyJawnKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 22D494658DBEB0D051FF4A8C /* KeyJawnKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		C2F8D707F7F9F58DA50E2A7F /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 974D61CF6F7ADA4824D53DC7 /* NIOSSH */; };
+		C01DB065ADBBD129FDFA832F /* SlashCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DF2807E8DD4CB2A02999BA /* SlashCommandTests.swift */; };
+		C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B940C548C192782A1073E16 /* HostConfigTests.swift */; };
+		C2F8D707F7F9F58DA50E2A7F /* NIOPosix in Frameworks */ = {isa = PBXBuildFile; productRef = 2C94B23FBDB89626C8A0294C /* NIOPosix */; };
 		C5D73FD296E1B9A8CD97626C /* SSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */; };
 		CA738FCA57272508A304C827 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = DBC5B9DCB9FBC1D3E054CE8F /* SwiftTerm */; };
 		D4959C7C420241BE04B8CD59 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 060BD31A2DD85CF9C0F6FE6F /* Citadel */; };
 		D833730B6D5B5B7CD1D39B17 /* TerminalInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F295D7985B88063D1F195088 /* TerminalInputView.swift */; };
+		DE63F87E7794F4FF03DA7A43 /* ANSISequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */; };
+		EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */; };
 		EB892014C8DC6C2A3258F241 /* PasswordPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6274AD171FD2D143D7DFDAC /* PasswordPromptView.swift */; };
 		ED013FF5D11FE489D6798508 /* HostEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5418E5BFCD5CA8FE0DDDAC5 /* HostEditView.swift */; };
 		EF86DC91B3F6A441505BFFF0 /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = E6BD72243EA2001DD46465E8 /* NIOSSH */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		563D214484F90B42E8D0A3E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CCE8758E3FDE1B4AD2B13B6F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8DE24E0AF7D60F6E8E2BA73E;
+			remoteInfo = KeyJawn;
+		};
 		E4D89C23F9C0FA756FEF3DAF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CCE8758E3FDE1B4AD2B13B6F /* Project object */;
@@ -70,25 +90,46 @@
 		2CC90B529187AE9DAFC1CDE6 /* SSHKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeysView.swift; sourceTree = "<group>"; };
 		2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyStore.swift; sourceTree = "<group>"; };
 		301482A615F90B93947563BC /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
+		396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPrefsTests.swift; sourceTree = "<group>"; };
 		62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		665662BFA6DECCD61154BEE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBoundaryTests.swift; sourceTree = "<group>"; };
 		7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTerminalView.swift; sourceTree = "<group>"; };
 		88516F15428436E247E65FD4 /* AppGroupHostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupHostStore.swift; sourceTree = "<group>"; };
-		95B8104B916CCC1CDE9400E8 /* SharedSSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSSHKeyStore.swift; sourceTree = "<group>"; };
+		97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputViewAudioFeedback.swift; sourceTree = "<group>"; };
+		98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayersTests.swift; sourceTree = "<group>"; };
 		98623C822345E60C48D7464D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		99A67662436F2C1180E1376F /* KeyJawnKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = KeyJawnKit; path = KeyJawnKit; sourceTree = SOURCE_ROOT; };
+		9B940C548C192782A1073E16 /* HostConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConfigTests.swift; sourceTree = "<group>"; };
 		A6274AD171FD2D143D7DFDAC /* PasswordPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordPromptView.swift; sourceTree = "<group>"; };
 		A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitadelSCPUploader.swift; sourceTree = "<group>"; };
 		AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyJawnApp.swift; sourceTree = "<group>"; };
 		AEF300C5B755C35A8B51FED3 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B5418E5BFCD5CA8FE0DDDAC5 /* HostEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostEditView.swift; sourceTree = "<group>"; };
 		B581E797ADEF1572390A6096 /* KeyboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardViewController.swift; sourceTree = "<group>"; };
+		B9DF2807E8DD4CB2A02999BA /* SlashCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandTests.swift; sourceTree = "<group>"; };
 		BC5405F0BD516F74C8E0EED5 /* HostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostStore.swift; sourceTree = "<group>"; };
+		C3ABDD7F74E5CC85881A5948 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
+		D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlStateTests.swift; sourceTree = "<group>"; };
+		D5835AD51EEE0C920DE898BD /* AltKeyMappingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltKeyMappingsTests.swift; sourceTree = "<group>"; };
+		D9913D1DFEB392733BA6B353 /* KeyJawnKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KeyJawnKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSSHKeyStore.swift; sourceTree = "<group>"; };
+		DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSISequenceTests.swift; sourceTree = "<group>"; };
 		DF6FA031277F874D263EF7AD /* TerminalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewController.swift; sourceTree = "<group>"; };
 		F295D7985B88063D1F195088 /* TerminalInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputView.swift; sourceTree = "<group>"; };
+		F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
+		FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardThemeContrastTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		46250930F872E7A12C3E9EBD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BD84EA7B58CE9D2536EADB34 /* KeyJawnKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		665CFC2E5492C3D48C05C775 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -97,8 +138,8 @@
 				CA738FCA57272508A304C827 /* SwiftTerm in Frameworks */,
 				6350BC0215D4AF763D7B6A6B /* Citadel in Frameworks */,
 				B958AD522581630C2F77C218 /* NIOCore in Frameworks */,
-				4F7A9D6C2B8E1A305C9F0D12 /* NIOPosix in Frameworks */,
-				C2F8D707F7F9F58DA50E2A7F /* NIOSSH in Frameworks */,
+				C2F8D707F7F9F58DA50E2A7F /* NIOPosix in Frameworks */,
+				76503EE687E0F88885DD27DE /* NIOSSH in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +174,23 @@
 				2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */,
 			);
 			path = Store;
+			sourceTree = "<group>";
+		};
+		5C348A9867C54DD9765F499B /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				D5835AD51EEE0C920DE898BD /* AltKeyMappingsTests.swift */,
+				DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */,
+				D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */,
+				9B940C548C192782A1073E16 /* HostConfigTests.swift */,
+				98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */,
+				396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */,
+				FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */,
+				F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */,
+				B9DF2807E8DD4CB2A02999BA /* SlashCommandTests.swift */,
+				686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		5FAE6907FF19D4FF99CBBFEE /* KeyJawn */ = {
@@ -173,10 +231,11 @@
 			isa = PBXGroup;
 			children = (
 				88516F15428436E247E65FD4 /* AppGroupHostStore.swift */,
-				95B8104B916CCC1CDE9400E8 /* SharedSSHKeyStore.swift */,
 				A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */,
 				2B92C187EB65640055598EB8 /* Info.plist */,
+				97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */,
 				B581E797ADEF1572390A6096 /* KeyboardViewController.swift */,
+				DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */,
 			);
 			path = KeyJawnKeyboard;
 			sourceTree = "<group>";
@@ -186,6 +245,7 @@
 			children = (
 				1455FBB90189E98F89DA75E3 /* KeyJawn.app */,
 				22D494658DBEB0D051FF4A8C /* KeyJawnKeyboard.appex */,
+				D9913D1DFEB392733BA6B353 /* KeyJawnKitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -196,6 +256,7 @@
 				5FAE6907FF19D4FF99CBBFEE /* KeyJawn */,
 				B0C968F9E2B99A69F54EEB84 /* KeyJawnKeyboard */,
 				EA6DC54EB5C8ABF2BCAB440C /* Packages */,
+				5C348A9867C54DD9765F499B /* Tests */,
 				B6F9E3CE713D092F9DF0D5CB /* Products */,
 			);
 			sourceTree = "<group>";
@@ -205,6 +266,7 @@
 			children = (
 				62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */,
 				AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */,
+				C3ABDD7F74E5CC85881A5948 /* OnboardingView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -220,6 +282,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		8524D9D4D7AA4286DF9B7EDC /* KeyJawnKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 358BE103B2FA779246962531 /* Build configuration list for PBXNativeTarget "KeyJawnKitTests" */;
+			buildPhases = (
+				0AB17E96A9D99CC4392C1B0C /* Sources */,
+				46250930F872E7A12C3E9EBD /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A55923E7E31E061347032269 /* PBXTargetDependency */,
+			);
+			name = KeyJawnKitTests;
+			packageProductDependencies = (
+				77314FC70430F6B0FC36684C /* KeyJawnKit */,
+			);
+			productName = KeyJawnKitTests;
+			productReference = D9913D1DFEB392733BA6B353 /* KeyJawnKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		8DE24E0AF7D60F6E8E2BA73E /* KeyJawn */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E00B304EAF9FA63522412A8B /* Build configuration list for PBXNativeTarget "KeyJawn" */;
@@ -240,7 +322,7 @@
 				DBC5B9DCB9FBC1D3E054CE8F /* SwiftTerm */,
 				CB9AD386707E3751FAD823A1 /* Citadel */,
 				9319CFF9722F6941701039BF /* NIOCore */,
-				7B3C8E1D4A6F2095D0B7C314 /* NIOPosix */,
+				2C94B23FBDB89626C8A0294C /* NIOPosix */,
 				974D61CF6F7ADA4824D53DC7 /* NIOSSH */,
 			);
 			productName = KeyJawn;
@@ -278,6 +360,10 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
+					8524D9D4D7AA4286DF9B7EDC = {
+						DevelopmentTeam = 5624SD289G;
+						ProvisioningStyle = Automatic;
+					};
 					8DE24E0AF7D60F6E8E2BA73E = {
 						DevelopmentTeam = 5624SD289G;
 					};
@@ -309,6 +395,7 @@
 			targets = (
 				8DE24E0AF7D60F6E8E2BA73E /* KeyJawn */,
 				D49A0F8A52046B2B5DB06FC5 /* KeyJawnKeyboard */,
+				8524D9D4D7AA4286DF9B7EDC /* KeyJawnKitTests */,
 			);
 		};
 /* End PBXProject section */
@@ -325,14 +412,32 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0AB17E96A9D99CC4392C1B0C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE63F87E7794F4FF03DA7A43 /* ANSISequenceTests.swift in Sources */,
+				68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */,
+				5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */,
+				C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */,
+				EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */,
+				5A51BC905F126948A48544C7 /* KeyboardPrefsTests.swift in Sources */,
+				12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */,
+				15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */,
+				C01DB065ADBBD129FDFA832F /* SlashCommandTests.swift in Sources */,
+				A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		237E92B592B1ABCED91EE6C6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				306C46342B0B52F882443953 /* AppGroupHostStore.swift in Sources */,
-				ADF9A4E2708CD41A45004661 /* SharedSSHKeyStore.swift in Sources */,
 				5629A0DC0147C9A855D09E0F /* CitadelSCPUploader.swift in Sources */,
+				348C2A63B6E68B94EE380311 /* InputViewAudioFeedback.swift in Sources */,
 				30FBF6554FC7A6F5548299C1 /* KeyboardViewController.swift in Sources */,
+				1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -346,6 +451,7 @@
 				7E2C29A442AE9E2630A2F301 /* HostStore.swift in Sources */,
 				1F3BC0FB1DEE09CF9586840D /* HostTerminalView.swift in Sources */,
 				1F6BA06DD660C887B3E1F79C /* KeyJawnApp.swift in Sources */,
+				5E5AAF93DC09AC4305BDA08D /* OnboardingView.swift in Sources */,
 				EB892014C8DC6C2A3258F241 /* PasswordPromptView.swift in Sources */,
 				C5D73FD296E1B9A8CD97626C /* SSHKeyStore.swift in Sources */,
 				AA523563B70682B4341E113C /* SSHKeysView.swift in Sources */,
@@ -364,9 +470,35 @@
 			target = D49A0F8A52046B2B5DB06FC5 /* KeyJawnKeyboard */;
 			targetProxy = E4D89C23F9C0FA756FEF3DAF /* PBXContainerItemProxy */;
 		};
+		A55923E7E31E061347032269 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8DE24E0AF7D60F6E8E2BA73E /* KeyJawn */;
+			targetProxy = 563D214484F90B42E8D0A3E8 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2AFA74702DA362ABD727849D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5624SD289G;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.keyjawn.tests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KeyJawn.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/KeyJawn";
+			};
+			name = Debug;
+		};
 		478B7335DAD39DF8D4D8DDC3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -534,6 +666,27 @@
 			};
 			name = Release;
 		};
+		C4C5222774657B204D4F17BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5624SD289G;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.keyjawn.tests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/KeyJawn.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/KeyJawn";
+			};
+			name = Release;
+		};
 		E6F1D58995AC59350BCB0EF8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -588,6 +741,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		358BE103B2FA779246962531 /* Build configuration list for PBXNativeTarget "KeyJawnKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2AFA74702DA362ABD727849D /* Debug */,
+				C4C5222774657B204D4F17BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		583BB0090DF66C4B0088B727 /* Build configuration list for PBXNativeTarget "KeyJawnKeyboard" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -669,10 +831,14 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = KeyJawnKit;
 		};
-		7B3C8E1D4A6F2095D0B7C314 /* NIOPosix */ = {
+		2C94B23FBDB89626C8A0294C /* NIOPosix */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E40D541DF4CADBAB4CD9CCCB /* XCRemoteSwiftPackageReference "swift-nio" */;
 			productName = NIOPosix;
+		};
+		77314FC70430F6B0FC36684C /* KeyJawnKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = KeyJawnKit;
 		};
 		9319CFF9722F6941701039BF /* NIOCore */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ios/KeyJawn/App/ContentView.swift
+++ b/ios/KeyJawn/App/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     // nothing — a first launch that looks broken. Hosts is where the app actually
     // starts: add a server, tap it, get a shell.
     @State private var selection: Tab = .hosts
+    @State private var showOnboarding = !KeyboardPrefs.shared.hasCompletedOnboarding
 
     var body: some View {
         TabView(selection: $selection) {
@@ -23,11 +24,16 @@ struct ContentView: View {
                 .tabItem { Label("Preview", systemImage: "terminal") }
                 .tag(Tab.preview)
 
-            SettingsView()
+            SettingsView(showOnboarding: $showOnboarding)
                 .tabItem { Label("Settings", systemImage: "gearshape") }
                 .tag(Tab.settings)
         }
         .preferredColorScheme(.dark)
+        .fullScreenCover(isPresented: $showOnboarding) {
+            OnboardingView {
+                showOnboarding = false
+            }
+        }
     }
 }
 

--- a/ios/KeyJawn/App/OnboardingView.swift
+++ b/ios/KeyJawn/App/OnboardingView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import UIKit
+import KeyJawnKit
+
+/// First-launch keyboard setup. Skippable. Reopened from Settings.
+///
+/// Completion is written to `KeyboardPrefs.hasCompletedOnboarding` in the
+/// `group.com.keyjawn` suite. Skip and Done use the same write.
+struct OnboardingView: View {
+
+    var prefs: KeyboardPrefs = .shared
+    var onFinished: () -> Void
+
+    @State private var page = 0
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 20) {
+                let current = OnboardingCopy.pages[page]
+                Text(current.title)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Text(current.body)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if page == 1 {
+                    Button(OnboardingCopy.openSettingsTitle) {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                }
+                HStack {
+                    Button(OnboardingCopy.skipTitle) {
+                        finish()
+                    }
+                    Spacer()
+                    Button(page == OnboardingCopy.pages.count - 1
+                           ? OnboardingCopy.doneTitle
+                           : OnboardingCopy.continueTitle) {
+                        if page == OnboardingCopy.pages.count - 1 {
+                            finish()
+                        } else {
+                            page += 1
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding()
+            .navigationTitle("Set up")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private func finish() {
+        prefs.hasCompletedOnboarding = true
+        onFinished()
+    }
+}

--- a/ios/KeyJawn/Settings/SettingsView.swift
+++ b/ios/KeyJawn/Settings/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     // the theme picker changed nothing, the haptics switch changed nothing, and the
     // autocorrect switch was not wired to any code at all. Every control here now
     // changes what the keyboard does.
+    @Binding var showOnboarding: Bool
     @State private var theme = KeyboardPrefs.shared.theme
     @State private var hapticsEnabled = KeyboardPrefs.shared.hapticsEnabled
     @State private var terminalArrowKeys = KeyboardPrefs.shared.terminalArrowKeys
@@ -19,6 +20,17 @@ struct SettingsView: View {
                     NavigationLink("SSH keys") {
                         SSHKeysView()
                     }
+                }
+
+                Section {
+                    Button(OnboardingCopy.reopenTitle) {
+                        showOnboarding = true
+                    }
+                } header: {
+                    Text("Setup")
+                } footer: {
+                    Text("How to enable KeyJawn Keyboard and add a host. You can skip it.")
+                        .font(.caption)
                 }
 
                 Section {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
@@ -23,6 +23,7 @@ public final class KeyboardPrefs: @unchecked Sendable {
         static let haptics = "keyjawn.haptics"
         static let terminalArrows = "keyjawn.terminalArrows"
         static let migrated = "keyjawn.prefs.migrated.v2"
+        static let onboardingCompleted = "keyjawn.onboarding.completed"
     }
 
     /// Storage supplied by a test. When nil the suite is looked up per access below.
@@ -96,6 +97,16 @@ public final class KeyboardPrefs: @unchecked Sendable {
     public var terminalArrowKeys: Bool {
         get { bool(Key.terminalArrows, default: true) }
         set { defaults.set(newValue, forKey: Key.terminalArrows) }
+    }
+
+    /// Whether the first-launch keyboard setup screens have been finished or skipped.
+    ///
+    /// Stored in the App Group suite so both the containing app and any later
+    /// process that can open `group.com.keyjawn` see the same value. Unset means
+    /// not completed — a fresh install shows the wizard.
+    public var hasCompletedOnboarding: Bool {
+        get { bool(Key.onboardingCompleted, default: false) }
+        set { defaults.set(newValue, forKey: Key.onboardingCompleted) }
     }
 
     // MARK: - Helpers

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/OnboardingCopy.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/OnboardingCopy.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// User-visible first-launch copy for the containing app.
+///
+/// KeyJawn is a mobile keyboard. The screens explain how to turn that keyboard on.
+/// The built-in SSH terminal is mentioned only as the app you use after the
+/// keyboard is enabled, not as a second product.
+///
+/// Kept as data so tests can assert the required topics and the absence of
+/// third-party tool names without instantiating SwiftUI.
+public enum OnboardingCopy: Sendable {
+
+    public struct Page: Sendable, Equatable {
+        public let title: String
+        public let body: String
+
+        public init(title: String, body: String) {
+            self.title = title
+            self.body = body
+        }
+    }
+
+    public static let pages: [Page] = [whatItIs, enableKeyboard, addAHost]
+
+    public static let whatItIs = Page(
+        title: "A keyboard for CLI agents",
+        body: """
+        KeyJawn is a phone keyboard with the extra keys a CLI agent session needs: Esc, Tab, Ctrl, arrows, and text shortcuts.
+
+        Slash shortcuts insert plain text into the field that has focus. They are not links to other apps.
+
+        This app also has a built-in SSH terminal so those keys can reach a shell on iOS, where a keyboard extension cannot send them as real key events.
+        """
+    )
+
+    public static let enableKeyboard = Page(
+        title: "Turn on the keyboard",
+        body: """
+        1. Open Settings, then General, then Keyboard, then Keyboards.
+        2. Tap Add new keyboard and choose KeyJawn Keyboard.
+        3. Basic typing works without Full Access.
+        4. Grant Full Access only if you want themes, clipboard history, and image upload to read shared settings.
+
+        The keyboard cannot open that screen for you. Use Open Settings below, then follow the steps. Full Access is a system permission, not something KeyJawn can grant itself.
+        """
+    )
+
+    public static let addAHost = Page(
+        title: "Add a host and copy your key",
+        body: """
+        After this screen, use the Hosts tab to add an SSH server.
+
+        Settings, then SSH keys, shows the public key to paste into authorized_keys on that server. The first connection asks you to pin the host key fingerprint.
+        """
+    )
+
+    public static let skipTitle = "Skip"
+    public static let continueTitle = "Continue"
+    public static let doneTitle = "Done"
+    public static let openSettingsTitle = "Open Settings"
+    public static let reopenTitle = "Set up keyboard"
+
+    /// Tokens that must not appear in user-visible onboarding copy.
+    /// Lowercased for comparison. Kept next to the pages so a new page cannot
+    /// silently reintroduce a 3.2.2-style tool name.
+    public static let forbiddenTokens: [String] = [
+        "claude",
+        "gemini",
+        "codex",
+        "aider",
+        "anthropic",
+        "openai",
+        "moshi",
+        "blink",
+        "termius",
+    ]
+
+    public static var allUserVisibleText: String {
+        let pageText = pages.map { $0.title + "\n" + $0.body }.joined(separator: "\n")
+        return [
+            pageText,
+            skipTitle,
+            continueTitle,
+            doneTitle,
+            openSettingsTitle,
+            reopenTitle,
+        ].joined(separator: "\n")
+    }
+}

--- a/ios/Tests/OnboardingTests.swift
+++ b/ios/Tests/OnboardingTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class OnboardingTests: XCTestCase {
+
+    private var suiteName: String!
+    private var suite: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.keyjawn.tests.onboarding.\(UUID().uuidString)"
+        suite = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        suite = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: - Flag
+
+    func testFreshSuiteHasNotCompletedOnboarding() {
+        XCTAssertFalse(KeyboardPrefs(defaults: suite).hasCompletedOnboarding)
+    }
+
+    func testCompletingOnboardingPersistsAcrossInstances() {
+        KeyboardPrefs(defaults: suite).hasCompletedOnboarding = true
+        XCTAssertTrue(KeyboardPrefs(defaults: suite).hasCompletedOnboarding)
+    }
+
+    func testSkippingOnboardingUsesTheSameCompletionFlag() {
+        // Skip and Done are the same write. The wizard must not come back
+        // after either gesture, including a process restart against the suite.
+        let prefs = KeyboardPrefs(defaults: suite)
+        prefs.hasCompletedOnboarding = true
+        XCTAssertTrue(KeyboardPrefs(defaults: suite).hasCompletedOnboarding)
+        prefs.hasCompletedOnboarding = false
+        XCTAssertFalse(KeyboardPrefs(defaults: suite).hasCompletedOnboarding)
+    }
+
+    func testOnboardingFlagLivesInTheInjectedAppGroupSuite() {
+        KeyboardPrefs(defaults: suite).hasCompletedOnboarding = true
+        XCTAssertEqual(suite.object(forKey: "keyjawn.onboarding.completed") as? Bool, true)
+    }
+
+    // MARK: - Copy
+
+    func testCopyCoversWhatTheAppIs() {
+        let text = OnboardingCopy.allUserVisibleText.lowercased()
+        XCTAssertTrue(text.contains("keyboard"), "must say it is a keyboard")
+        XCTAssertTrue(text.contains("esc"), "must name a terminal key")
+        XCTAssertTrue(text.contains("plain text"), "must say slash inserts text")
+    }
+
+    func testCopyCoversEnablingTheKeyboardAndFullAccess() {
+        let text = OnboardingCopy.allUserVisibleText.lowercased()
+        XCTAssertTrue(text.contains("keyjawn keyboard"))
+        XCTAssertTrue(text.contains("add new keyboard"))
+        XCTAssertTrue(text.contains("full access"))
+        XCTAssertTrue(text.contains("without full access") || text.contains("works without full access"))
+        XCTAssertTrue(OnboardingCopy.openSettingsTitle == "Open Settings")
+    }
+
+    func testCopyCoversAddingAHostAndCopyingThePublicKey() {
+        let text = OnboardingCopy.allUserVisibleText.lowercased()
+        XCTAssertTrue(text.contains("hosts"))
+        XCTAssertTrue(text.contains("public key"))
+        XCTAssertTrue(text.contains("authorized_keys"))
+    }
+
+    func testSkipAndDoneAreAvailable() {
+        XCTAssertEqual(OnboardingCopy.skipTitle, "Skip")
+        XCTAssertEqual(OnboardingCopy.doneTitle, "Done")
+        XCTAssertEqual(OnboardingCopy.continueTitle, "Continue")
+        XCTAssertEqual(OnboardingCopy.reopenTitle, "Set up keyboard")
+    }
+
+    func testCopyHasNoThirdPartyToolNames() {
+        let text = OnboardingCopy.allUserVisibleText.lowercased()
+        for token in OnboardingCopy.forbiddenTokens {
+            XCTAssertFalse(text.contains(token), "onboarding copy contains \(token)")
+        }
+    }
+
+    func testPagesAreTheShippedSourceOfOnboardingCopy() {
+        XCTAssertEqual(OnboardingCopy.pages.count, 3)
+        XCTAssertEqual(OnboardingCopy.pages[0], OnboardingCopy.whatItIs)
+        XCTAssertEqual(OnboardingCopy.pages[1], OnboardingCopy.enableKeyboard)
+        XCTAssertEqual(OnboardingCopy.pages[2], OnboardingCopy.addAHost)
+    }
+}


### PR DESCRIPTION
Fixes #80.

KeyJawn is a mobile keyboard. This is first-launch setup for enabling that keyboard, not a pitch for a desktop terminal.

## What

- `OnboardingCopy` in KeyJawnKit: three pages (what it is, turn on the keyboard / Full Access, add a host and copy the public key). No third-party tool names.
- `KeyboardPrefs.hasCompletedOnboarding` in the `group.com.keyjawn` suite. Skip and Done write the same flag.
- Full-screen cover on first launch; Settings → Set up keyboard reopens it.
- Open Settings uses `UIApplication.openSettingsURLString` (not a private prefs URL).
- Tests drive the shipped flag and copy.

## Test plan

- [ ] `OnboardingTests` and `KeyboardPrefsTests` pass (`xcodebuild test` / the ios-test job once #93 is on main)
- [ ] Cold install shows the wizard; Skip still reaches Hosts
- [ ] Settings can reopen it

Do not merge until Joe names this PR.