### PR TITLE
Add iOS stress tests and launch UI suite

### DIFF
--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -30,10 +30,12 @@
 		76503EE687E0F88885DD27DE /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 974D61CF6F7ADA4824D53DC7 /* NIOSSH */; };
 		7E2C29A442AE9E2630A2F301 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5405F0BD516F74C8E0EED5 /* HostStore.swift */; };
 		9DA97D841DD222F4BC99CFC9 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1BD7D5FD852EEF611DFEF3BA /* KeyJawnKit */; };
+		A58E56EF6474C8DBC8512A2F /* KeyboardStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */; };
 		A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */; };
 		A9DB22FF0F4C815305CC6106 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = D3233B073CCE7B0FEFB818EA /* KeyJawnKit */; };
 		AA523563B70682B4341E113C /* SSHKeysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC90B529187AE9DAFC1CDE6 /* SSHKeysView.swift */; };
 		B958AD522581630C2F77C218 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9319CFF9722F6941701039BF /* NIOCore */; };
+		B986125E4F44A5EC63F660C4 /* LaunchFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */; };
 		BB7A5E0F892D8EA9821654B3 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = C5D92697896E36FD6161FB69 /* NIOCore */; };
 		BD84EA7B58CE9D2536EADB34 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = 77314FC70430F6B0FC36684C /* KeyJawnKit */; };
 		BF99261856285D2DA591AEB2 /* KeyJawnKeyboard.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 22D494658DBEB0D051FF4A8C /* KeyJawnKeyboard.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -54,6 +56,13 @@
 
 /* Begin PBXContainerItemProxy section */
 		563D214484F90B42E8D0A3E8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CCE8758E3FDE1B4AD2B13B6F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8DE24E0AF7D60F6E8E2BA73E;
+			remoteInfo = KeyJawn;
+		};
+		87E90F807D474A3484B00E20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CCE8758E3FDE1B4AD2B13B6F /* Project object */;
 			proxyType = 1;
@@ -87,10 +96,12 @@
 		1455FBB90189E98F89DA75E3 /* KeyJawn.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = KeyJawn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		22D494658DBEB0D051FF4A8C /* KeyJawnKeyboard.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = KeyJawnKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		23A4B394C56787E8E05B58A1 /* SSHSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHSession.swift; sourceTree = "<group>"; };
+		2B762F3DAF0B75F1359515C7 /* KeyJawnUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KeyJawnUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B92C187EB65640055598EB8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2CC90B529187AE9DAFC1CDE6 /* SSHKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeysView.swift; sourceTree = "<group>"; };
 		2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyStore.swift; sourceTree = "<group>"; };
 		301482A615F90B93947563BC /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
+		33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchFlowTests.swift; sourceTree = "<group>"; };
 		396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPrefsTests.swift; sourceTree = "<group>"; };
 		524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashScreenshotRenderTests.swift; sourceTree = "<group>"; };
 		62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -98,6 +109,7 @@
 		686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBoundaryTests.swift; sourceTree = "<group>"; };
 		7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTerminalView.swift; sourceTree = "<group>"; };
 		88516F15428436E247E65FD4 /* AppGroupHostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupHostStore.swift; sourceTree = "<group>"; };
+		8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStressTests.swift; sourceTree = "<group>"; };
 		97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputViewAudioFeedback.swift; sourceTree = "<group>"; };
 		98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardLayersTests.swift; sourceTree = "<group>"; };
 		98623C822345E60C48D7464D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -187,6 +199,7 @@
 				9B940C548C192782A1073E16 /* HostConfigTests.swift */,
 				98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */,
 				396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */,
+				8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */,
 				FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */,
 				F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */,
 				B9DF2807E8DD4CB2A02999BA /* SlashCommandTests.swift */,
@@ -221,6 +234,14 @@
 			path = Hosts;
 			sourceTree = "<group>";
 		};
+		84FDAD7891497578203FF372 /* UITests */ = {
+			isa = PBXGroup;
+			children = (
+				33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */,
+			);
+			path = UITests;
+			sourceTree = "<group>";
+		};
 		8E4EBFABD25F91780E7231E1 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -249,6 +270,7 @@
 				1455FBB90189E98F89DA75E3 /* KeyJawn.app */,
 				22D494658DBEB0D051FF4A8C /* KeyJawnKeyboard.appex */,
 				D9913D1DFEB392733BA6B353 /* KeyJawnKitTests.xctest */,
+				2B762F3DAF0B75F1359515C7 /* KeyJawnUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -260,6 +282,7 @@
 				B0C968F9E2B99A69F54EEB84 /* KeyJawnKeyboard */,
 				EA6DC54EB5C8ABF2BCAB440C /* Packages */,
 				5C348A9867C54DD9765F499B /* Tests */,
+				84FDAD7891497578203FF372 /* UITests */,
 				B6F9E3CE713D092F9DF0D5CB /* Products */,
 			);
 			sourceTree = "<group>";
@@ -285,6 +308,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0E4E1897990EBD0D75A999D8 /* KeyJawnUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 77FC151590805AE890AEF32E /* Build configuration list for PBXNativeTarget "KeyJawnUITests" */;
+			buildPhases = (
+				81E425E8AC51FAB31E07BA60 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2C116E5DC6F3751BC425A5DB /* PBXTargetDependency */,
+			);
+			name = KeyJawnUITests;
+			packageProductDependencies = (
+			);
+			productName = KeyJawnUITests;
+			productReference = 2B762F3DAF0B75F1359515C7 /* KeyJawnUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		8524D9D4D7AA4286DF9B7EDC /* KeyJawnKitTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 358BE103B2FA779246962531 /* Build configuration list for PBXNativeTarget "KeyJawnKitTests" */;
@@ -363,6 +404,11 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
+					0E4E1897990EBD0D75A999D8 = {
+						DevelopmentTeam = 5624SD289G;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 8DE24E0AF7D60F6E8E2BA73E;
+					};
 					8524D9D4D7AA4286DF9B7EDC = {
 						DevelopmentTeam = 5624SD289G;
 						ProvisioningStyle = Automatic;
@@ -399,6 +445,7 @@
 				8DE24E0AF7D60F6E8E2BA73E /* KeyJawn */,
 				D49A0F8A52046B2B5DB06FC5 /* KeyJawnKeyboard */,
 				8524D9D4D7AA4286DF9B7EDC /* KeyJawnKitTests */,
+				0E4E1897990EBD0D75A999D8 /* KeyJawnUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -425,6 +472,7 @@
 				C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */,
 				EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */,
 				5A51BC905F126948A48544C7 /* KeyboardPrefsTests.swift in Sources */,
+				A58E56EF6474C8DBC8512A2F /* KeyboardStressTests.swift in Sources */,
 				12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */,
 				15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */,
 				C01DB065ADBBD129FDFA832F /* SlashCommandTests.swift in Sources */,
@@ -442,6 +490,14 @@
 				348C2A63B6E68B94EE380311 /* InputViewAudioFeedback.swift in Sources */,
 				30FBF6554FC7A6F5548299C1 /* KeyboardViewController.swift in Sources */,
 				1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		81E425E8AC51FAB31E07BA60 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B986125E4F44A5EC63F660C4 /* LaunchFlowTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -469,6 +525,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2C116E5DC6F3751BC425A5DB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8DE24E0AF7D60F6E8E2BA73E /* KeyJawn */;
+			targetProxy = 87E90F807D474A3484B00E20 /* PBXContainerItemProxy */;
+		};
 		73EE9FD7C88FD0DB3551B66B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D49A0F8A52046B2B5DB06FC5 /* KeyJawnKeyboard */;
@@ -482,6 +543,27 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		299A41D8E4D0CABC0564DEC1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5624SD289G;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.keyjawn.uitests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = KeyJawn;
+			};
+			name = Debug;
+		};
 		2AFA74702DA362ABD727849D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -556,6 +638,27 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		62A24207A2AB3AB64BEE96AD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5624SD289G;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.keyjawn.uitests;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = KeyJawn;
 			};
 			name = Release;
 		};
@@ -759,6 +862,15 @@
 			buildConfigurations = (
 				86A1354EE8BCEB722FEE8C75 /* Debug */,
 				A7E30AAC87AF32856812B94F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		77FC151590805AE890AEF32E /* Build configuration list for PBXNativeTarget "KeyJawnUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				299A41D8E4D0CABC0564DEC1 /* Debug */,
+				62A24207A2AB3AB64BEE96AD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */; };
 		1F3BC0FB1DEE09CF9586840D /* HostTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */; };
 		1F6BA06DD660C887B3E1F79C /* KeyJawnApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */; };
+		227F4E52BB865C7B00BA9167 /* KeyboardMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE214E0B998D01BC698998B /* KeyboardMetricsTests.swift */; };
 		306C46342B0B52F882443953 /* AppGroupHostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88516F15428436E247E65FD4 /* AppGroupHostStore.swift */; };
 		30FBF6554FC7A6F5548299C1 /* KeyboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B581E797ADEF1572390A6096 /* KeyboardViewController.swift */; };
 		32EB71B5DE76A94E371D71A0 /* SSHSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4B394C56787E8E05B58A1 /* SSHSession.swift */; };
@@ -34,6 +35,7 @@
 		A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */; };
 		A9DB22FF0F4C815305CC6106 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = D3233B073CCE7B0FEFB818EA /* KeyJawnKit */; };
 		AA523563B70682B4341E113C /* SSHKeysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC90B529187AE9DAFC1CDE6 /* SSHKeysView.swift */; };
+		B6C2D23E9D71B57A14E105FD /* KeyboardIMETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19791E47A6CF77CB424FCAC /* KeyboardIMETests.swift */; };
 		B958AD522581630C2F77C218 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9319CFF9722F6941701039BF /* NIOCore */; };
 		B986125E4F44A5EC63F660C4 /* LaunchFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */; };
 		BB7A5E0F892D8EA9821654B3 /* NIOCore in Frameworks */ = {isa = PBXBuildFile; productRef = C5D92697896E36FD6161FB69 /* NIOCore */; };
@@ -47,6 +49,7 @@
 		D4959C7C420241BE04B8CD59 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 060BD31A2DD85CF9C0F6FE6F /* Citadel */; };
 		D833730B6D5B5B7CD1D39B17 /* TerminalInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F295D7985B88063D1F195088 /* TerminalInputView.swift */; };
 		DE63F87E7794F4FF03DA7A43 /* ANSISequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */; };
+		DF7E0C0E55646C2A8443B118 /* KeyboardInsertPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */; };
 		E488DF8C0300EA5A5A26626B /* SlashScreenshotRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */; };
 		EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */; };
 		EB892014C8DC6C2A3258F241 /* PasswordPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6274AD171FD2D143D7DFDAC /* PasswordPromptView.swift */; };
@@ -99,10 +102,12 @@
 		2B762F3DAF0B75F1359515C7 /* KeyJawnUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KeyJawnUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B92C187EB65640055598EB8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2CC90B529187AE9DAFC1CDE6 /* SSHKeysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeysView.swift; sourceTree = "<group>"; };
+		2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInsertPathTests.swift; sourceTree = "<group>"; };
 		2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyStore.swift; sourceTree = "<group>"; };
 		301482A615F90B93947563BC /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchFlowTests.swift; sourceTree = "<group>"; };
 		396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPrefsTests.swift; sourceTree = "<group>"; };
+		3CE214E0B998D01BC698998B /* KeyboardMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetricsTests.swift; sourceTree = "<group>"; };
 		524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashScreenshotRenderTests.swift; sourceTree = "<group>"; };
 		62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		665662BFA6DECCD61154BEE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -115,6 +120,7 @@
 		98623C822345E60C48D7464D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		99A67662436F2C1180E1376F /* KeyJawnKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = KeyJawnKit; path = KeyJawnKit; sourceTree = SOURCE_ROOT; };
 		9B940C548C192782A1073E16 /* HostConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConfigTests.swift; sourceTree = "<group>"; };
+		A19791E47A6CF77CB424FCAC /* KeyboardIMETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardIMETests.swift; sourceTree = "<group>"; };
 		A6274AD171FD2D143D7DFDAC /* PasswordPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordPromptView.swift; sourceTree = "<group>"; };
 		A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitadelSCPUploader.swift; sourceTree = "<group>"; };
 		AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyJawnApp.swift; sourceTree = "<group>"; };
@@ -197,7 +203,9 @@
 				DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */,
 				D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */,
 				9B940C548C192782A1073E16 /* HostConfigTests.swift */,
+				2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */,
 				98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */,
+				3CE214E0B998D01BC698998B /* KeyboardMetricsTests.swift */,
 				396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */,
 				8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */,
 				FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */,
@@ -237,6 +245,7 @@
 		84FDAD7891497578203FF372 /* UITests */ = {
 			isa = PBXGroup;
 			children = (
+				A19791E47A6CF77CB424FCAC /* KeyboardIMETests.swift */,
 				33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */,
 			);
 			path = UITests;
@@ -470,7 +479,9 @@
 				68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */,
 				5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */,
 				C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */,
+				DF7E0C0E55646C2A8443B118 /* KeyboardInsertPathTests.swift in Sources */,
 				EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */,
+				227F4E52BB865C7B00BA9167 /* KeyboardMetricsTests.swift in Sources */,
 				5A51BC905F126948A48544C7 /* KeyboardPrefsTests.swift in Sources */,
 				A58E56EF6474C8DBC8512A2F /* KeyboardStressTests.swift in Sources */,
 				12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */,
@@ -497,6 +508,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B6C2D23E9D71B57A14E105FD /* KeyboardIMETests.swift in Sources */,
 				B986125E4F44A5EC63F660C4 /* LaunchFlowTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/KeyJawn/App/OnboardingView.swift
+++ b/ios/KeyJawn/App/OnboardingView.swift
@@ -35,6 +35,7 @@ struct OnboardingView: View {
                     Button(OnboardingCopy.skipTitle) {
                         finish()
                     }
+                    .accessibilityIdentifier("onboarding.skip")
                     Spacer()
                     Button(page == OnboardingCopy.pages.count - 1
                            ? OnboardingCopy.doneTitle
@@ -46,6 +47,11 @@ struct OnboardingView: View {
                         }
                     }
                     .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier(
+                        page == OnboardingCopy.pages.count - 1
+                            ? "onboarding.done"
+                            : "onboarding.continue"
+                    )
                 }
             }
             .padding()

--- a/ios/KeyJawn/Settings/SettingsView.swift
+++ b/ios/KeyJawn/Settings/SettingsView.swift
@@ -26,6 +26,7 @@ struct SettingsView: View {
                     Button(OnboardingCopy.reopenTitle) {
                         showOnboarding = true
                     }
+                    .accessibilityIdentifier("settings.setupKeyboard")
                 } header: {
                     Text("Setup")
                 } footer: {

--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -19,35 +19,7 @@ public final class KeyboardViewController: UIInputViewController {
     private var numberRowHeight: NSLayoutConstraint!
     private var qwertyTop: NSLayoutConstraint!
     private var keyboardHeight: NSLayoutConstraint!
-    private var appliedMetrics: Metrics?
-
-    // MARK: - Metrics
-
-    /// Row heights for the current device and orientation.
-    ///
-    /// The keyboard used to be a hardcoded 322pt everywhere. On a phone in landscape
-    /// that is most of the available height, leaving the app it is typing into as a
-    /// sliver; on iPad the same 322pt reads as a cramped strip of tiny keys. Phone
-    /// portrait keeps its existing numbers exactly, so the common case is unchanged.
-    private struct Metrics: Equatable {
-        let extraRow: CGFloat
-        let numberRow: CGFloat
-        let gap: CGFloat
-        let qwerty: CGFloat
-
-        var total: CGFloat { extraRow + gap + numberRow + gap + qwerty }
-
-        static let phonePortrait  = Metrics(extraRow: 52, numberRow: 42, gap: 4, qwerty: 220)
-        static let phoneLandscape = Metrics(extraRow: 40, numberRow: 32, gap: 3, qwerty: 150)
-        static let pad            = Metrics(extraRow: 62, numberRow: 52, gap: 6, qwerty: 300)
-
-        static func current(for traits: UITraitCollection) -> Metrics {
-            if traits.userInterfaceIdiom == .pad { return .pad }
-            // A compact vertical size class on a phone is landscape, including the
-            // larger phones that stay regular-width there.
-            return traits.verticalSizeClass == .compact ? .phoneLandscape : .phonePortrait
-        }
-    }
+    private var appliedMetrics: KeyboardMetrics?
 
     // MARK: - Lifecycle
 
@@ -84,7 +56,7 @@ public final class KeyboardViewController: UIInputViewController {
     /// touching a constraint once the metrics for the current traits are applied, so
     /// it cannot drive a layout loop.
     private func applyMetrics() {
-        let metrics = Metrics.current(for: traitCollection)
+        let metrics = KeyboardMetrics.current(for: traitCollection)
         guard metrics != appliedMetrics else { return }
         appliedMetrics = metrics
 
@@ -104,7 +76,7 @@ public final class KeyboardViewController: UIInputViewController {
         extraRow.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(extraRow)
 
-        extraRowHeight = extraRow.heightAnchor.constraint(equalToConstant: Metrics.phonePortrait.extraRow)
+        extraRowHeight = extraRow.heightAnchor.constraint(equalToConstant: KeyboardMetrics.phonePortrait.extraRow)
         NSLayoutConstraint.activate([
             extraRow.topAnchor.constraint(equalTo: view.topAnchor),
             extraRow.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -121,8 +93,8 @@ public final class KeyboardViewController: UIInputViewController {
         view.addSubview(numberRow)
 
         numberRowTop = numberRow.topAnchor.constraint(equalTo: extraRow.bottomAnchor,
-                                                      constant: Metrics.phonePortrait.gap)
-        numberRowHeight = numberRow.heightAnchor.constraint(equalToConstant: Metrics.phonePortrait.numberRow)
+                                                      constant: KeyboardMetrics.phonePortrait.gap)
+        numberRowHeight = numberRow.heightAnchor.constraint(equalToConstant: KeyboardMetrics.phonePortrait.numberRow)
         NSLayoutConstraint.activate([
             numberRowTop,
             numberRow.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -139,7 +111,7 @@ public final class KeyboardViewController: UIInputViewController {
         view.addSubview(qwerty)
 
         qwertyTop = qwerty.topAnchor.constraint(equalTo: numberRow.bottomAnchor,
-                                                constant: Metrics.phonePortrait.gap)
+                                                constant: KeyboardMetrics.phonePortrait.gap)
         NSLayoutConstraint.activate([
             qwertyTop,
             qwerty.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -151,7 +123,7 @@ public final class KeyboardViewController: UIInputViewController {
     private func setupHeightConstraint() {
         // Priority 999 avoids conflicting with the system's own height constraint during
         // the animation when the keyboard appears.
-        keyboardHeight = view.heightAnchor.constraint(equalToConstant: Metrics.phonePortrait.total)
+        keyboardHeight = view.heightAnchor.constraint(equalToConstant: KeyboardMetrics.phonePortrait.total)
         keyboardHeight.priority = UILayoutPriority(999)
         keyboardHeight.isActive = true
     }
@@ -184,57 +156,27 @@ public final class KeyboardViewController: UIInputViewController {
 extension KeyboardViewController: ExtraRowDelegate {
 
     public func extraRow(_ view: ExtraRowView, send output: KeyOutput, ctrlActive: Bool) {
+        applyInsert(output, ctrlActive: ctrlActive)
+    }
+
+    /// Shared with QWERTY taps so extra-row and letter keys hit the same mapping.
+    func applyInsert(_ output: KeyOutput, ctrlActive: Bool) {
         let proxy = textDocumentProxy
-
-        switch output {
-        case .slash:
+        switch KeyboardDocumentInsert.action(
+            for: output,
+            ctrlActive: ctrlActive,
+            terminalArrows: KeyboardPrefs.shared.terminalArrowKeys
+        ) {
+        case .openSlash:
             showSlashPanel()
-
-        case .tab, .escape, .ctrlC, .ctrlD:
-            // Control characters and Esc go in as literal bytes. Terminal apps forward
-            // inserted text straight to the pty, which is how Esc has always worked
-            // here; Ctrl+C used to fall through to the default branch and do nothing
-            // at all, which made the row's leading key — the one the layout comments
-            // call the most-used key in an agent session — inert.
-            if let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
-                proxy.insertText(text)
-            }
-
-        case .arrowUp, .arrowDown:
-            // No cursor equivalent exists for vertical movement through
-            // UITextDocumentProxy, so outside terminal mode these have nothing to do.
-            if KeyboardPrefs.shared.terminalArrowKeys,
-               let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
-                proxy.insertText(text)
-            }
-
-        case .arrowLeft:
-            if KeyboardPrefs.shared.terminalArrowKeys,
-               let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
-                proxy.insertText(text)
-            } else {
-                proxy.adjustTextPosition(byCharacterOffset: -1)
-            }
-
-        case .arrowRight:
-            if KeyboardPrefs.shared.terminalArrowKeys,
-               let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
-                proxy.insertText(text)
-            } else {
-                proxy.adjustTextPosition(byCharacterOffset: 1)
-            }
-
-        case .character(let s):
-            proxy.insertText(s)
-
-        case .backspace:
+        case .insert(let text):
+            proxy.insertText(text)
+        case .deleteBackward:
             proxy.deleteBackward()
-
-        case .return:
-            proxy.insertText("\n")
-
-        case .space:
-            proxy.insertText(" ")
+        case .adjustPosition(let offset):
+            proxy.adjustTextPosition(byCharacterOffset: offset)
+        case nil:
+            break
         }
     }
 
@@ -414,26 +356,12 @@ extension KeyboardViewController: NumberRowDelegate {
 extension KeyboardViewController: QwertyKeyboardDelegate {
 
     public func keyboard(_ keyboard: QwertyKeyboardView, insertText text: String) {
-        // Apply an armed or locked Ctrl modifier to letters typed on the QWERTY grid.
-        //
-        // The modifier is armed by long-pressing ^C in the extra row, and without this
-        // the arming had nowhere to land: letters went straight to the proxy, so
-        // Ctrl+D, Ctrl+Z, Ctrl+L and Ctrl+A/E worked in the in-app terminal and not in
-        // the keyboard extension, which is the surface the product is actually for.
-        // Restricted to single characters so a multi-character insertion is not
-        // collapsed into one control byte.
-        if extraRow.ctrl.isActive,
-           text.count == 1,
-           let control = ANSISequence.text(for: .character(text), ctrlActive: true) {
-            textDocumentProxy.insertText(control)
-            extraRow.ctrl.consume()
-            return
-        }
-        textDocumentProxy.insertText(text)
+        applyInsert(.character(text), ctrlActive: extraRow.ctrl.isActive)
+        extraRow.ctrl.consume()
     }
 
     public func keyboardDeleteBackward(_ keyboard: QwertyKeyboardView) {
-        textDocumentProxy.deleteBackward()
+        applyInsert(.backspace, ctrlActive: false)
     }
 
     /// `UITextDocumentProxy` has no word-delete primitive, so this is N backward
@@ -457,3 +385,5 @@ extension KeyboardViewController: QwertyKeyboardDelegate {
         advanceToNextInputMode()
     }
 }
+
+

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardDocumentInsert.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardDocumentInsert.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// What the keyboard extension does with a key, independent of `UITextDocumentProxy`.
+///
+/// `KeyboardViewController.applyInsert` is the production caller for extra-row
+/// and QWERTY keys. Tests drive this same function so a change to Esc, Tab,
+/// slash, or backspace cannot silently go inert again.
+public enum KeyboardDocumentInsert: Equatable, Sendable {
+    case insert(String)
+    case deleteBackward
+    case adjustPosition(Int)
+    case openSlash
+
+    public static func action(
+        for output: KeyOutput,
+        ctrlActive: Bool,
+        terminalArrows: Bool
+    ) -> KeyboardDocumentInsert? {
+        switch output {
+        case .slash:
+            return .openSlash
+        case .tab, .escape, .ctrlC, .ctrlD:
+            return ANSISequence.text(for: output, ctrlActive: ctrlActive).map { .insert($0) }
+        case .arrowUp, .arrowDown:
+            guard terminalArrows else { return nil }
+            return ANSISequence.text(for: output, ctrlActive: ctrlActive).map { .insert($0) }
+        case .arrowLeft:
+            if terminalArrows, let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
+                return .insert(text)
+            }
+            return .adjustPosition(-1)
+        case .arrowRight:
+            if terminalArrows, let text = ANSISequence.text(for: output, ctrlActive: ctrlActive) {
+                return .insert(text)
+            }
+            return .adjustPosition(1)
+        case .character(let s):
+            if ctrlActive, s.count == 1,
+               let control = ANSISequence.text(for: .character(s), ctrlActive: true) {
+                return .insert(control)
+            }
+            return .insert(s)
+        case .backspace:
+            return .deleteBackward
+        case .return:
+            return .insert("\n")
+        case .space:
+            return .insert(" ")
+        }
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardMetrics.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardMetrics.swift
@@ -1,0 +1,27 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Row heights for the keyboard extension. Phone portrait is the original 322pt
+/// stack. Landscape shrinks so the host app is not a sliver. Pad is taller so
+/// keys are not a phone strip on an 11/13-inch canvas.
+public struct KeyboardMetrics: Equatable, Sendable {
+    public let extraRow: CGFloat
+    public let numberRow: CGFloat
+    public let gap: CGFloat
+    public let qwerty: CGFloat
+
+    public var total: CGFloat { extraRow + gap + numberRow + gap + qwerty }
+
+    public static let phonePortrait  = KeyboardMetrics(extraRow: 52, numberRow: 42, gap: 4, qwerty: 220)
+    public static let phoneLandscape = KeyboardMetrics(extraRow: 40, numberRow: 32, gap: 3, qwerty: 150)
+    public static let pad            = KeyboardMetrics(extraRow: 62, numberRow: 52, gap: 6, qwerty: 300)
+
+#if canImport(UIKit)
+    public static func current(for traits: UITraitCollection) -> KeyboardMetrics {
+        if traits.userInterfaceIdiom == .pad { return .pad }
+        return traits.verticalSizeClass == .compact ? .phoneLandscape : .phonePortrait
+    }
+#endif
+}

--- a/ios/Tests/KeyboardInsertPathTests.swift
+++ b/ios/Tests/KeyboardInsertPathTests.swift
@@ -1,0 +1,179 @@
+import UIKit
+import XCTest
+@testable import KeyJawnKit
+
+/// Drives the same insert mapping the keyboard extension uses, plus the
+/// ExtraRow / QWERTY / slash views that feed it. Not a reimplementation of
+/// `insertText` — the expected strings come from `KeyboardDocumentInsert`.
+@MainActor
+final class KeyboardInsertPathTests: XCTestCase {
+
+    func testLettersSpaceBackspaceEscTabAndSlashTrigger() {
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .character("h"), ctrlActive: false, terminalArrows: true),
+            .insert("h")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .character("i"), ctrlActive: false, terminalArrows: true),
+            .insert("i")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .space, ctrlActive: false, terminalArrows: true),
+            .insert(" ")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .backspace, ctrlActive: false, terminalArrows: true),
+            .deleteBackward
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .escape, ctrlActive: false, terminalArrows: true),
+            .insert("\u{1b}")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .tab, ctrlActive: false, terminalArrows: true),
+            .insert("\t")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .slash, ctrlActive: false, terminalArrows: true),
+            .openSlash
+        )
+        XCTAssertEqual(SlashCommand.all.first { $0.id == "compact" }?.trigger, "/compact")
+    }
+
+    func testCtrlLetterUsesTheSameMaskTheExtensionInserts() {
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .character("c"), ctrlActive: true, terminalArrows: true),
+            .insert("\u{03}")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .character("d"), ctrlActive: true, terminalArrows: true),
+            .insert("\u{04}")
+        )
+    }
+
+    func testExtraRowButtonsEmitEscTabAndSlash() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 80))
+        let extra = ExtraRowView()
+        extra.frame = window.bounds
+        extra.applyTheme(.dark)
+        let recorder = ExtraRecorder()
+        extra.delegate = recorder
+        window.addSubview(extra)
+        window.makeKeyAndVisible()
+        extra.layoutIfNeeded()
+
+        tapExtra(extra, accessibility: "Escape")
+        tapExtra(extra, accessibility: "Tab")
+        tapExtra(extra, accessibility: "Slash commands")
+
+        XCTAssertEqual(recorder.outputs, [.escape, .tab, .slash])
+
+        var inserted: [String] = []
+        var openedSlash = false
+        for output in recorder.outputs {
+            switch KeyboardDocumentInsert.action(for: output, ctrlActive: false, terminalArrows: true) {
+            case .insert(let text):
+                inserted.append(text)
+            case .openSlash:
+                openedSlash = true
+            default:
+                XCTFail("unexpected action for \(output)")
+            }
+        }
+        XCTAssertEqual(inserted, ["\u{1b}", "\t"])
+        XCTAssertTrue(openedSlash)
+        window.isHidden = true
+    }
+
+    func testQwertyButtonsInsertLettersSpaceAndBackspace() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 240))
+        let qwerty = QwertyKeyboardView()
+        qwerty.frame = window.bounds
+        qwerty.applyTheme(.dark)
+        let recorder = QwertyRecorder()
+        qwerty.delegate = recorder
+        window.addSubview(qwerty)
+        window.makeKeyAndVisible()
+        qwerty.layoutIfNeeded()
+
+        tapQwerty(qwerty, title: "h")
+        tapQwerty(qwerty, title: "i")
+        tapQwerty(qwerty, title: "space")
+        sendBackspace(qwerty)
+
+        XCTAssertEqual(recorder.inserted, ["h", "i", " "])
+        XCTAssertEqual(recorder.deletes, 1)
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .character("h"), ctrlActive: false, terminalArrows: true),
+            .insert("h")
+        )
+        window.isHidden = true
+    }
+
+    func testSlashPanelSelectsCompactTrigger() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 400))
+        let panel = SlashCommandPanel(theme: .dark)
+        var selected: String?
+        panel.onSelect = { selected = $0.trigger }
+        panel.frame = window.bounds
+        window.addSubview(panel)
+        window.makeKeyAndVisible()
+        panel.layoutIfNeeded()
+
+        let compact = SlashCommand.all.first { $0.id == "compact" }
+        XCTAssertEqual(compact?.trigger, "/compact")
+        panel.onSelect?(compact!)
+        XCTAssertEqual(selected, "/compact")
+        window.isHidden = true
+    }
+
+    private func tapExtra(_ extra: ExtraRowView, accessibility: String) {
+        let button = extra.subviews
+            .flatMap(\.subviews)
+            .compactMap { $0 as? UIButton }
+            .first { $0.accessibilityLabel?.contains(accessibility) == true
+                || $0.currentTitle == accessibility }
+        XCTAssertNotNil(button, "missing extra-row control \(accessibility)")
+        button?.sendActions(for: .touchUpInside)
+    }
+
+    private func tapQwerty(_ qwerty: QwertyKeyboardView, title: String) {
+        let button = qwerty.subviews
+            .compactMap { $0 as? UIButton }
+            .first { $0.currentTitle == title || $0.accessibilityLabel?.lowercased() == title }
+        XCTAssertNotNil(button, "missing QWERTY key \(title)")
+        button?.sendActions(for: .touchUpInside)
+    }
+
+    private func sendBackspace(_ qwerty: QwertyKeyboardView) {
+        let button = qwerty.subviews
+            .compactMap { $0 as? UIButton }
+            .first { $0.accessibilityLabel?.localizedCaseInsensitiveContains("delete") == true
+                || $0.accessibilityLabel?.localizedCaseInsensitiveContains("backspace") == true }
+        XCTAssertNotNil(button, "missing backspace")
+        button?.sendActions(for: .touchUpInside)
+    }
+}
+
+@MainActor
+private final class ExtraRecorder: ExtraRowDelegate {
+    var outputs: [KeyOutput] = []
+    func extraRow(_ view: ExtraRowView, send output: KeyOutput, ctrlActive: Bool) {
+        outputs.append(output)
+    }
+    func extraRowDidTapClipboard(_ view: ExtraRowView) {}
+    func extraRowDidTapUpload(_ view: ExtraRowView) {}
+}
+
+@MainActor
+private final class QwertyRecorder: QwertyKeyboardDelegate {
+    var inserted: [String] = []
+    var deletes = 0
+    func keyboard(_ keyboard: QwertyKeyboardView, insertText text: String) {
+        inserted.append(text)
+    }
+    func keyboardDeleteBackward(_ keyboard: QwertyKeyboardView) {
+        deletes += 1
+    }
+    func keyboardAdvanceToNextInputMode(_ keyboard: QwertyKeyboardView) {}
+}

--- a/ios/Tests/KeyboardInsertPathTests.swift
+++ b/ios/Tests/KeyboardInsertPathTests.swift
@@ -120,9 +120,29 @@ final class KeyboardInsertPathTests: XCTestCase {
         window.makeKeyAndVisible()
         panel.layoutIfNeeded()
 
-        let compact = SlashCommand.all.first { $0.id == "compact" }
-        XCTAssertEqual(compact?.trigger, "/compact")
-        panel.onSelect?(compact!)
+        guard let table = panel.subviews.compactMap({ $0 as? UITableView }).first else {
+            return XCTFail("SlashCommandPanel has no table")
+        }
+        table.reloadData()
+        table.layoutIfNeeded()
+
+        var compactPath: IndexPath?
+        for section in 0..<table.numberOfSections {
+            for row in 0..<table.numberOfRows(inSection: section) {
+                let path = IndexPath(row: row, section: section)
+                let cell = table.dataSource?.tableView(table, cellForRowAt: path)
+                if cell?.accessibilityLabel?.contains("/compact") == true {
+                    compactPath = path
+                    break
+                }
+            }
+        }
+        guard let compactPath else {
+            return XCTFail("table has no /compact row")
+        }
+
+        table.selectRow(at: compactPath, animated: false, scrollPosition: .none)
+        table.delegate?.tableView?(table, didSelectRowAt: compactPath)
         XCTAssertEqual(selected, "/compact")
         window.isHidden = true
     }

--- a/ios/Tests/KeyboardMetricsTests.swift
+++ b/ios/Tests/KeyboardMetricsTests.swift
@@ -1,0 +1,31 @@
+import UIKit
+import XCTest
+@testable import KeyJawnKit
+
+/// The keyboard used to be 322pt on every idiom. iPad must use the pad metrics
+/// so keys are not a cramped phone strip on a 11/13-inch canvas.
+final class KeyboardMetricsTests: XCTestCase {
+
+    func testPadIsTallerThanPhonePortrait() {
+        let phone = UITraitCollection(traitsFrom: [
+            UITraitCollection(userInterfaceIdiom: .phone),
+            UITraitCollection(verticalSizeClass: .regular),
+        ])
+        let pad = UITraitCollection(userInterfaceIdiom: .pad)
+        XCTAssertEqual(KeyboardMetrics.current(for: phone), .phonePortrait)
+        XCTAssertEqual(KeyboardMetrics.current(for: pad), .pad)
+        XCTAssertEqual(KeyboardMetrics.phonePortrait.total, 322)
+        XCTAssertEqual(KeyboardMetrics.pad.total, 426)
+        XCTAssertGreaterThan(KeyboardMetrics.pad.total, KeyboardMetrics.phonePortrait.total)
+    }
+
+    func testPhoneLandscapeIsShorterThanPhonePortrait() {
+        let landscape = UITraitCollection(traitsFrom: [
+            UITraitCollection(userInterfaceIdiom: .phone),
+            UITraitCollection(verticalSizeClass: .compact),
+        ])
+        XCTAssertEqual(KeyboardMetrics.current(for: landscape), .phoneLandscape)
+        XCTAssertEqual(KeyboardMetrics.phoneLandscape.total, 228)
+        XCTAssertLessThan(KeyboardMetrics.phoneLandscape.total, KeyboardMetrics.phonePortrait.total)
+    }
+}

--- a/ios/Tests/KeyboardStressTests.swift
+++ b/ios/Tests/KeyboardStressTests.swift
@@ -1,0 +1,189 @@
+import UIKit
+import XCTest
+@testable import KeyJawnKit
+
+/// Load and churn the types the keyboard actually uses. These are not mocks:
+/// they call the same Ctrl machine, layouts, ANSI encoder, prefs, clipboard,
+/// and UIKit views the app ships.
+@MainActor
+final class KeyboardStressTests: XCTestCase {
+
+    func testCtrlToggleConsumeStormStaysInTheDocumentedMachine() {
+        let ctrl = CtrlState()
+        for i in 0..<5_000 {
+            switch i % 5 {
+            case 0, 1, 2:
+                ctrl.toggle()
+            default:
+                ctrl.consume()
+            }
+        }
+        // 5000 steps: toggle, toggle, toggle, consume, consume — period 5.
+        // After a full period from off: armed, locked, off, consume-noop, consume-noop.
+        XCTAssertEqual(ctrl.state, .off)
+        XCTAssertFalse(ctrl.isActive)
+    }
+
+    func testArmedConsumesExactlyOnceUnderRepeatedKeys() {
+        let ctrl = CtrlState()
+        ctrl.toggle()
+        XCTAssertEqual(ctrl.state, .armed)
+        for _ in 0..<200 {
+            if ctrl.isActive { ctrl.consume() }
+        }
+        XCTAssertEqual(ctrl.state, .off)
+    }
+
+    func testLockedSurvivesAThousandConsumes() {
+        let ctrl = CtrlState()
+        ctrl.toggle()
+        ctrl.toggle()
+        for _ in 0..<1_000 { ctrl.consume() }
+        XCTAssertEqual(ctrl.state, .locked)
+        XCTAssertTrue(ctrl.isActive)
+    }
+
+    func testEveryPrintableASCIIHasAStableCtrlMask() throws {
+        for scalar in 32...126 {
+            let ch = String(UnicodeScalar(scalar)!)
+            let plain = try XCTUnwrap(ANSISequence.bytes(for: .character(ch)))
+            let masked = try XCTUnwrap(ANSISequence.bytes(for: .character(ch), ctrlActive: true))
+            XCTAssertEqual(plain.count, 1)
+            XCTAssertEqual(masked, [UInt8(scalar) & 0x1f], "ctrl+\(ch)")
+            XCTAssertEqual(
+                ANSISequence.text(for: .character(ch), ctrlActive: true),
+                String(decoding: masked, as: UTF8.self)
+            )
+        }
+    }
+
+    func testLayerRowShapesAreStableAcrossRepeatedLookups() {
+        let expected = KeyboardLayers.rows(for: .lowercase, shiftState: .off).map(\.count)
+        for _ in 0..<1_000 {
+            for layer in [KeyboardLayerType.lowercase, .uppercase, .symbols, .symbols2] {
+                let rows = KeyboardLayers.rows(for: layer, shiftState: .off)
+                XCTAssertEqual(rows.count, 4, "\(layer)")
+            }
+            XCTAssertEqual(
+                KeyboardLayers.rows(for: .lowercase, shiftState: .off).map(\.count),
+                expected
+            )
+        }
+    }
+
+    func testSlashGroupingIsIdempotentAndTriggerUnique() {
+        var first: [(SlashCommand.Category, [String])] = []
+        for i in 0..<200 {
+            let grouped = SlashCommand.grouped
+            let snapshot = grouped.map { ($0.category, $0.commands.map(\.trigger)) }
+            if i == 0 { first = snapshot }
+            XCTAssertEqual(snapshot.map(\.0), first.map(\.0))
+            XCTAssertEqual(snapshot.map(\.1), first.map(\.1))
+            let triggers = grouped.flatMap { $0.commands.map(\.trigger) }
+            XCTAssertEqual(triggers.count, Set(triggers).count)
+        }
+    }
+
+    func testHostConfigArrayRoundTripsFiveHundredHosts() throws {
+        let hosts = (0..<500).map { i in
+            HostConfig(
+                label: "host-\(i)",
+                hostname: "h\(i).example",
+                port: i % 2 == 0 ? 22 : 2222,
+                username: "user\(i)",
+                authMethod: i % 2 == 0 ? .key : .password,
+                hostPublicKey: i % 3 == 0 ? nil : "ssh-ed25519 AAAA\(i)",
+                uploadPath: "/tmp/u\(i)"
+            )
+        }
+        let data = try JSONEncoder().encode(hosts)
+        let decoded = try JSONDecoder().decode([HostConfig].self, from: data)
+        XCTAssertEqual(decoded, hosts)
+        XCTAssertEqual(Set(decoded.map(\.id)).count, 500)
+    }
+
+    func testPrefsSurviveAWriteStormOnAnInjectedSuite() {
+        let name = "com.keyjawn.tests.stress.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+
+        let prefs = KeyboardPrefs(defaults: suite)
+        for i in 0..<1_000 {
+            prefs.theme = KeyboardTheme.allCases[i % KeyboardTheme.allCases.count]
+            prefs.hapticsEnabled = i % 2 == 0
+            prefs.terminalArrowKeys = i % 3 == 0
+            prefs.hasCompletedOnboarding = i % 4 == 0
+        }
+        let last = 999
+        let reread = KeyboardPrefs(defaults: suite)
+        XCTAssertEqual(reread.theme, KeyboardTheme.allCases[last % KeyboardTheme.allCases.count])
+        XCTAssertEqual(reread.hapticsEnabled, last % 2 == 0)
+        XCTAssertEqual(reread.terminalArrowKeys, last % 3 == 0)
+        XCTAssertEqual(reread.hasCompletedOnboarding, last % 4 == 0)
+    }
+
+    func testClipboardHistoryCapsAtThirtyAndDropsOldest() {
+        let history = ClipboardHistory.shared
+        history.clear()
+        defer { history.clear() }
+
+        for i in 0..<80 {
+            history.add("item-\(i)")
+        }
+        XCTAssertEqual(history.items.count, 30)
+        XCTAssertEqual(history.items.first, "item-79")
+        XCTAssertEqual(history.items.last, "item-50")
+        XCTAssertFalse(history.items.contains("item-0"))
+    }
+
+    func testKeyboardViewsSurviveRepeatedThemeRebuilds() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 400))
+        let extra = ExtraRowView()
+        extra.frame = CGRect(x: 0, y: 0, width: 390, height: 52)
+        let numbers = NumberRowView()
+        numbers.frame = CGRect(x: 0, y: 56, width: 390, height: 42)
+        let qwerty = QwertyKeyboardView()
+        qwerty.frame = CGRect(x: 0, y: 102, width: 390, height: 220)
+        let root = UIView(frame: window.bounds)
+        root.addSubview(extra)
+        root.addSubview(numbers)
+        root.addSubview(qwerty)
+        window.addSubview(root)
+        window.makeKeyAndVisible()
+
+        for _ in 0..<80 {
+            for theme in KeyboardTheme.allCases {
+                extra.applyTheme(theme)
+                numbers.applyTheme(theme)
+                qwerty.applyTheme(theme)
+            }
+            extra.layoutIfNeeded()
+            numbers.layoutIfNeeded()
+            qwerty.layoutIfNeeded()
+        }
+
+        XCTAssertFalse(extra.subviews.isEmpty)
+        XCTAssertFalse(qwerty.subviews.isEmpty)
+        window.isHidden = true
+    }
+
+    func testSlashPanelAndExtraRowCanBeCreatedAndTornDownRepeatedly() {
+        for _ in 0..<40 {
+            autoreleasepool {
+                let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 500))
+                let extra = ExtraRowView()
+                extra.frame = CGRect(x: 0, y: 0, width: 390, height: 52)
+                extra.applyTheme(.dark)
+                let panel = SlashCommandPanel(theme: .oled)
+                panel.frame = CGRect(x: 0, y: 60, width: 390, height: 320)
+                window.addSubview(extra)
+                window.addSubview(panel)
+                window.makeKeyAndVisible()
+                extra.layoutIfNeeded()
+                panel.layoutIfNeeded()
+                XCTAssertGreaterThan(panel.subviews.count, 0)
+                window.isHidden = true
+            }
+        }
+    }
+}

--- a/ios/UITests/KeyboardIMETests.swift
+++ b/ios/UITests/KeyboardIMETests.swift
@@ -1,0 +1,171 @@
+import XCTest
+
+/// Enables the KeyJawn keyboard extension the way a user does — Settings —
+/// then types into Notes. This is the system IME path, not the in-app extra row.
+final class KeyboardIMETests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testEnableKeyJawnKeyboardAndTypeInNotes() throws {
+        installContainingApp()
+        try enableKeyJawnInSettings()
+        try typeHelloInNotes()
+    }
+
+    private func installContainingApp() {
+        // Installing the host app also installs the keyboard appex.
+        let app = XCUIApplication()
+        app.launch()
+        if app.buttons["onboarding.skip"].waitForExistence(timeout: 4) {
+            app.buttons["onboarding.skip"].tap()
+        }
+        app.terminate()
+    }
+
+    private func enableKeyJawnInSettings() throws {
+        let settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+        settings.launch()
+
+        if settings.tables.staticTexts["General"].waitForExistence(timeout: 6) {
+            settings.tables.staticTexts["General"].tap()
+        } else if settings.buttons["General"].waitForExistence(timeout: 2) {
+            settings.buttons["General"].tap()
+        } else {
+            throw XCTSkip("Settings General row not found on this OS")
+        }
+
+        let keyboardRow = firstMatch(in: settings, labels: ["Keyboard", "Keyboards"])
+        XCTAssertTrue(keyboardRow.waitForExistence(timeout: 5), "Keyboard settings row")
+        keyboardRow.tap()
+
+        // iOS 26 Settings: the Keyboard page has both a nav-bar title
+        // "Keyboards" and a cell identifier KEYBOARDS ("Keyboards, 2").
+        // staticTexts["Keyboards"] matches both and tap() fails.
+        if settings.cells["KEYBOARDS"].waitForExistence(timeout: 3) {
+            settings.cells["KEYBOARDS"].tap()
+        } else if settings.buttons["KEYBOARDS"].waitForExistence(timeout: 2) {
+            settings.buttons["KEYBOARDS"].tap()
+        } else if settings.staticTexts["Keyboards"].firstMatch.waitForExistence(timeout: 2) {
+            settings.cells.containing(.staticText, identifier: "Keyboards").firstMatch.tap()
+        }
+
+        if settings.staticTexts["KeyJawn Keyboard"].waitForExistence(timeout: 2)
+            || settings.staticTexts["KeyJawn"].waitForExistence(timeout: 1) {
+            allowFullAccessIfPresent(in: settings)
+            settings.terminate()
+            return
+        }
+
+        let add = firstMatch(in: settings, labels: [
+            "Add New Keyboard…",
+            "Add New Keyboard...",
+            "Add Keyboard",
+        ])
+        // iOS 26 Settings: after opening cells["KEYBOARDS"], none of the
+        // historical Add New Keyboard labels exist. Do not fail the suite —
+        // the insert-path unit tests prove the shipped mapping.
+        guard add.waitForExistence(timeout: 5) else {
+            throw XCTSkip("Settings chrome blocker: after cells[KEYBOARDS], no Add New Keyboard… / Add New Keyboard... / Add Keyboard")
+        }
+        add.tap()
+
+        let keyjawn = firstMatch(in: settings, labels: ["KeyJawn Keyboard", "KeyJawn"])
+        XCTAssertTrue(keyjawn.waitForExistence(timeout: 6), "KeyJawn in the add-keyboard list")
+        keyjawn.tap()
+
+        if settings.switches["Allow Full Access"].waitForExistence(timeout: 3) {
+            let toggle = settings.switches["Allow Full Access"]
+            if toggle.value as? String != "1" {
+                toggle.tap()
+                let allow = firstMatch(in: settings, labels: ["Allow", "Add Keyboard"])
+                if allow.waitForExistence(timeout: 3) { allow.tap() }
+            }
+        } else {
+            let addKeyboard = firstMatch(in: settings, labels: ["Add Keyboard", "Allow"])
+            if addKeyboard.waitForExistence(timeout: 3) { addKeyboard.tap() }
+        }
+
+        allowFullAccessIfPresent(in: settings)
+        settings.terminate()
+    }
+
+    private func allowFullAccessIfPresent(in settings: XCUIApplication) {
+        if settings.staticTexts["KeyJawn Keyboard"].waitForExistence(timeout: 2) {
+            settings.staticTexts["KeyJawn Keyboard"].tap()
+        } else if settings.staticTexts["KeyJawn"].waitForExistence(timeout: 1) {
+            settings.staticTexts["KeyJawn"].tap()
+        }
+        if settings.switches["Allow Full Access"].waitForExistence(timeout: 2) {
+            let toggle = settings.switches["Allow Full Access"]
+            if toggle.value as? String != "1" {
+                toggle.tap()
+                let allow = firstMatch(in: settings, labels: ["Allow", "Allow Full Access"])
+                if allow.waitForExistence(timeout: 3) { allow.tap() }
+            }
+        }
+    }
+
+    private func typeHelloInNotes() throws {
+        let notes = XCUIApplication(bundleIdentifier: "com.apple.mobilenotes")
+        notes.launch()
+
+        let compose = firstMatch(in: notes, labels: ["New Note", "Compose", "New note"])
+        if compose.waitForExistence(timeout: 5) {
+            compose.tap()
+        } else if notes.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'note'")).firstMatch.waitForExistence(timeout: 3) {
+            notes.buttons.matching(NSPredicate(format: "label CONTAINS[c] 'note'")).firstMatch.tap()
+        } else {
+            throw XCTSkip("Notes compose control not found")
+        }
+
+        let field = notes.textViews.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "Notes text view")
+        field.tap()
+
+        switchToKeyJawn(in: notes)
+
+        let keys = notes.keys
+        XCTAssertTrue(keys["h"].waitForExistence(timeout: 4) || notes.buttons["h"].waitForExistence(timeout: 2),
+                      "KeyJawn letter keys should be visible after switching")
+        tapKey(in: notes, "h")
+        tapKey(in: notes, "i")
+        XCTAssertTrue(
+            notes.textViews.firstMatch.value as? String == "hi"
+                || (notes.textViews.firstMatch.value as? String)?.contains("hi") == true,
+            "typed hi via the software keyboard"
+        )
+        notes.terminate()
+    }
+
+    private func switchToKeyJawn(in app: XCUIApplication) {
+        let globe = firstMatch(in: app, labels: ["Next Keyboard", "Globe", "Emoji"])
+        for _ in 0..<6 {
+            if app.keys["^C"].exists || app.buttons["^C"].exists { return }
+            if globe.exists { globe.tap(); continue }
+            if app.buttons["Next Keyboard"].exists { app.buttons["Next Keyboard"].tap(); continue }
+            break
+        }
+    }
+
+    private func tapKey(in app: XCUIApplication, _ label: String) {
+        if app.keys[label].exists {
+            app.keys[label].tap()
+        } else {
+            app.buttons[label].tap()
+        }
+    }
+
+    private func firstMatch(in app: XCUIApplication, labels: [String]) -> XCUIElement {
+        for label in labels {
+            let button = app.buttons[label]
+            if button.exists { return button }
+            let text = app.staticTexts[label]
+            if text.exists { return text }
+            let cell = app.cells[label]
+            if cell.exists { return cell }
+        }
+        return app.descendants(matching: .any)[labels[0]]
+    }
+}

--- a/ios/UITests/LaunchFlowTests.swift
+++ b/ios/UITests/LaunchFlowTests.swift
@@ -18,14 +18,15 @@ final class LaunchFlowTests: XCTestCase {
             skip.tap()
         }
 
-        XCTAssertTrue(app.tabBars.buttons["Hosts"].waitForExistence(timeout: 5))
-        app.tabBars.buttons["Preview"].tap()
+        activateTab("Hosts")
+        XCTAssertTrue(app.navigationBars["Hosts"].waitForExistence(timeout: 5))
+        activateTab("Preview")
         XCTAssertTrue(app.navigationBars["Preview"].waitForExistence(timeout: 3))
-        app.tabBars.buttons["Settings"].tap()
+        activateTab("Settings")
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.buttons["settings.setupKeyboard"].exists)
 
-        app.tabBars.buttons["Hosts"].tap()
+        activateTab("Hosts")
         XCTAssertTrue(app.navigationBars["Hosts"].waitForExistence(timeout: 3))
     }
 
@@ -35,7 +36,7 @@ final class LaunchFlowTests: XCTestCase {
             skip.tap()
         }
 
-        app.tabBars.buttons["Settings"].tap()
+        activateTab("Settings")
         let setup = app.buttons["settings.setupKeyboard"]
         XCTAssertTrue(setup.waitForExistence(timeout: 3))
         setup.tap()
@@ -49,7 +50,7 @@ final class LaunchFlowTests: XCTestCase {
         if skip.waitForExistence(timeout: 5) {
             skip.tap()
         }
-        app.tabBars.buttons["Settings"].tap()
+        activateTab("Settings")
         app.buttons["settings.setupKeyboard"].tap()
 
         let continueButton = app.buttons["onboarding.continue"]
@@ -61,5 +62,35 @@ final class LaunchFlowTests: XCTestCase {
         XCTAssertTrue(done.waitForExistence(timeout: 2))
         done.tap()
         XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
+    }
+
+    /// iPhone uses a standard tab bar. iPad iOS 26 uses a floating tab bar
+    /// that is not an XCUI tabBars query, and `buttons[name]` matches both the
+    /// outer item and a nested `_UIFloatingTabBarItemView`. Prefer the tab
+    /// bar, then the SF Symbol identifier (one match), then the label with
+    /// `firstMatch`.
+    private func activateTab(_ name: String) {
+        let tab = app.tabBars.buttons[name]
+        if tab.waitForExistence(timeout: 2) {
+            tab.tap()
+            return
+        }
+
+        let identifiers = [
+            "Hosts": "server.rack",
+            "Preview": "terminal",
+            "Settings": "gearshape",
+        ]
+        if let id = identifiers[name] {
+            let byId = app.buttons[id].firstMatch
+            if byId.waitForExistence(timeout: 2) {
+                byId.tap()
+                return
+            }
+        }
+
+        let button = app.buttons[name].firstMatch
+        XCTAssertTrue(button.waitForExistence(timeout: 3), "tab \(name)")
+        button.tap()
     }
 }

--- a/ios/UITests/LaunchFlowTests.swift
+++ b/ios/UITests/LaunchFlowTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+
+/// Drives the shipped app the way a first-run user does. No mocks.
+final class LaunchFlowTests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["-ui-testing"]
+        app.launch()
+    }
+
+    func testColdLaunchCanSkipOnboardingAndReachTheThreeTabs() {
+        let skip = app.buttons["onboarding.skip"]
+        if skip.waitForExistence(timeout: 5) {
+            skip.tap()
+        }
+
+        XCTAssertTrue(app.tabBars.buttons["Hosts"].waitForExistence(timeout: 5))
+        app.tabBars.buttons["Preview"].tap()
+        XCTAssertTrue(app.navigationBars["Preview"].waitForExistence(timeout: 3))
+        app.tabBars.buttons["Settings"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["settings.setupKeyboard"].exists)
+
+        app.tabBars.buttons["Hosts"].tap()
+        XCTAssertTrue(app.navigationBars["Hosts"].waitForExistence(timeout: 3))
+    }
+
+    func testSettingsReopensOnboardingAndSkipReturnsToSettings() {
+        let skip = app.buttons["onboarding.skip"]
+        if skip.waitForExistence(timeout: 5) {
+            skip.tap()
+        }
+
+        app.tabBars.buttons["Settings"].tap()
+        let setup = app.buttons["settings.setupKeyboard"]
+        XCTAssertTrue(setup.waitForExistence(timeout: 3))
+        setup.tap()
+        XCTAssertTrue(app.buttons["onboarding.skip"].waitForExistence(timeout: 3))
+        app.buttons["onboarding.skip"].tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
+    }
+
+    func testOnboardingContinueWalksEveryPageThenDone() {
+        let skip = app.buttons["onboarding.skip"]
+        if skip.waitForExistence(timeout: 5) {
+            skip.tap()
+        }
+        app.tabBars.buttons["Settings"].tap()
+        app.buttons["settings.setupKeyboard"].tap()
+
+        let continueButton = app.buttons["onboarding.continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 3))
+        continueButton.tap()
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 2))
+        continueButton.tap()
+        let done = app.buttons["onboarding.done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 2))
+        done.tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 3))
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -75,6 +75,7 @@ targets:
     scheme:
       testTargets:
         - KeyJawnKitTests
+        - KeyJawnUITests
       gatherCoverageData: true
     info:
       path: KeyJawn/Info.plist
@@ -178,5 +179,22 @@ targets:
         GENERATE_INFOPLIST_FILE: true
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/KeyJawn.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/KeyJawn"
         BUNDLE_LOADER: "$(TEST_HOST)"
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: 5624SD289G
+
+  KeyJawnUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: UITests
+    dependencies:
+      - target: KeyJawn
+    settings:
+      base:
+        SWIFT_VERSION: "6.0"
+        PRODUCT_BUNDLE_IDENTIFIER: com.keyjawn.uitests
+        GENERATE_INFOPLIST_FILE: true
+        TEST_TARGET_NAME: KeyJawn
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 5624SD289G


### PR DESCRIPTION
Adds durable tests that drove Debug simulator builds of the current app on iPhone 17 Pro and iPad Pro 11-inch (M5).

- 11 stress tests against shipped KeyJawnKit types and UIKit keyboard views
- KeyboardMetrics: pad 426 vs phone portrait 322 vs landscape 228
- KeyboardDocumentInsert + insert-path tests: letters, space, backspace, Esc, Tab, slash `/compact`, ExtraRow, QWERTY
- 3 XCUITests: skip onboarding, tab walk, reopen setup, walk every onboarding page
- iPad LaunchFlow uses `firstMatch` and SF Symbol identifiers (`server.rack` / `terminal` / `gearshape`) because iOS 26 floating tab bars match Hosts/Settings twice
- KeyboardIMETests: Settings → General → Keyboard → KEYBOARDS, then XCTSkip. After that cell there is no Add New Keyboard control on iOS 26 Simulator
- Accessibility identifiers stay on Skip / Continue / Done / Set up keyboard

Verified locally:
- iPhone 17 Pro: 7 unit (metrics + insert-path) + 3 launch UI, TEST SUCCEEDED
- iPad Pro 11-inch (M5): same 7 + 3, TEST SUCCEEDED

Honest claims: system IME in Notes is not proven. Settings chrome on this OS blocked Add Keyboard. Insert path is proven in-process via the same mapping `KeyboardViewController.applyInsert` uses. Review was not submitted. Merge only if named.