### PR TITLE
Address Codex review on the iOS ship PRs

### DIFF
--- a/ios/KeyJawn/App/ContentView.swift
+++ b/ios/KeyJawn/App/ContentView.swift
@@ -12,7 +12,16 @@ struct ContentView: View {
     // nothing — a first launch that looks broken. Hosts is where the app actually
     // starts: add a server, tap it, get a shell.
     @State private var selection: Tab = .hosts
-    @State private var showOnboarding = !KeyboardPrefs.shared.hasCompletedOnboarding
+    @State private var showOnboarding = Self.shouldShowOnboarding()
+
+    /// UI tests pass `-ui-testing` so a reused simulator still presents first
+    /// launch. The flag is not stored; production launches keep the prefs value.
+    private static func shouldShowOnboarding() -> Bool {
+        if ProcessInfo.processInfo.arguments.contains("-ui-testing") {
+            return true
+        }
+        return !KeyboardPrefs.shared.hasCompletedOnboarding
+    }
 
     var body: some View {
         TabView(selection: $selection) {

--- a/ios/KeyJawn/App/OnboardingView.swift
+++ b/ios/KeyJawn/App/OnboardingView.swift
@@ -17,19 +17,23 @@ struct OnboardingView: View {
         NavigationStack {
             VStack(alignment: .leading, spacing: 20) {
                 let current = OnboardingCopy.pages[page]
-                Text(current.title)
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                Text(current.body)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                if page == 1 {
-                    Button(OnboardingCopy.openSettingsTitle) {
-                        if let url = URL(string: UIApplication.openSettingsURLString) {
-                            UIApplication.shared.open(url)
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        Text(current.title)
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                        Text(current.body)
+                            .foregroundStyle(.secondary)
+                        if page == 1 {
+                            Button(OnboardingCopy.openSettingsTitle) {
+                                if let url = URL(string: UIApplication.openSettingsURLString) {
+                                    UIApplication.shared.open(url)
+                                }
+                            }
+                            .buttonStyle(.bordered)
                         }
                     }
-                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 HStack {
                     Button(OnboardingCopy.skipTitle) {

--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -356,8 +356,12 @@ extension KeyboardViewController: NumberRowDelegate {
 extension KeyboardViewController: QwertyKeyboardDelegate {
 
     public func keyboard(_ keyboard: QwertyKeyboardView, insertText text: String) {
-        applyInsert(.character(text), ctrlActive: extraRow.ctrl.isActive)
-        extraRow.ctrl.consume()
+        let output = KeyOutput.character(text)
+        let ctrlActive = extraRow.ctrl.isActive
+        applyInsert(output, ctrlActive: ctrlActive)
+        if KeyboardDocumentInsert.consumesCtrl(for: output, ctrlActive: ctrlActive) {
+            extraRow.ctrl.consume()
+        }
     }
 
     public func keyboardDeleteBackward(_ keyboard: QwertyKeyboardView) {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
@@ -6,13 +6,16 @@ import UIKit
 @MainActor
 public final class ClipboardHistory {
     public static let shared = ClipboardHistory()
-    private init() {}
 
     private let maxItems = 30
     private let maxPinned = 10
     private let historyKey = "keyjawn.clipboard.history"
     private let pinnedKey  = "keyjawn.clipboard.pinned"
-    private let defaults   = UserDefaults.standard
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
 
     // MARK: - Recent items
 

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardDocumentInsert.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardDocumentInsert.swift
@@ -48,4 +48,20 @@ public enum KeyboardDocumentInsert: Equatable, Sendable {
             return .insert(" ")
         }
     }
+
+    /// Armed Ctrl is one-shot only when a control mapping was actually used.
+    /// A multi-character QWERTY alternate (`..`) inserts unchanged and must
+    /// leave Ctrl armed for the next letter.
+    public static func consumesCtrl(for output: KeyOutput, ctrlActive: Bool) -> Bool {
+        guard ctrlActive else { return false }
+        if case .character(let text) = output, text.count != 1 {
+            return false
+        }
+        switch action(for: output, ctrlActive: true, terminalArrows: true) {
+        case .insert:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
@@ -79,6 +79,10 @@ public struct ExtraRowKey: Sendable {
         }
     }
 
+    /// Stable XCUITest identifier. VoiceOver still uses `accessibilityLabel`;
+    /// queries must not use the visible glyph (`^C`, `▲`).
+    public var accessibilityIdentifier: String { "extra.\(slot)" }
+
     public static let defaults: [ExtraRowKey] = [
         ExtraRowKey(slot: .ctrlC,      label: "^C",  output: .ctrlC),
         ExtraRowKey(slot: .tab,        label: "Tab", output: .tab),

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
@@ -252,6 +252,7 @@ final class ExtraRowButton: UIButton {
         titleLabel?.font = .monospacedSystemFont(ofSize: 13, weight: .semibold)
         setTitle(key.label, for: .normal)
         accessibilityLabel = key.accessibilityLabel
+        accessibilityIdentifier = key.accessibilityIdentifier
         layer.cornerRadius = 6
         layer.masksToBounds = false
         layer.shadowOpacity = 0

--- a/ios/Tests/ANSISequenceTests.swift
+++ b/ios/Tests/ANSISequenceTests.swift
@@ -85,4 +85,13 @@ final class ANSISequenceTests: XCTestCase {
                               "\(key.label) falls back to its glyph for VoiceOver")
         }
     }
+
+    func testExtraRowIdentifiersAreStableAndNotTheVisibleGlyph() throws {
+        let ctrl = try XCTUnwrap(ExtraRowKey.defaults.first { $0.slot == .ctrlC })
+        XCTAssertEqual(ctrl.accessibilityIdentifier, "extra.ctrlC")
+        XCTAssertNotEqual(ctrl.accessibilityIdentifier, ctrl.label)
+        for key in ExtraRowKey.defaults {
+            XCTAssertEqual(key.accessibilityIdentifier, "extra.\(key.slot)")
+        }
+    }
 }

--- a/ios/Tests/KeyboardInsertPathTests.swift
+++ b/ios/Tests/KeyboardInsertPathTests.swift
@@ -51,6 +51,18 @@ final class KeyboardInsertPathTests: XCTestCase {
         )
     }
 
+    func testArmedCtrlSurvivesAMultiCharacterAlternate() {
+        XCTAssertTrue(
+            KeyboardDocumentInsert.consumesCtrl(for: .character("c"), ctrlActive: true)
+        )
+        XCTAssertFalse(
+            KeyboardDocumentInsert.consumesCtrl(for: .character(".."), ctrlActive: true)
+        )
+        XCTAssertFalse(
+            KeyboardDocumentInsert.consumesCtrl(for: .character("c"), ctrlActive: false)
+        )
+    }
+
     func testExtraRowButtonsEmitEscTabAndSlash() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 80))
         let extra = ExtraRowView()

--- a/ios/Tests/KeyboardStressTests.swift
+++ b/ios/Tests/KeyboardStressTests.swift
@@ -123,9 +123,10 @@ final class KeyboardStressTests: XCTestCase {
     }
 
     func testClipboardHistoryCapsAtThirtyAndDropsOldest() {
-        let history = ClipboardHistory.shared
-        history.clear()
-        defer { history.clear() }
+        let name = "com.keyjawn.tests.clipboard.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+        let history = ClipboardHistory(defaults: suite)
 
         for i in 0..<80 {
             history.add("item-\(i)")

--- a/ios/Tests/SlashScreenshotRenderTests.swift
+++ b/ios/Tests/SlashScreenshotRenderTests.swift
@@ -18,16 +18,11 @@ final class SlashScreenshotRenderTests: XCTestCase {
         let data = try XCTUnwrap(image.pngData())
         XCTAssertGreaterThan(data.count, 50_000)
 
-        // Local runs refresh the store/website asset. CI leaves the committed PNG alone.
-        if ProcessInfo.processInfo.environment["CI"] == nil {
-            let repo = URL(fileURLWithPath: #filePath)
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-                .deletingLastPathComponent()
-            let out = repo.appendingPathComponent(
-                "website/public/screenshots/ios-screenshots/ios-slash-commands.png"
-            )
-            try data.write(to: out)
+        // Opt-in only. Ordinary local `xcodebuild test` must not rewrite the
+        // tracked listing PNG.
+        if let dest = ProcessInfo.processInfo.environment["SLASH_SCREENSHOT_PATH"],
+           !dest.isEmpty {
+            try data.write(to: URL(fileURLWithPath: dest))
         }
     }
 

--- a/ios/UITests/KeyboardIMETests.swift
+++ b/ios/UITests/KeyboardIMETests.swift
@@ -126,9 +126,10 @@ final class KeyboardIMETests: XCTestCase {
 
         switchToKeyJawn(in: notes)
 
-        let keys = notes.keys
-        XCTAssertTrue(keys["h"].waitForExistence(timeout: 4) || notes.buttons["h"].waitForExistence(timeout: 2),
-                      "KeyJawn letter keys should be visible after switching")
+        XCTAssertTrue(
+            notes.buttons["^C"].waitForExistence(timeout: 4) || notes.keys["^C"].waitForExistence(timeout: 2),
+            "KeyJawn extra-row ^C must be visible before letter taps"
+        )
         tapKey(in: notes, "h")
         tapKey(in: notes, "i")
         XCTAssertTrue(

--- a/ios/UITests/KeyboardIMETests.swift
+++ b/ios/UITests/KeyboardIMETests.swift
@@ -127,8 +127,8 @@ final class KeyboardIMETests: XCTestCase {
         switchToKeyJawn(in: notes)
 
         XCTAssertTrue(
-            notes.buttons["^C"].waitForExistence(timeout: 4) || notes.keys["^C"].waitForExistence(timeout: 2),
-            "KeyJawn extra-row ^C must be visible before letter taps"
+            extraRowIsVisible(in: notes, wait: 4),
+            "KeyJawn extra-row Control must be visible before letter taps"
         )
         tapKey(in: notes, "h")
         tapKey(in: notes, "i")
@@ -140,10 +140,35 @@ final class KeyboardIMETests: XCTestCase {
         notes.terminate()
     }
 
+    /// ExtraRowButton exposes identifier `extra.ctrlC` and the spoken Control-C
+    /// label, not the visible `^C` title. XCUIElement queries match those.
+    private static let extraRowCtrlCId = "extra.ctrlC"
+    private static let extraRowCtrlCLabel =
+        "Control C. Double tap and hold to lock the Control modifier."
+
+    private func extraRowIsVisible(in app: XCUIApplication, wait: TimeInterval = 0) -> Bool {
+        let deadline = Date().addingTimeInterval(wait)
+        repeat {
+            if extraRowElement(in: app).exists { return true }
+            if wait > 0 { RunLoop.current.run(until: Date().addingTimeInterval(0.2)) }
+        } while Date() < deadline
+        return extraRowElement(in: app).exists
+    }
+
+    private func extraRowElement(in app: XCUIApplication) -> XCUIElement {
+        let byId = app.buttons[Self.extraRowCtrlCId]
+        if byId.exists { return byId }
+        let keyById = app.keys[Self.extraRowCtrlCId]
+        if keyById.exists { return keyById }
+        let byLabel = app.buttons[Self.extraRowCtrlCLabel]
+        if byLabel.exists { return byLabel }
+        return app.keys[Self.extraRowCtrlCLabel]
+    }
+
     private func switchToKeyJawn(in app: XCUIApplication) {
         let globe = firstMatch(in: app, labels: ["Next Keyboard", "Globe", "Emoji"])
         for _ in 0..<6 {
-            if app.keys["^C"].exists || app.buttons["^C"].exists { return }
+            if extraRowIsVisible(in: app) { return }
             if globe.exists { globe.tap(); continue }
             if app.buttons["Next Keyboard"].exists { app.buttons["Next Keyboard"].tap(); continue }
             break

--- a/ios/UITests/LaunchFlowTests.swift
+++ b/ios/UITests/LaunchFlowTests.swift
@@ -14,9 +14,8 @@ final class LaunchFlowTests: XCTestCase {
 
     func testColdLaunchCanSkipOnboardingAndReachTheThreeTabs() {
         let skip = app.buttons["onboarding.skip"]
-        if skip.waitForExistence(timeout: 5) {
-            skip.tap()
-        }
+        XCTAssertTrue(skip.waitForExistence(timeout: 5), "first launch must show Skip")
+        skip.tap()
 
         activateTab("Hosts")
         XCTAssertTrue(app.navigationBars["Hosts"].waitForExistence(timeout: 5))


### PR DESCRIPTION
Follow-up for chatgpt-codex-connector comments on already-merged #93–#96. No open PRs were left; this is the remaining review work before a new store build.

Done:
- Ctrl consume only when a one-character control mapping was used (`..` no longer clears armed Ctrl)
- Clipboard cap test uses an injected UserDefaults suite
- `-ui-testing` now forces the onboarding cover; cold-launch asserts Skip exists
- Onboarding page body is in a ScrollView so landscape / large type still works
- Slash screenshot PNG write is opt-in via `SLASH_SCREENSHOT_PATH`
- IME type path requires extra-row `^C` before letter keys so stock QWERTY cannot pass

Not done, with reason:
- Restore Full Access / delete the Notes document: the IME test XCTSkips on iOS 26 Settings, and Notes is missing on the iOS 17.5 SE runtime. Flipping those system settings on a reused device is worse than leaving them.
- Re-render the listing PNG to full keyboard bounds: the 3.2.2 asset is a crop that keeps the panel as the subject. Gating the write is the actual local-test bug.
- CI fallback `iPhone SE (3rd generation)` parse in `.github/workflows/ios-test.yml`: the write hook blocked that file. The sed should keep parenthesized device names and only strip the trailing UUID/state.

Unit tests: KeyboardInsertPathTests, KeyboardStressTests, SlashScreenshotRenderTests — TEST SUCCEEDED on iPhone 16e.

Do not merge unless named. This is not an App Store upload.