### PR TITLE
Fix the in-app extra row slash, Return, Clip, and clipboard suite

### DIFF
--- a/SOCIAL.md
+++ b/SOCIAL.md
@@ -60,6 +60,7 @@ The target user: anyone running Claude Code, Gemini CLI, Codex CLI, OpenCode, or
 ### Recent changes
 <!-- Add entries here as things ship. Newest first. -->
 
+- iOS SSH extra row: `/` opens the slash panel, system Return submits CR, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
 - Android typing and voice overhaul: keys fire on press instead of release (with rollover), backspace escalates to word deletion and supports swipe-to-delete, auto-capitalize at sentence starts, haptics on the number row.
 - Android voice input is now continuous — dictate a whole prompt in natural sentences instead of one tap per phrase. Live transcription appears in the field as you speak, hold the mic for push-to-talk, and cancel discards instead of committing. Optional spoken punctuation ("new line", "open paren").
 - Google Play internal testing set up (7 testers). Production launch pending.

--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08A795D28CCACD6079370712 /* CitadelSCPUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C051D02F5B8C10F3E75D7A /* CitadelSCPUploader.swift */; };
 		12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */; };
 		15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */; };
 		1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */; };
@@ -18,13 +19,15 @@
 		32EB71B5DE76A94E371D71A0 /* SSHSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4B394C56787E8E05B58A1 /* SSHSession.swift */; };
 		348C2A63B6E68B94EE380311 /* InputViewAudioFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */; };
 		35BA636F86655A1E133B3BB2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 98623C822345E60C48D7464D /* Assets.xcassets */; };
-		5629A0DC0147C9A855D09E0F /* CitadelSCPUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */; };
+		3694F662CD2D10BFC8388AF2 /* TerminalInputMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64762D93ADF3F2AB82F1A548 /* TerminalInputMappingTests.swift */; };
+		3E7E682B7731F46E6D232280 /* ClipboardHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38264316C6A0140F8FEB1667 /* ClipboardHistoryTests.swift */; };
 		5A4CC73980A76F9DB9E5A5E2 /* TerminalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6FA031277F874D263EF7AD /* TerminalViewController.swift */; };
 		5A51BC905F126948A48544C7 /* KeyboardPrefsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */; };
 		5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */; };
 		5DF5361C7BE43FB5D0F34CA5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */; };
 		5E5AAF93DC09AC4305BDA08D /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3ABDD7F74E5CC85881A5948 /* OnboardingView.swift */; };
 		6350BC0215D4AF763D7B6A6B /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = CB9AD386707E3751FAD823A1 /* Citadel */; };
+		64F0A7BFAD402AB5064BA7A1 /* CitadelSCPUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C051D02F5B8C10F3E75D7A /* CitadelSCPUploader.swift */; };
 		67B39BE35B75861A3813BF5C /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF300C5B755C35A8B51FED3 /* SettingsView.swift */; };
 		68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5835AD51EEE0C920DE898BD /* AltKeyMappingsTests.swift */; };
 		68B8A22CEFDB19DE99CA2EB5 /* HostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301482A615F90B93947563BC /* HostListView.swift */; };
@@ -106,10 +109,12 @@
 		2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHKeyStore.swift; sourceTree = "<group>"; };
 		301482A615F90B93947563BC /* HostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostListView.swift; sourceTree = "<group>"; };
 		33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchFlowTests.swift; sourceTree = "<group>"; };
+		38264316C6A0140F8FEB1667 /* ClipboardHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardHistoryTests.swift; sourceTree = "<group>"; };
 		396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPrefsTests.swift; sourceTree = "<group>"; };
 		3CE214E0B998D01BC698998B /* KeyboardMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetricsTests.swift; sourceTree = "<group>"; };
 		524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashScreenshotRenderTests.swift; sourceTree = "<group>"; };
 		62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		64762D93ADF3F2AB82F1A548 /* TerminalInputMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputMappingTests.swift; sourceTree = "<group>"; };
 		665662BFA6DECCD61154BEE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBoundaryTests.swift; sourceTree = "<group>"; };
 		7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTerminalView.swift; sourceTree = "<group>"; };
@@ -122,7 +127,6 @@
 		9B940C548C192782A1073E16 /* HostConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConfigTests.swift; sourceTree = "<group>"; };
 		A19791E47A6CF77CB424FCAC /* KeyboardIMETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardIMETests.swift; sourceTree = "<group>"; };
 		A6274AD171FD2D143D7DFDAC /* PasswordPromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordPromptView.swift; sourceTree = "<group>"; };
-		A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitadelSCPUploader.swift; sourceTree = "<group>"; };
 		AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyJawnApp.swift; sourceTree = "<group>"; };
 		AEF300C5B755C35A8B51FED3 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		B5418E5BFCD5CA8FE0DDDAC5 /* HostEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostEditView.swift; sourceTree = "<group>"; };
@@ -133,6 +137,7 @@
 		D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlStateTests.swift; sourceTree = "<group>"; };
 		D5835AD51EEE0C920DE898BD /* AltKeyMappingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltKeyMappingsTests.swift; sourceTree = "<group>"; };
 		D9913D1DFEB392733BA6B353 /* KeyJawnKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KeyJawnKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9C051D02F5B8C10F3E75D7A /* CitadelSCPUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitadelSCPUploader.swift; sourceTree = "<group>"; };
 		DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSSHKeyStore.swift; sourceTree = "<group>"; };
 		DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSISequenceTests.swift; sourceTree = "<group>"; };
 		DF6FA031277F874D263EF7AD /* TerminalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewController.swift; sourceTree = "<group>"; };
@@ -201,6 +206,7 @@
 			children = (
 				D5835AD51EEE0C920DE898BD /* AltKeyMappingsTests.swift */,
 				DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */,
+				38264316C6A0140F8FEB1667 /* ClipboardHistoryTests.swift */,
 				D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */,
 				9B940C548C192782A1073E16 /* HostConfigTests.swift */,
 				2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */,
@@ -212,6 +218,7 @@
 				F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */,
 				B9DF2807E8DD4CB2A02999BA /* SlashCommandTests.swift */,
 				524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */,
+				64762D93ADF3F2AB82F1A548 /* TerminalInputMappingTests.swift */,
 				686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */,
 			);
 			path = Tests;
@@ -264,7 +271,6 @@
 			isa = PBXGroup;
 			children = (
 				88516F15428436E247E65FD4 /* AppGroupHostStore.swift */,
-				A8E002CDE30BEFD6840ABB3A /* CitadelSCPUploader.swift */,
 				2B92C187EB65640055598EB8 /* Info.plist */,
 				97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */,
 				B581E797ADEF1572390A6096 /* KeyboardViewController.swift */,
@@ -284,12 +290,21 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		BFFD31A5D7E5989EFA817A79 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				D9C051D02F5B8C10F3E75D7A /* CitadelSCPUploader.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
 		C9F78F23B732FA5959061518 = {
 			isa = PBXGroup;
 			children = (
 				5FAE6907FF19D4FF99CBBFEE /* KeyJawn */,
 				B0C968F9E2B99A69F54EEB84 /* KeyJawnKeyboard */,
 				EA6DC54EB5C8ABF2BCAB440C /* Packages */,
+				BFFD31A5D7E5989EFA817A79 /* Shared */,
 				5C348A9867C54DD9765F499B /* Tests */,
 				84FDAD7891497578203FF372 /* UITests */,
 				B6F9E3CE713D092F9DF0D5CB /* Products */,
@@ -477,6 +492,7 @@
 			files = (
 				DE63F87E7794F4FF03DA7A43 /* ANSISequenceTests.swift in Sources */,
 				68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */,
+				3E7E682B7731F46E6D232280 /* ClipboardHistoryTests.swift in Sources */,
 				5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */,
 				C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */,
 				DF7E0C0E55646C2A8443B118 /* KeyboardInsertPathTests.swift in Sources */,
@@ -488,6 +504,7 @@
 				15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */,
 				C01DB065ADBBD129FDFA832F /* SlashCommandTests.swift in Sources */,
 				E488DF8C0300EA5A5A26626B /* SlashScreenshotRenderTests.swift in Sources */,
+				3694F662CD2D10BFC8388AF2 /* TerminalInputMappingTests.swift in Sources */,
 				A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -497,7 +514,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				306C46342B0B52F882443953 /* AppGroupHostStore.swift in Sources */,
-				5629A0DC0147C9A855D09E0F /* CitadelSCPUploader.swift in Sources */,
+				64F0A7BFAD402AB5064BA7A1 /* CitadelSCPUploader.swift in Sources */,
 				348C2A63B6E68B94EE380311 /* InputViewAudioFeedback.swift in Sources */,
 				30FBF6554FC7A6F5548299C1 /* KeyboardViewController.swift in Sources */,
 				1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */,
@@ -517,6 +534,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08A795D28CCACD6079370712 /* CitadelSCPUploader.swift in Sources */,
 				5DF5361C7BE43FB5D0F34CA5 /* ContentView.swift in Sources */,
 				ED013FF5D11FE489D6798508 /* HostEditView.swift in Sources */,
 				68B8A22CEFDB19DE99CA2EB5 /* HostListView.swift in Sources */,

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -77,8 +77,10 @@ final class TerminalInputView: UITextView {
             return
         }
         onRawInput?(TerminalInputMapping.bytes(forInsertedText: text))
-        extraRow.ctrl.consume()
         // Intentionally no super call — keeps UITextView text empty.
+        // Armed Ctrl is only consumed when a single-character control mapping
+        // actually fired, so a paste or dictation result does not eat the next
+        // Ctrl+letter.
     }
 
     override func deleteBackward() {
@@ -135,9 +137,14 @@ extension TerminalInputView {
 
     private func showOverlay(_ panel: UIView) {
         let host = overlayHost()
-        panel.frame = host.bounds
-        panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        panel.translatesAutoresizingMaskIntoConstraints = false
         host.addSubview(panel)
+        NSLayoutConstraint.activate([
+            panel.topAnchor.constraint(equalTo: host.topAnchor),
+            panel.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+            panel.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+            panel.bottomAnchor.constraint(equalTo: host.keyboardLayoutGuide.topAnchor),
+        ])
     }
 
     // MARK: Slash

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -77,10 +77,12 @@ final class TerminalInputView: UITextView {
             return
         }
         onRawInput?(TerminalInputMapping.bytes(forInsertedText: text))
+        if text == "\n" || text == "\r" {
+            extraRow.ctrl.consume()
+        }
         // Intentionally no super call — keeps UITextView text empty.
-        // Armed Ctrl is only consumed when a single-character control mapping
-        // actually fired, so a paste or dictation result does not eat the next
-        // Ctrl+letter.
+        // Armed Ctrl is only consumed for a control mapping or a submit, so a
+        // paste or dictation result does not eat the next Ctrl+letter.
     }
 
     override func deleteBackward() {

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -12,6 +12,18 @@ final class TerminalInputView: UITextView {
     /// Called for every raw byte sequence produced by keyboard or extra row.
     var onRawInput: (([UInt8]) -> Void)?
 
+    /// Hosts for the in-app SCP panel. Defaults to a live `HostStore` load so
+    /// the accessory sees the same list as Settings. Tests inject a snapshot.
+    var uploadHosts: () -> [HostConfig] = { HostStore().hosts }
+
+    /// Private key bytes for the in-app SCP upload. Defaults to the shared
+    /// identity. Tests inject a stub.
+    var uploadPrivateKeyData: () -> Data? = { SSHKeyStore.shared.privateKey.rawRepresentation }
+
+    private var slashPanel: SlashCommandPanel?
+    private var clipboardPanel: ClipboardPanel?
+    private var uploadPanel: UploadPanel?
+
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
         setup()
@@ -57,35 +69,204 @@ final class TerminalInputView: UITextView {
         // not silently collapsed into one control byte.
         if extraRow.ctrl.isActive,
            text.count == 1,
+           text != "\n",
+           text != "\r",
            let bytes = ANSISequence.bytes(for: .character(text), ctrlActive: true) {
             onRawInput?(bytes)
             extraRow.ctrl.consume()
             return
         }
-        onRawInput?(Array(text.utf8))
+        onRawInput?(TerminalInputMapping.bytes(forInsertedText: text))
+        extraRow.ctrl.consume()
         // Intentionally no super call — keeps UITextView text empty.
     }
 
     override func deleteBackward() {
         onRawInput?([0x7f]) // DEL
     }
+
+    /// Inserts a non-submit newline (LF). Used by long-press Send so a
+    /// multiline prompt can gain a line without submitting to the agent.
+    func insertNewlineWithoutSubmit() {
+        onRawInput?(TerminalInputMapping.newlineBytes)
+    }
+
+    /// Writes the submit byte (CR) the same way a system Return does.
+    func submitLine() {
+        onRawInput?(TerminalInputMapping.submitBytes)
+    }
 }
 
 extension TerminalInputView: ExtraRowDelegate {
     func extraRow(_ view: ExtraRowView, send output: KeyOutput, ctrlActive: Bool) {
-        if let bytes = ANSISequence.bytes(for: output, ctrlActive: ctrlActive) {
+        switch TerminalInputMapping.extraRow(output, ctrlActive: ctrlActive) {
+        case .write(let bytes):
             onRawInput?(bytes)
+        case .openSlash:
+            showSlashPanel()
+        case .none:
+            break
         }
     }
 
     func extraRowDidTapClipboard(_ view: ExtraRowView) {
-        guard let string = UIPasteboard.general.string else { return }
-        onRawInput?(Array(string.utf8))
+        if clipboardPanel != nil {
+            hideClipboardPanel()
+        } else {
+            showClipboardPanel()
+        }
     }
 
-    /// SCP upload is not available from the in-app terminal extra row.
-    /// It is only active in the keyboard extension.
     func extraRowDidTapUpload(_ view: ExtraRowView) {
-        // no-op in terminal context
+        if uploadPanel != nil {
+            hideUploadPanel()
+        } else {
+            showUploadPanel()
+        }
+    }
+}
+
+// MARK: - Overlays
+
+extension TerminalInputView {
+    private func overlayHost() -> UIView {
+        superview ?? self
+    }
+
+    private func showOverlay(_ panel: UIView) {
+        let host = overlayHost()
+        panel.frame = host.bounds
+        panel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        host.addSubview(panel)
+    }
+
+    // MARK: Slash
+
+    private func showSlashPanel() {
+        guard slashPanel == nil else { return }
+        hideClipboardPanel()
+        hideUploadPanel()
+
+        let panel = SlashCommandPanel(theme: KeyboardPrefs.shared.theme)
+        panel.onSelect = { [weak self] command in
+            self?.onRawInput?(Array(command.trigger.utf8))
+            self?.hideSlashPanel()
+        }
+        panel.onDismiss = { [weak self] in
+            self?.hideSlashPanel()
+        }
+        showOverlay(panel)
+        slashPanel = panel
+    }
+
+    private func hideSlashPanel() {
+        slashPanel?.removeFromSuperview()
+        slashPanel = nil
+    }
+
+    // MARK: Clipboard
+
+    private func showClipboardPanel() {
+        guard clipboardPanel == nil else { return }
+        hideSlashPanel()
+        hideUploadPanel()
+        ClipboardHistory.shared.addCurrent()
+
+        let panel = ClipboardPanel(theme: KeyboardPrefs.shared.theme)
+        panel.refresh()
+        panel.onSelect = { [weak self] text in
+            self?.onRawInput?(Array(text.utf8))
+            self?.hideClipboardPanel()
+        }
+        panel.onDismiss = { [weak self] in
+            self?.hideClipboardPanel()
+        }
+        showOverlay(panel)
+        clipboardPanel = panel
+    }
+
+    private func hideClipboardPanel() {
+        clipboardPanel?.removeFromSuperview()
+        clipboardPanel = nil
+    }
+
+    // MARK: Upload
+
+    private func showUploadPanel() {
+        guard uploadPanel == nil else { return }
+        hideSlashPanel()
+        hideClipboardPanel()
+
+        let theme = KeyboardPrefs.shared.theme
+        let panel = UploadPanel(theme: theme)
+        let hosts = uploadHosts()
+        panel.hosts = hosts
+        panel.emptyReason = .noHostsConfigured
+        panel.onDismiss = { [weak self] in self?.hideUploadPanel() }
+
+        guard let rawImageData = UIPasteboard.general.firstImageData else {
+            panel.statusMessage = UIPasteboard.general.hasImages
+                ? "Couldn't read that image. Try copying it again."
+                : "Copy an image first, then tap SCP"
+            panel.isUploadEnabled = false
+            panel.onUpload = { _ in }
+            showOverlay(panel)
+            uploadPanel = panel
+            return
+        }
+
+        panel.statusMessage = "Preparing image..."
+        panel.isUploadEnabled = false
+        panel.onUpload = { _ in }
+        showOverlay(panel)
+        uploadPanel = panel
+
+        Task { [weak self] in
+            let imageData = await Task.detached(priority: .userInitiated) {
+                PasteboardImagePreparer.downsampledJPEGData(from: rawImageData)
+            }.value
+
+            guard let self, self.uploadPanel === panel else { return }
+            guard let imageData else {
+                panel.statusMessage = "Couldn't read that image. Try copying it again."
+                return
+            }
+            panel.statusMessage = hosts.isEmpty
+                ? "No hosts configured. Add one in Settings."
+                : "Select a host to upload"
+            panel.onUpload = { [weak self] host in
+                self?.performUpload(imageData: imageData, to: host)
+            }
+            panel.isUploadEnabled = !hosts.isEmpty
+        }
+    }
+
+    private func hideUploadPanel() {
+        uploadPanel?.removeFromSuperview()
+        uploadPanel = nil
+    }
+
+    private func performUpload(imageData: Data, to host: HostConfig) {
+        guard let keyData = uploadPrivateKeyData() else {
+            uploadPanel?.statusMessage = "SSH key not found. Open Settings → SSH keys first."
+            return
+        }
+        uploadPanel?.statusMessage = "Uploading to \(host.label)..."
+        uploadPanel?.isUploadEnabled = false
+
+        Task { @MainActor in
+            do {
+                let path = try await CitadelSCPUploader.upload(
+                    imageData: imageData,
+                    to: host,
+                    privateKeyData: keyData
+                )
+                self.onRawInput?(Array(path.utf8))
+                self.hideUploadPanel()
+            } catch {
+                self.uploadPanel?.statusMessage = "Upload failed: \(error.localizedDescription)"
+                self.uploadPanel?.isUploadEnabled = true
+            }
+        }
     }
 }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
@@ -23,17 +23,15 @@ public final class ClipboardHistory {
 
     /// - Parameters:
     ///   - defaults: backing store. Defaults to the shared App Group suite.
-    ///   - migratesLegacyValues: copy pins/history from `UserDefaults.standard`
-    ///     once. Off for injected test suites and the keyboard extension
-    ///     (the extension cannot see the app's standard suite).
+    ///   - migratesLegacyValues: copy pins/history from this process's
+    ///     `UserDefaults.standard` once. The extension was the production
+    ///     caller, so its sandbox holds the legacy pins; the app may have a
+    ///     separate set. Each process copies its own standard suite into the
+    ///     App Group when the shared keys are empty. Off for injected tests.
     public init(defaults: UserDefaults? = nil, migratesLegacyValues: Bool? = nil) {
         self.injectedDefaults = defaults
-        self.migratesLegacyValues = migratesLegacyValues ?? (defaults == nil && !Self.isAppExtension)
+        self.migratesLegacyValues = migratesLegacyValues ?? (defaults == nil)
         migrateLegacyValuesIfNeeded()
-    }
-
-    private static var isAppExtension: Bool {
-        Bundle.main.bundleURL.pathExtension == "appex"
     }
 
     private var defaults: UserDefaults {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
@@ -1,8 +1,14 @@
 import UIKit
 
-/// Stores recent clipboard items in UserDefaults.
-/// Works in both the main app and the keyboard extension (each has its own sandbox).
-/// Items are added manually when the user taps the Clip button — no background monitoring.
+/// Stores recent clipboard items in the `group.com.keyjawn` App Group suite.
+///
+/// The app and the keyboard extension are separate processes. `UserDefaults.standard`
+/// is a per-process sandbox, so pins written in one never appeared in the other —
+/// the same class of bug `KeyboardPrefs` already fixed. Items are added when the
+/// user taps Clip; there is no background monitoring.
+///
+/// A keyboard extension can only open the shared suite with Full Access. Without
+/// it the suite lookup falls back to the extension sandbox and pins stay local.
 @MainActor
 public final class ClipboardHistory {
     public static let shared = ClipboardHistory()
@@ -11,10 +17,17 @@ public final class ClipboardHistory {
     private let maxPinned = 10
     private let historyKey = "keyjawn.clipboard.history"
     private let pinnedKey  = "keyjawn.clipboard.pinned"
-    private let defaults: UserDefaults
+    private let injectedDefaults: UserDefaults?
 
-    public init(defaults: UserDefaults = .standard) {
-        self.defaults = defaults
+    /// - Parameter defaults: backing store. Defaults to the shared App Group
+    ///   suite, resolved per access. Injectable so tests can use a scratch suite.
+    public init(defaults: UserDefaults? = nil) {
+        self.injectedDefaults = defaults
+    }
+
+    private var defaults: UserDefaults {
+        if let injectedDefaults { return injectedDefaults }
+        return UserDefaults(suiteName: AppGroupConfig.suiteName) ?? .standard
     }
 
     // MARK: - Recent items

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ClipboardHistory.swift
@@ -17,17 +17,45 @@ public final class ClipboardHistory {
     private let maxPinned = 10
     private let historyKey = "keyjawn.clipboard.history"
     private let pinnedKey  = "keyjawn.clipboard.pinned"
+    private let migratedKey = "keyjawn.clipboard.migrated.v1"
     private let injectedDefaults: UserDefaults?
+    private let migratesLegacyValues: Bool
 
-    /// - Parameter defaults: backing store. Defaults to the shared App Group
-    ///   suite, resolved per access. Injectable so tests can use a scratch suite.
-    public init(defaults: UserDefaults? = nil) {
+    /// - Parameters:
+    ///   - defaults: backing store. Defaults to the shared App Group suite.
+    ///   - migratesLegacyValues: copy pins/history from `UserDefaults.standard`
+    ///     once. Off for injected test suites and the keyboard extension
+    ///     (the extension cannot see the app's standard suite).
+    public init(defaults: UserDefaults? = nil, migratesLegacyValues: Bool? = nil) {
         self.injectedDefaults = defaults
+        self.migratesLegacyValues = migratesLegacyValues ?? (defaults == nil && !Self.isAppExtension)
+        migrateLegacyValuesIfNeeded()
+    }
+
+    private static var isAppExtension: Bool {
+        Bundle.main.bundleURL.pathExtension == "appex"
     }
 
     private var defaults: UserDefaults {
         if let injectedDefaults { return injectedDefaults }
         return UserDefaults(suiteName: AppGroupConfig.suiteName) ?? .standard
+    }
+
+    private func migrateLegacyValuesIfNeeded() {
+        guard migratesLegacyValues else { return }
+        let store = defaults
+        guard !store.bool(forKey: migratedKey) else { return }
+        let legacy = UserDefaults.standard
+        guard legacy != store else { return }
+        defer { store.set(true, forKey: migratedKey) }
+        if store.object(forKey: historyKey) == nil,
+           let items = legacy.stringArray(forKey: historyKey) {
+            store.set(items, forKey: historyKey)
+        }
+        if store.object(forKey: pinnedKey) == nil,
+           let pinned = legacy.stringArray(forKey: pinnedKey) {
+            store.set(pinned, forKey: pinnedKey)
+        }
     }
 
     // MARK: - Recent items

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/TerminalInputMapping.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/TerminalInputMapping.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Byte mapping the SSH sink uses for system Return, Send, and a non-submit newline.
+///
+/// `TerminalInputView.insertText` and the extra-row Send key both call through
+/// here so a test of this type is a test of the shipped submit path, not a copy
+/// of it. A lone Return is CR (`0x0d`) because that is what a PTY treats as
+/// submit. A dedicated newline helper writes LF (`0x0a`) so a multiline prompt
+/// can gain a line without submitting.
+public enum TerminalInputMapping: Sendable {
+    public static let submitBytes: [UInt8] = [0x0d]
+    public static let newlineBytes: [UInt8] = [0x0a]
+
+    /// What the sink writes for a `UITextView.insertText` payload.
+    ///
+    /// Only a lone `"\n"` or `"\r"` is a submit. A multiline paste keeps its
+    /// UTF-8 bytes so a copied block is not collapsed into one CR.
+    public static func bytes(forInsertedText text: String) -> [UInt8] {
+        if text == "\n" || text == "\r" {
+            return submitBytes
+        }
+        return Array(text.utf8)
+    }
+
+    public enum ExtraRowAction: Equatable, Sendable {
+        case write([UInt8])
+        case openSlash
+        case none
+    }
+
+    /// Extra-row key → terminal action. Slash opens the panel; everything else
+    /// that has ANSI bytes is written. Clipboard and upload stay on the
+    /// delegate methods because they are not `KeyOutput`s.
+    public static func extraRow(_ output: KeyOutput, ctrlActive: Bool) -> ExtraRowAction {
+        if output == .slash { return .openSlash }
+        if let bytes = ANSISequence.bytes(for: output, ctrlActive: ctrlActive) {
+            return .write(bytes)
+        }
+        return .none
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ClipboardPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ClipboardPanel.swift
@@ -47,6 +47,7 @@ public final class ClipboardPanel: UIView, UITableViewDataSource, UITableViewDel
     public init(theme: KeyboardTheme = .dark) {
         self.theme = theme
         super.init(frame: .zero)
+        accessibilityIdentifier = "clipboard-panel"
         setupView()
     }
 

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/SlashCommandPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/SlashCommandPanel.swift
@@ -25,6 +25,7 @@ public final class SlashCommandPanel: UIView {
         }
         self.theme = theme
         super.init(frame: .zero)
+        accessibilityIdentifier = "slash-command-panel"
         build()
     }
 

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/UploadPanel.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/UploadPanel.swift
@@ -50,6 +50,7 @@ public final class UploadPanel: UIView {
     public init(theme: KeyboardTheme = .dark) {
         self.theme = theme
         super.init(frame: .zero)
+        accessibilityIdentifier = "upload-panel"
         setup()
     }
 

--- a/ios/Shared/CitadelSCPUploader.swift
+++ b/ios/Shared/CitadelSCPUploader.swift
@@ -6,7 +6,9 @@ import CryptoKit
 import KeyJawnKit
 
 /// Uploads image data to a remote host via SFTP using Citadel.
-/// Lives in the keyboard extension (not KeyJawnKit) so it can import Citadel freely.
+/// Compiled into both the app and the keyboard extension so the in-app extra
+/// row can use the same upload path as the IME. Not in KeyJawnKit because
+/// the kit must stay free of the Citadel dependency.
 enum CitadelSCPUploader {
 
     enum UploadError: Error, LocalizedError {

--- a/ios/Tests/ClipboardHistoryTests.swift
+++ b/ios/Tests/ClipboardHistoryTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import KeyJawnKit
+
+@MainActor
+final class ClipboardHistoryTests: XCTestCase {
+
+    func testPinIsVisibleToAnotherInstanceOnTheSameSuite() {
+        let name = "com.keyjawn.tests.clip-pin.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+
+        let writer = ClipboardHistory(defaults: suite)
+        writer.pin("pinned-path")
+        let reader = ClipboardHistory(defaults: suite)
+        XCTAssertTrue(reader.isPinned("pinned-path"))
+        XCTAssertEqual(reader.pinned, ["pinned-path"])
+    }
+
+    func testUninjectedHistoryUsesAppGroupSuite() {
+        let suite = UserDefaults(suiteName: AppGroupConfig.suiteName)
+        XCTAssertNotNil(suite, "group.com.keyjawn suite must resolve in tests")
+        let sentinel = "suite-sentinel-\(UUID().uuidString)"
+        let key = "keyjawn.clipboard.history"
+        let previous = suite?.stringArray(forKey: key)
+        suite?.set([sentinel], forKey: key)
+        defer {
+            if let previous {
+                suite?.set(previous, forKey: key)
+            } else {
+                suite?.removeObject(forKey: key)
+            }
+        }
+
+        let history = ClipboardHistory()
+        XCTAssertTrue(history.items.contains(sentinel),
+                      "uninjected ClipboardHistory must read group.com.keyjawn")
+    }
+}

--- a/ios/Tests/ClipboardHistoryTests.swift
+++ b/ios/Tests/ClipboardHistoryTests.swift
@@ -16,6 +16,26 @@ final class ClipboardHistoryTests: XCTestCase {
         XCTAssertEqual(reader.pinned, ["pinned-path"])
     }
 
+    func testLegacyStandardSuitePinsMoveToTheAppGroup() {
+        let suiteName = "com.keyjawn.tests.clip-migrate.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: suiteName)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        let previous = UserDefaults.standard.stringArray(forKey: "keyjawn.clipboard.pinned")
+        UserDefaults.standard.set(["legacy-pin"], forKey: "keyjawn.clipboard.pinned")
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: "keyjawn.clipboard.pinned")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "keyjawn.clipboard.pinned")
+            }
+        }
+
+        let history = ClipboardHistory(defaults: suite, migratesLegacyValues: true)
+        XCTAssertTrue(history.isPinned("legacy-pin"))
+        XCTAssertTrue(ClipboardHistory(defaults: suite, migratesLegacyValues: false).isPinned("legacy-pin"))
+    }
+
     func testUninjectedHistoryUsesAppGroupSuite() {
         let suite = UserDefaults(suiteName: AppGroupConfig.suiteName)
         XCTAssertNotNil(suite, "group.com.keyjawn suite must resolve in tests")

--- a/ios/Tests/TerminalInputMappingTests.swift
+++ b/ios/Tests/TerminalInputMappingTests.swift
@@ -85,6 +85,13 @@ final class TerminalInputViewTests: XCTestCase {
         XCTAssertFalse(sink.extraRow.ctrl.isActive)
     }
 
+    func testArmedCtrlIsConsumedOnSystemReturn() {
+        let sink = TerminalInputView()
+        sink.extraRow.ctrl.toggle()
+        sink.insertText("\n")
+        XCTAssertFalse(sink.extraRow.ctrl.isActive, "submit must consume armed Ctrl")
+    }
+
     func testExtraRowSlashOpensPanelAndCompactWritesTrigger() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
         let sink = TerminalInputView(frame: window.bounds)

--- a/ios/Tests/TerminalInputMappingTests.swift
+++ b/ios/Tests/TerminalInputMappingTests.swift
@@ -1,0 +1,172 @@
+import UIKit
+import XCTest
+@testable import KeyJawn
+@testable import KeyJawnKit
+
+/// Drives the same mapping `TerminalInputView.insertText` and extra-row Send use.
+final class TerminalInputMappingTests: XCTestCase {
+
+    func testLoneReturnIsCR() {
+        XCTAssertEqual(TerminalInputMapping.bytes(forInsertedText: "\n"), [0x0d])
+        XCTAssertEqual(TerminalInputMapping.bytes(forInsertedText: "\r"), [0x0d])
+        XCTAssertEqual(TerminalInputMapping.bytes(forInsertedText: "\n"), TerminalInputMapping.submitBytes)
+    }
+
+    func testNonSubmitNewlineIsNotASubmit() {
+        XCTAssertEqual(TerminalInputMapping.newlineBytes, [0x0a])
+        XCTAssertNotEqual(TerminalInputMapping.newlineBytes, TerminalInputMapping.submitBytes)
+    }
+
+    func testOrdinaryTextIsUTF8() {
+        XCTAssertEqual(TerminalInputMapping.bytes(forInsertedText: "hi"), Array("hi".utf8))
+    }
+
+    func testMultilinePasteIsNotCollapsedToSubmit() {
+        XCTAssertEqual(TerminalInputMapping.bytes(forInsertedText: "a\nb"), Array("a\nb".utf8))
+    }
+
+    func testExtraRowSlashOpensThePanelInsteadOfWritingBytes() {
+        XCTAssertEqual(TerminalInputMapping.extraRow(.slash, ctrlActive: false), .openSlash)
+        XCTAssertNil(ANSISequence.bytes(for: .slash))
+    }
+
+    func testExtraRowReturnIsSubmitCR() {
+        XCTAssertEqual(TerminalInputMapping.extraRow(.return, ctrlActive: false), .write([0x0d]))
+    }
+}
+
+@MainActor
+final class TerminalInputViewTests: XCTestCase {
+
+    func testSystemReturnUsesTheShippedSubmitMapping() {
+        let sink = TerminalInputView()
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        sink.insertText("\n")
+        XCTAssertEqual(got, [TerminalInputMapping.submitBytes])
+        XCTAssertEqual(got.first, [0x0d])
+    }
+
+    func testInsertNewlineWithoutSubmitIsNotSubmit() {
+        let sink = TerminalInputView()
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        sink.insertNewlineWithoutSubmit()
+        XCTAssertEqual(got, [TerminalInputMapping.newlineBytes])
+        XCTAssertNotEqual(got.first, TerminalInputMapping.submitBytes)
+    }
+
+    func testSubmitLineWritesCR() {
+        let sink = TerminalInputView()
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        sink.submitLine()
+        XCTAssertEqual(got, [[0x0d]])
+    }
+
+    func testTypedTextIsUTF8() {
+        let sink = TerminalInputView()
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        sink.insertText("ab")
+        XCTAssertEqual(got, [Array("ab".utf8)])
+    }
+
+    func testExtraRowSlashOpensPanelAndCompactWritesTrigger() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        let sink = TerminalInputView(frame: window.bounds)
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        window.addSubview(sink)
+        window.makeKeyAndVisible()
+        sink.layoutIfNeeded()
+
+        let extra = sink.extraRow
+        extra.frame = CGRect(x: 0, y: 640, width: 390, height: 52)
+        window.addSubview(extra)
+        extra.layoutIfNeeded()
+
+        tapExtra(extra, accessibility: "Slash commands")
+
+        guard let panel = window.subviews.reversed().first(where: {
+            $0.accessibilityIdentifier == "slash-command-panel"
+        }) as? SlashCommandPanel else {
+            return XCTFail("slash panel did not appear over the terminal")
+        }
+
+        guard let table = panel.subviews.compactMap({ $0 as? UITableView }).first else {
+            return XCTFail("SlashCommandPanel has no table")
+        }
+        table.reloadData()
+        table.layoutIfNeeded()
+
+        var compactPath: IndexPath?
+        for section in 0..<table.numberOfSections {
+            for row in 0..<table.numberOfRows(inSection: section) {
+                let path = IndexPath(row: row, section: section)
+                let cell = table.dataSource?.tableView(table, cellForRowAt: path)
+                if cell?.accessibilityLabel?.contains("/compact") == true {
+                    compactPath = path
+                    break
+                }
+            }
+        }
+        guard let compactPath else {
+            return XCTFail("table has no /compact row")
+        }
+
+        table.selectRow(at: compactPath, animated: false, scrollPosition: .none)
+        table.delegate?.tableView?(table, didSelectRowAt: compactPath)
+        XCTAssertEqual(got, [Array("/compact".utf8)])
+        window.isHidden = true
+    }
+
+    func testClipOpensClipboardPanel() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        let sink = TerminalInputView(frame: window.bounds)
+        window.addSubview(sink)
+        window.makeKeyAndVisible()
+
+        let extra = sink.extraRow
+        extra.frame = CGRect(x: 0, y: 640, width: 390, height: 52)
+        window.addSubview(extra)
+        extra.layoutIfNeeded()
+
+        tapExtra(extra, accessibility: "Clipboard history")
+        XCTAssertTrue(
+            window.subviews.contains { $0.accessibilityIdentifier == "clipboard-panel" },
+            "Clip must present ClipboardPanel, not one-shot paste"
+        )
+        window.isHidden = true
+    }
+
+    func testSCPOpensUploadPanel() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
+        let sink = TerminalInputView(frame: window.bounds)
+        sink.uploadHosts = { [] }
+        window.addSubview(sink)
+        window.makeKeyAndVisible()
+
+        let extra = sink.extraRow
+        extra.frame = CGRect(x: 0, y: 640, width: 390, height: 52)
+        window.addSubview(extra)
+        extra.layoutIfNeeded()
+
+        tapExtra(extra, accessibility: "Upload image over SFTP")
+        XCTAssertTrue(
+            window.subviews.contains { $0.accessibilityIdentifier == "upload-panel" },
+            "SCP must present UploadPanel, not a no-op"
+        )
+        window.isHidden = true
+    }
+
+    private func tapExtra(_ extra: ExtraRowView, accessibility: String) {
+        let button = extra.subviews
+            .flatMap(\.subviews)
+            .compactMap { $0 as? UIButton }
+            .first { $0.accessibilityLabel?.contains(accessibility) == true
+                || $0.currentTitle == accessibility }
+        XCTAssertNotNil(button, "missing extra-row control \(accessibility)")
+        button?.sendActions(for: .touchUpInside)
+    }
+}

--- a/ios/Tests/TerminalInputMappingTests.swift
+++ b/ios/Tests/TerminalInputMappingTests.swift
@@ -72,6 +72,19 @@ final class TerminalInputViewTests: XCTestCase {
         XCTAssertEqual(got, [Array("ab".utf8)])
     }
 
+    func testArmedCtrlSurvivesAMultilinePaste() {
+        let sink = TerminalInputView()
+        sink.extraRow.ctrl.toggle()
+        XCTAssertTrue(sink.extraRow.ctrl.isActive)
+        sink.insertText("ab\ncd")
+        XCTAssertTrue(sink.extraRow.ctrl.isActive, "paste must not consume armed Ctrl")
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        sink.insertText("c")
+        XCTAssertEqual(got, [[0x03]])
+        XCTAssertFalse(sink.extraRow.ctrl.isActive)
+    }
+
     func testExtraRowSlashOpensPanelAndCompactWritesTrigger() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 700))
         let sink = TerminalInputView(frame: window.bounds)

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -32,6 +32,7 @@ targets:
     deploymentTarget: "17.0"
     sources:
       - path: KeyJawn
+      - path: Shared
     dependencies:
       - package: KeyJawnKit
         product: KeyJawnKit
@@ -113,6 +114,7 @@ targets:
     deploymentTarget: "17.0"
     sources:
       - path: KeyJawnKeyboard
+      - path: Shared
     dependencies:
       - package: KeyJawnKit
         product: KeyJawnKit


### PR DESCRIPTION
Closes #98
Closes #99
Closes #100
Closes #101

The SSH accessory extra row advertised slash commands, Clip, and SCP, and the system Return key looked like submit. None of that was true in the app:

- Extra-row `/` went through `ANSISequence.bytes(.slash)`, which is `nil`. There was no `SlashCommandPanel` in the terminal. The extension already opened the panel.
- `insertText("\n")` wrote LF (`0x0a`). Agents and shells want CR (`0x0d`).
- Clip pasted `UIPasteboard.general` once. SCP was an empty `extraRowDidTapUpload`.
- `ClipboardHistory` used `UserDefaults.standard`, so pins never crossed the app/extension boundary. Same class of bug `KeyboardPrefs` already fixed.

## What changed

- `TerminalInputMapping` is the shipped submit/newline/extra-row map. A lone Return is CR. A dedicated newline helper writes LF. Slash is `.openSlash`.
- `TerminalInputView` uses that map. Extra-row `/` presents `SlashCommandPanel` and writes the trigger (e.g. `/compact`) to the PTY. Clip and SCP present the real panels. SCP shares `CitadelSCPUploader` with the extension.
- `ClipboardHistory` defaults to `group.com.keyjawn`.

## Tests

- CR vs LF through `TerminalInputView.insertText` and `TerminalInputMapping`.
- Extra-row `/` opens the panel; selecting `/compact` writes those bytes.
- Clip and SCP present their panels.
- Pins written on one injected suite are visible to another; uninjected history reads the App Group.

## Review

Codex 5.4/low: password-auth hosts can still be picked in the SCP panel even though the uploader is Ed25519-only. That is also how the extension panel already works. Filed as #110 rather than changing both surfaces here.

## Out of scope

No TestFlight/App Store upload. No version bump. Password-host filter is #110. Prompt scratchpad and path-back-into-prompt remain deferred (#103, #104).