### PR TITLE
iOS agent-loop: Send, presets, hardware keys, voice, custom slash

### DIFF
--- a/SOCIAL.md
+++ b/SOCIAL.md
@@ -60,7 +60,7 @@ The target user: anyone running Claude Code, Gemini CLI, Codex CLI, OpenCode, or
 ### Recent changes
 <!-- Add entries here as things ship. Newest first. -->
 
-- iOS SSH extra row: `/` opens the slash panel, system Return and Send submit CR, long-press Send inserts a newline without submitting, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
+- iOS SSH extra row: `/` opens the slash panel, system Return and Send submit CR, long-press Send inserts a newline without submitting, Agent/Confirm presets switch the row, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
 - Android typing and voice overhaul: keys fire on press instead of release (with rollover), backspace escalates to word deletion and supports swipe-to-delete, auto-capitalize at sentence starts, haptics on the number row.
 - Android voice input is now continuous — dictate a whole prompt in natural sentences instead of one tap per phrase. Live transcription appears in the field as you speak, hold the mic for push-to-talk, and cancel discards instead of committing. Optional spoken punctuation ("new line", "open paren").
 - Google Play internal testing set up (7 testers). Production launch pending.

--- a/SOCIAL.md
+++ b/SOCIAL.md
@@ -60,7 +60,7 @@ The target user: anyone running Claude Code, Gemini CLI, Codex CLI, OpenCode, or
 ### Recent changes
 <!-- Add entries here as things ship. Newest first. -->
 
-- iOS SSH extra row: `/` opens the slash panel, system Return submits CR, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
+- iOS SSH extra row: `/` opens the slash panel, system Return and Send submit CR, long-press Send inserts a newline without submitting, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
 - Android typing and voice overhaul: keys fire on press instead of release (with rollover), backspace escalates to word deletion and supports swipe-to-delete, auto-capitalize at sentence starts, haptics on the number row.
 - Android voice input is now continuous — dictate a whole prompt in natural sentences instead of one tap per phrase. Live transcription appears in the field as you speak, hold the mic for push-to-talk, and cancel discards instead of committing. Optional spoken punctuation ("new line", "open paren").
 - Google Play internal testing set up (7 testers). Production launch pending.

--- a/SOCIAL.md
+++ b/SOCIAL.md
@@ -60,7 +60,7 @@ The target user: anyone running Claude Code, Gemini CLI, Codex CLI, OpenCode, or
 ### Recent changes
 <!-- Add entries here as things ship. Newest first. -->
 
-- iOS SSH extra row: `/` opens the slash panel, system Return and Send submit CR, long-press Send inserts a newline without submitting, Agent/Confirm presets switch the row, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
+- iOS SSH extra row: `/` opens the slash panel (including custom shortcuts), system Return and Send submit CR, long-press Send inserts a newline without submitting, Agent/Confirm presets switch the row, hardware Esc/Tab/arrows/Ctrl+C reach the PTY, mic dictation is main-app only, Clip and SCP open the real panels, and clipboard pins live in the App Group so the app and keyboard share them.
 - Android typing and voice overhaul: keys fire on press instead of release (with rollover), backspace escalates to word deletion and supports swipe-to-delete, auto-capitalize at sentence starts, haptics on the number row.
 - Android voice input is now continuous — dictate a whole prompt in natural sentences instead of one tap per phrase. Live transcription appears in the field as you speak, hold the mic for push-to-talk, and cancel discards instead of committing. Optional spoken punctuation ("new line", "open paren").
 - Google Play internal testing set up (7 testers). Production launch pending.

--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -8,8 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		08A795D28CCACD6079370712 /* CitadelSCPUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9C051D02F5B8C10F3E75D7A /* CitadelSCPUploader.swift */; };
+		112B82237850CDFD6CE0A92C /* SlashCommandStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD05F7B8B824B359DEE870C9 /* SlashCommandStoreTests.swift */; };
 		12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */; };
+		1537E06440732A988EE7463F /* ExtensionHonestyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF4D90B05932E700713A941 /* ExtensionHonestyTests.swift */; };
 		15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */; };
+		1796EA69BCD6FDFC5C4544A2 /* VoiceSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838BAAD1067A5FE9A2DDE1E4 /* VoiceSessionTests.swift */; };
 		1C5FD6A31F1A4AFF704FFF74 /* SharedSSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */; };
 		1F3BC0FB1DEE09CF9586840D /* HostTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */; };
 		1F6BA06DD660C887B3E1F79C /* KeyJawnApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD9AC295E87CCA2D770BDB6A /* KeyJawnApp.swift */; };
@@ -33,6 +36,7 @@
 		68B8A22CEFDB19DE99CA2EB5 /* HostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301482A615F90B93947563BC /* HostListView.swift */; };
 		76503EE687E0F88885DD27DE /* NIOSSH in Frameworks */ = {isa = PBXBuildFile; productRef = 974D61CF6F7ADA4824D53DC7 /* NIOSSH */; };
 		7E2C29A442AE9E2630A2F301 /* HostStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5405F0BD516F74C8E0EED5 /* HostStore.swift */; };
+		913F17D07A48356C667DF51A /* TerminalVoiceInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 458667FC8591E01311ADA8AF /* TerminalVoiceInput.swift */; };
 		9DA97D841DD222F4BC99CFC9 /* KeyJawnKit in Frameworks */ = {isa = PBXBuildFile; productRef = 1BD7D5FD852EEF611DFEF3BA /* KeyJawnKit */; };
 		A58E56EF6474C8DBC8512A2F /* KeyboardStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */; };
 		A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */; };
@@ -52,6 +56,7 @@
 		CCDB3D09BF10D8B0C6C4B9BD /* ExtraRowPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54003BE0AD4A0942B2C7D0F1 /* ExtraRowPresetTests.swift */; };
 		D4959C7C420241BE04B8CD59 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 060BD31A2DD85CF9C0F6FE6F /* Citadel */; };
 		D833730B6D5B5B7CD1D39B17 /* TerminalInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F295D7985B88063D1F195088 /* TerminalInputView.swift */; };
+		DC086B3EB381E69972DDC0AA /* HardwareKeyMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F5FD863B6B104B7A7FBE477 /* HardwareKeyMappingTests.swift */; };
 		DE63F87E7794F4FF03DA7A43 /* ANSISequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */; };
 		DF7E0C0E55646C2A8443B118 /* KeyboardInsertPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */; };
 		E488DF8C0300EA5A5A26626B /* SlashScreenshotRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */; };
@@ -112,7 +117,9 @@
 		33E1CA9E994C39BD29662DF0 /* LaunchFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchFlowTests.swift; sourceTree = "<group>"; };
 		38264316C6A0140F8FEB1667 /* ClipboardHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardHistoryTests.swift; sourceTree = "<group>"; };
 		396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPrefsTests.swift; sourceTree = "<group>"; };
+		3AF4D90B05932E700713A941 /* ExtensionHonestyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionHonestyTests.swift; sourceTree = "<group>"; };
 		3CE214E0B998D01BC698998B /* KeyboardMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetricsTests.swift; sourceTree = "<group>"; };
+		458667FC8591E01311ADA8AF /* TerminalVoiceInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalVoiceInput.swift; sourceTree = "<group>"; };
 		524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashScreenshotRenderTests.swift; sourceTree = "<group>"; };
 		54003BE0AD4A0942B2C7D0F1 /* ExtraRowPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraRowPresetTests.swift; sourceTree = "<group>"; };
 		62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -120,6 +127,8 @@
 		665662BFA6DECCD61154BEE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordBoundaryTests.swift; sourceTree = "<group>"; };
 		7588DD4C7951CF1F99C3A433 /* HostTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTerminalView.swift; sourceTree = "<group>"; };
+		7F5FD863B6B104B7A7FBE477 /* HardwareKeyMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareKeyMappingTests.swift; sourceTree = "<group>"; };
+		838BAAD1067A5FE9A2DDE1E4 /* VoiceSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSessionTests.swift; sourceTree = "<group>"; };
 		88516F15428436E247E65FD4 /* AppGroupHostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupHostStore.swift; sourceTree = "<group>"; };
 		8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardStressTests.swift; sourceTree = "<group>"; };
 		97D63ED3E15ECBC88F45E3B6 /* InputViewAudioFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputViewAudioFeedback.swift; sourceTree = "<group>"; };
@@ -141,6 +150,7 @@
 		D9913D1DFEB392733BA6B353 /* KeyJawnKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = KeyJawnKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9C051D02F5B8C10F3E75D7A /* CitadelSCPUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CitadelSCPUploader.swift; sourceTree = "<group>"; };
 		DB7A1E2373DA280920653B41 /* SharedSSHKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSSHKeyStore.swift; sourceTree = "<group>"; };
+		DD05F7B8B824B359DEE870C9 /* SlashCommandStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashCommandStoreTests.swift; sourceTree = "<group>"; };
 		DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ANSISequenceTests.swift; sourceTree = "<group>"; };
 		DF6FA031277F874D263EF7AD /* TerminalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalViewController.swift; sourceTree = "<group>"; };
 		F295D7985B88063D1F195088 /* TerminalInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputView.swift; sourceTree = "<group>"; };
@@ -190,6 +200,7 @@
 				23A4B394C56787E8E05B58A1 /* SSHSession.swift */,
 				F295D7985B88063D1F195088 /* TerminalInputView.swift */,
 				DF6FA031277F874D263EF7AD /* TerminalViewController.swift */,
+				458667FC8591E01311ADA8AF /* TerminalVoiceInput.swift */,
 			);
 			path = Terminal;
 			sourceTree = "<group>";
@@ -210,7 +221,9 @@
 				DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */,
 				38264316C6A0140F8FEB1667 /* ClipboardHistoryTests.swift */,
 				D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */,
+				3AF4D90B05932E700713A941 /* ExtensionHonestyTests.swift */,
 				54003BE0AD4A0942B2C7D0F1 /* ExtraRowPresetTests.swift */,
+				7F5FD863B6B104B7A7FBE477 /* HardwareKeyMappingTests.swift */,
 				9B940C548C192782A1073E16 /* HostConfigTests.swift */,
 				2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */,
 				98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */,
@@ -219,9 +232,11 @@
 				8BD88603C1C49C4DCF6E4364 /* KeyboardStressTests.swift */,
 				FAA8A921E20FE294CCFC815A /* KeyboardThemeContrastTests.swift */,
 				F48343C46F1026C97DFEE5F1 /* OnboardingTests.swift */,
+				DD05F7B8B824B359DEE870C9 /* SlashCommandStoreTests.swift */,
 				B9DF2807E8DD4CB2A02999BA /* SlashCommandTests.swift */,
 				524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */,
 				64762D93ADF3F2AB82F1A548 /* TerminalInputMappingTests.swift */,
+				838BAAD1067A5FE9A2DDE1E4 /* VoiceSessionTests.swift */,
 				686608D07F38BF2952BC2A05 /* WordBoundaryTests.swift */,
 			);
 			path = Tests;
@@ -497,7 +512,9 @@
 				68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */,
 				3E7E682B7731F46E6D232280 /* ClipboardHistoryTests.swift in Sources */,
 				5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */,
+				1537E06440732A988EE7463F /* ExtensionHonestyTests.swift in Sources */,
 				CCDB3D09BF10D8B0C6C4B9BD /* ExtraRowPresetTests.swift in Sources */,
+				DC086B3EB381E69972DDC0AA /* HardwareKeyMappingTests.swift in Sources */,
 				C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */,
 				DF7E0C0E55646C2A8443B118 /* KeyboardInsertPathTests.swift in Sources */,
 				EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */,
@@ -506,9 +523,11 @@
 				A58E56EF6474C8DBC8512A2F /* KeyboardStressTests.swift in Sources */,
 				12AE43CD002393743BACEB75 /* KeyboardThemeContrastTests.swift in Sources */,
 				15533E56B3ECB76AAEE83116 /* OnboardingTests.swift in Sources */,
+				112B82237850CDFD6CE0A92C /* SlashCommandStoreTests.swift in Sources */,
 				C01DB065ADBBD129FDFA832F /* SlashCommandTests.swift in Sources */,
 				E488DF8C0300EA5A5A26626B /* SlashScreenshotRenderTests.swift in Sources */,
 				3694F662CD2D10BFC8388AF2 /* TerminalInputMappingTests.swift in Sources */,
+				1796EA69BCD6FDFC5C4544A2 /* VoiceSessionTests.swift in Sources */,
 				A793BD0FFA4FDCD6DA278117 /* WordBoundaryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -553,6 +572,7 @@
 				67B39BE35B75861A3813BF5C /* SettingsView.swift in Sources */,
 				D833730B6D5B5B7CD1D39B17 /* TerminalInputView.swift in Sources */,
 				5A4CC73980A76F9DB9E5A5E2 /* TerminalViewController.swift in Sources */,
+				913F17D07A48356C667DF51A /* TerminalVoiceInput.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/KeyJawn.xcodeproj/project.pbxproj
+++ b/ios/KeyJawn.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		C2F8D707F7F9F58DA50E2A7F /* NIOPosix in Frameworks */ = {isa = PBXBuildFile; productRef = 2C94B23FBDB89626C8A0294C /* NIOPosix */; };
 		C5D73FD296E1B9A8CD97626C /* SSHKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE62DD6DE973B1FB26C0314 /* SSHKeyStore.swift */; };
 		CA738FCA57272508A304C827 /* SwiftTerm in Frameworks */ = {isa = PBXBuildFile; productRef = DBC5B9DCB9FBC1D3E054CE8F /* SwiftTerm */; };
+		CCDB3D09BF10D8B0C6C4B9BD /* ExtraRowPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54003BE0AD4A0942B2C7D0F1 /* ExtraRowPresetTests.swift */; };
 		D4959C7C420241BE04B8CD59 /* Citadel in Frameworks */ = {isa = PBXBuildFile; productRef = 060BD31A2DD85CF9C0F6FE6F /* Citadel */; };
 		D833730B6D5B5B7CD1D39B17 /* TerminalInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F295D7985B88063D1F195088 /* TerminalInputView.swift */; };
 		DE63F87E7794F4FF03DA7A43 /* ANSISequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */; };
@@ -113,6 +114,7 @@
 		396D44A07DE95A000C7627D0 /* KeyboardPrefsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPrefsTests.swift; sourceTree = "<group>"; };
 		3CE214E0B998D01BC698998B /* KeyboardMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardMetricsTests.swift; sourceTree = "<group>"; };
 		524D3943A19BA98402D9549F /* SlashScreenshotRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlashScreenshotRenderTests.swift; sourceTree = "<group>"; };
+		54003BE0AD4A0942B2C7D0F1 /* ExtraRowPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraRowPresetTests.swift; sourceTree = "<group>"; };
 		62CD2B5A99C09A3BD18B1B2C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		64762D93ADF3F2AB82F1A548 /* TerminalInputMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalInputMappingTests.swift; sourceTree = "<group>"; };
 		665662BFA6DECCD61154BEE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 				DE81ADA79A468E5CF872E5B1 /* ANSISequenceTests.swift */,
 				38264316C6A0140F8FEB1667 /* ClipboardHistoryTests.swift */,
 				D02EAAA4D51DA2E825C9B5BA /* CtrlStateTests.swift */,
+				54003BE0AD4A0942B2C7D0F1 /* ExtraRowPresetTests.swift */,
 				9B940C548C192782A1073E16 /* HostConfigTests.swift */,
 				2D7B5B0254BBE72FA1A9ADA0 /* KeyboardInsertPathTests.swift */,
 				98604D5BA08246970836FD92 /* KeyboardLayersTests.swift */,
@@ -494,6 +497,7 @@
 				68B2C30E8CD52FC6DE13253C /* AltKeyMappingsTests.swift in Sources */,
 				3E7E682B7731F46E6D232280 /* ClipboardHistoryTests.swift in Sources */,
 				5D3FA20C7AADA0E3754284D5 /* CtrlStateTests.swift in Sources */,
+				CCDB3D09BF10D8B0C6C4B9BD /* ExtraRowPresetTests.swift in Sources */,
 				C2CB34B81FFC8B56D356D8AF /* HostConfigTests.swift in Sources */,
 				DF7E0C0E55646C2A8443B118 /* KeyboardInsertPathTests.swift in Sources */,
 				EAD2BFA42A42418E10696035 /* KeyboardLayersTests.swift in Sources */,

--- a/ios/KeyJawn/Settings/SettingsView.swift
+++ b/ios/KeyJawn/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @State private var theme = KeyboardPrefs.shared.theme
     @State private var hapticsEnabled = KeyboardPrefs.shared.hapticsEnabled
     @State private var terminalArrowKeys = KeyboardPrefs.shared.terminalArrowKeys
+    @State private var extraRowPreset = KeyboardPrefs.shared.extraRowPreset
 
     var body: some View {
         NavigationStack {
@@ -47,6 +48,14 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    Picker("Preset", selection: $extraRowPreset) {
+                        ForEach(ExtraRowPreset.allCases, id: \.self) { option in
+                            Text(option.displayName).tag(option)
+                        }
+                    }
+                    .onChange(of: extraRowPreset) { _, newValue in
+                        KeyboardPrefs.shared.extraRowPreset = newValue
+                    }
                     Toggle("Terminal arrow keys", isOn: $terminalArrowKeys)
                         .onChange(of: terminalArrowKeys) { _, newValue in
                             KeyboardPrefs.shared.terminalArrowKeys = newValue
@@ -54,7 +63,9 @@ struct SettingsView: View {
                 } header: {
                     Text("Extra row")
                 } footer: {
-                    Text(terminalArrowKeys
+                    Text(extraRowPreset == .confirm
+                         ? "Confirm types y, n, a, 1, 2, 3 and can submit. Agent is the default ten-key row."
+                         : terminalArrowKeys
                          ? "Arrows send escape codes, so up and down reach shell history in a terminal app."
                          : "Left and right move the text cursor. Up and down have no effect with this off.")
                         .font(.caption)

--- a/ios/KeyJawn/Settings/SettingsView.swift
+++ b/ios/KeyJawn/Settings/SettingsView.swift
@@ -13,6 +13,10 @@ struct SettingsView: View {
     @State private var hapticsEnabled = KeyboardPrefs.shared.hapticsEnabled
     @State private var terminalArrowKeys = KeyboardPrefs.shared.terminalArrowKeys
     @State private var extraRowPreset = KeyboardPrefs.shared.extraRowPreset
+    @State private var customTrigger = ""
+    @State private var customDescription = ""
+    @State private var customError = ""
+    @State private var customCommands = SlashCommandStore.load(from: SlashCommandStore.appGroupDefaults())
 
     var body: some View {
         NavigationStack {
@@ -84,6 +88,52 @@ struct SettingsView: View {
                     Text("Appearance")
                 } footer: {
                     Text("Applies to the KeyJawn keyboard. The keyboard needs Full Access to read this setting: Settings → General → Keyboard → Keyboards → KeyJawn.")
+                        .font(.caption)
+                }
+
+                Section {
+                    ForEach(customCommands, id: \.id) { record in
+                        HStack {
+                            Text(record.trigger)
+                                .font(.body.monospaced())
+                            Spacer()
+                            Button("Delete") {
+                                SlashCommandStore.remove(id: record.id, from: SlashCommandStore.appGroupDefaults())
+                                customCommands = SlashCommandStore.load(from: SlashCommandStore.appGroupDefaults())
+                            }
+                            .foregroundStyle(.red)
+                        }
+                    }
+                    TextField("Trigger", text: $customTrigger)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Description", text: $customDescription)
+                    Button("Add shortcut") {
+                        switch SlashCommandStore.add(
+                            trigger: customTrigger,
+                            description: customDescription,
+                            to: SlashCommandStore.appGroupDefaults()
+                        ) {
+                        case .success:
+                            customTrigger = ""
+                            customDescription = ""
+                            customError = ""
+                            customCommands = SlashCommandStore.load(from: SlashCommandStore.appGroupDefaults())
+                        case .failure(.duplicateTrigger):
+                            customError = "That shortcut already exists"
+                        case .failure(.invalidTrigger):
+                            customError = "Use a short /name with no spaces"
+                        }
+                    }
+                    if !customError.isEmpty {
+                        Text(customError)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                } header: {
+                    Text("Custom shortcuts")
+                } footer: {
+                    Text("Shown in the slash panel. Inserts the trigger as plain text. Full Access is required for the keyboard extension to see them.")
                         .font(.caption)
                 }
 

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -23,6 +23,8 @@ final class TerminalInputView: UITextView {
     private var slashPanel: SlashCommandPanel?
     private var clipboardPanel: ClipboardPanel?
     private var uploadPanel: UploadPanel?
+    private let voice = TerminalVoiceInput()
+    private var lastHardwareEmit: (bytes: [UInt8], at: CFTimeInterval)?
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
@@ -55,6 +57,12 @@ final class TerminalInputView: UITextView {
         extraRow.applyTheme(KeyboardPrefs.shared.theme)
         KeyboardHaptics.refresh()
         inputAccessoryView = extraRow
+        voice.onCommit = { [weak self] text in
+            self?.onRawInput?(Array(text.utf8))
+        }
+        voice.onListeningChange = { [weak self] listening in
+            self?.extraRow.setMicListening(listening)
+        }
     }
 
     /// Re-read the App Group preset. The accessory lives across tab switches.
@@ -106,6 +114,85 @@ final class TerminalInputView: UITextView {
     func submitLine() {
         onRawInput?(TerminalInputMapping.submitBytes)
     }
+
+    // MARK: Hardware keyboard
+
+    override var keyCommands: [UIKeyCommand]? {
+        [
+            UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(hardwareEscape)),
+            UIKeyCommand(input: "\t", modifierFlags: [], action: #selector(hardwareTab)),
+            UIKeyCommand(input: UIKeyCommand.inputUpArrow, modifierFlags: [], action: #selector(hardwareUp)),
+            UIKeyCommand(input: UIKeyCommand.inputDownArrow, modifierFlags: [], action: #selector(hardwareDown)),
+            UIKeyCommand(input: UIKeyCommand.inputLeftArrow, modifierFlags: [], action: #selector(hardwareLeft)),
+            UIKeyCommand(input: UIKeyCommand.inputRightArrow, modifierFlags: [], action: #selector(hardwareRight)),
+            UIKeyCommand(input: "c", modifierFlags: .control, action: #selector(hardwareCtrlC)),
+            UIKeyCommand(input: "d", modifierFlags: .control, action: #selector(hardwareCtrlD)),
+            UIKeyCommand(input: "z", modifierFlags: .control, action: #selector(hardwareCtrlZ)),
+        ]
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+        var handled = false
+        for press in presses {
+            guard let key = press.key,
+                  let mapped = hardwareKey(from: key) else { continue }
+            let modifiers = hardwareModifiers(from: key)
+            if emitHardware(mapped, modifiers: modifiers) {
+                handled = true
+            }
+        }
+        if !handled {
+            super.pressesBegan(presses, with: event)
+        }
+    }
+
+    @discardableResult
+    private func emitHardware(_ key: HardwareKey, modifiers: HardwareModifiers) -> Bool {
+        guard let bytes = HardwareKeyMapping.bytes(for: key, modifiers: modifiers) else {
+            return false
+        }
+        let now = CACurrentMediaTime()
+        if let last = lastHardwareEmit, last.bytes == bytes, now - last.at < 0.03 {
+            return true
+        }
+        lastHardwareEmit = (bytes, now)
+        onRawInput?(bytes)
+        return true
+    }
+
+    private func hardwareKey(from key: UIKey) -> HardwareKey? {
+        switch key.keyCode {
+        case .keyboardEscape: return .escape
+        case .keyboardTab: return .tab
+        case .keyboardUpArrow: return .arrowUp
+        case .keyboardDownArrow: return .arrowDown
+        case .keyboardLeftArrow: return .arrowLeft
+        case .keyboardRightArrow: return .arrowRight
+        default:
+            let chars = key.charactersIgnoringModifiers
+            guard chars.count == 1 else { return nil }
+            return .character(chars)
+        }
+    }
+
+    private func hardwareModifiers(from key: UIKey) -> HardwareModifiers {
+        var mods = HardwareModifiers()
+        if key.modifierFlags.contains(.control) { mods.insert(.control) }
+        if key.modifierFlags.contains(.command) { mods.insert(.command) }
+        if key.modifierFlags.contains(.alternate) { mods.insert(.alternate) }
+        if key.modifierFlags.contains(.shift) { mods.insert(.shift) }
+        return mods
+    }
+
+    @objc private func hardwareEscape() { emitHardware(.escape, modifiers: []) }
+    @objc private func hardwareTab() { emitHardware(.tab, modifiers: []) }
+    @objc private func hardwareUp() { emitHardware(.arrowUp, modifiers: []) }
+    @objc private func hardwareDown() { emitHardware(.arrowDown, modifiers: []) }
+    @objc private func hardwareLeft() { emitHardware(.arrowLeft, modifiers: []) }
+    @objc private func hardwareRight() { emitHardware(.arrowRight, modifiers: []) }
+    @objc private func hardwareCtrlC() { emitHardware(.character("c"), modifiers: .control) }
+    @objc private func hardwareCtrlD() { emitHardware(.character("d"), modifiers: .control) }
+    @objc private func hardwareCtrlZ() { emitHardware(.character("z"), modifiers: .control) }
 }
 
 extension TerminalInputView: ExtraRowDelegate {
@@ -135,6 +222,14 @@ extension TerminalInputView: ExtraRowDelegate {
             showUploadPanel()
         }
     }
+
+    func extraRowDidTapMic(_ view: ExtraRowView) {
+        voice.toggle()
+    }
+
+    func extraRowDidCancelMic(_ view: ExtraRowView) {
+        voice.cancel()
+    }
 }
 
 // MARK: - Overlays
@@ -163,7 +258,11 @@ extension TerminalInputView {
         hideClipboardPanel()
         hideUploadPanel()
 
-        let panel = SlashCommandPanel(theme: KeyboardPrefs.shared.theme)
+        let customs = SlashCommandStore.commands(from: SlashCommandStore.appGroupDefaults())
+        let panel = SlashCommandPanel(
+            commands: SlashCommand.all + customs,
+            theme: KeyboardPrefs.shared.theme
+        )
         panel.onSelect = { [weak self] command in
             self?.onRawInput?(Array(command.trigger.utf8))
             self?.hideSlashPanel()

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -71,6 +71,10 @@ final class TerminalInputView: UITextView {
         extraRow.applyTheme(KeyboardPrefs.shared.theme)
     }
 
+    func cancelVoice() {
+        voice.cancel()
+    }
+
     // MARK: UIKeyInput — intercept before text hits the text view
 
     override func insertText(_ text: String) {

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -48,13 +48,19 @@ final class TerminalInputView: UITextView {
         smartInsertDeleteType    = .no
 
         extraRow.frame     = CGRect(x: 0, y: 0, width: 0, height: 52)
-        extraRow.setKeys(ExtraRowKey.terminalKeys)
+        extraRow.setKeys(KeyboardPrefs.shared.extraRowPreset.terminalKeys)
         extraRow.delegate  = self
         // Same theme the keyboard extension uses, so the row looks like one component
         // wherever it appears rather than defaulting to dark here and themed there.
         extraRow.applyTheme(KeyboardPrefs.shared.theme)
         KeyboardHaptics.refresh()
         inputAccessoryView = extraRow
+    }
+
+    /// Re-read the App Group preset. The accessory lives across tab switches.
+    func applyExtraRowPreset() {
+        extraRow.setKeys(KeyboardPrefs.shared.extraRowPreset.terminalKeys)
+        extraRow.applyTheme(KeyboardPrefs.shared.theme)
     }
 
     // MARK: UIKeyInput — intercept before text hits the text view

--- a/ios/KeyJawn/Terminal/TerminalInputView.swift
+++ b/ios/KeyJawn/Terminal/TerminalInputView.swift
@@ -48,6 +48,7 @@ final class TerminalInputView: UITextView {
         smartInsertDeleteType    = .no
 
         extraRow.frame     = CGRect(x: 0, y: 0, width: 0, height: 52)
+        extraRow.setKeys(ExtraRowKey.terminalKeys)
         extraRow.delegate  = self
         // Same theme the keyboard extension uses, so the row looks like one component
         // wherever it appears rather than defaulting to dark here and themed there.

--- a/ios/KeyJawn/Terminal/TerminalViewController.swift
+++ b/ios/KeyJawn/Terminal/TerminalViewController.swift
@@ -56,6 +56,7 @@ final class TerminalViewController: UIViewController {
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        inputSink.cancelVoice()
         // Tear the SSH session down only when the terminal is actually going away
         // (a navigation pop or a modal dismissal), not when it is merely hidden.
         // HostTerminalView is a pushed destination inside the Hosts tab of a

--- a/ios/KeyJawn/Terminal/TerminalViewController.swift
+++ b/ios/KeyJawn/Terminal/TerminalViewController.swift
@@ -49,6 +49,11 @@ final class TerminalViewController: UIViewController {
         wireSession()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        inputSink.applyExtraRowPreset()
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         // Tear the SSH session down only when the terminal is actually going away

--- a/ios/KeyJawn/Terminal/TerminalVoiceInput.swift
+++ b/ios/KeyJawn/Terminal/TerminalVoiceInput.swift
@@ -15,19 +15,21 @@ final class TerminalVoiceInput {
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
     private let engine = AVAudioEngine()
+    private var generation = 0
+    private var awaitingFinal = false
 
     var isListening: Bool { session.isListening }
 
     func toggle() {
         if session.isListening {
-            finish(commit: true)
+            stopListening(commit: true)
         } else {
             start()
         }
     }
 
     func cancel() {
-        finish(commit: false)
+        stopListening(commit: false)
     }
 
     private func start() {
@@ -52,10 +54,19 @@ final class TerminalVoiceInput {
     }
 
     private func beginRecording() {
-        finish(commit: false)
+        stopListening(commit: false)
         recognizer = SFSpeechRecognizer()
         guard let recognizer, recognizer.isAvailable else {
             onError?("Speech recognition is not available")
+            return
+        }
+
+        do {
+            let audio = AVAudioSession.sharedInstance()
+            try audio.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try audio.setActive(true)
+        } catch {
+            onError?("Could not start the microphone")
             return
         }
 
@@ -63,19 +74,22 @@ final class TerminalVoiceInput {
         request.shouldReportPartialResults = true
         self.request = request
 
+        generation += 1
+        let started = generation
         session.start()
+        awaitingFinal = false
         onListeningChange?(true)
 
         task = recognizer.recognitionTask(with: request) { [weak self] result, error in
             Task { @MainActor in
-                guard let self else { return }
+                guard let self, self.generation == started else { return }
                 if let result {
                     self.session.updatePartial(result.bestTranscription.formattedString)
                     if result.isFinal {
-                        self.finish(commit: true)
+                        self.emitCommit()
                     }
-                } else if error != nil, self.session.isListening {
-                    self.finish(commit: true)
+                } else if error != nil, self.awaitingFinal {
+                    self.emitCommit()
                 }
             }
         }
@@ -91,22 +105,39 @@ final class TerminalVoiceInput {
             try engine.start()
         } catch {
             onError?("Could not start the microphone")
-            finish(commit: false)
+            stopListening(commit: false)
         }
     }
 
-    private func finish(commit: Bool) {
-        engine.stop()
+    private func stopListening(commit: Bool) {
+        if engine.isRunning {
+            engine.stop()
+        }
         engine.inputNode.removeTap(onBus: 0)
         request?.endAudio()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+
+        if commit, session.isListening {
+            awaitingFinal = true
+            onListeningChange?(false)
+            return
+        }
+
+        generation += 1
+        awaitingFinal = false
         task?.cancel()
         task = nil
         request = nil
+        session.cancel()
+        onListeningChange?(false)
+    }
 
-        if commit, let text = session.commit() {
+    private func emitCommit() {
+        awaitingFinal = false
+        task = nil
+        request = nil
+        if let text = session.commit() {
             onCommit?(text)
-        } else {
-            session.cancel()
         }
         onListeningChange?(false)
     }

--- a/ios/KeyJawn/Terminal/TerminalVoiceInput.swift
+++ b/ios/KeyJawn/Terminal/TerminalVoiceInput.swift
@@ -1,0 +1,113 @@
+import AVFoundation
+import Foundation
+import Speech
+import KeyJawnKit
+
+/// Main-app speech recognizer. The keyboard extension must not instantiate this.
+@MainActor
+final class TerminalVoiceInput {
+    var onCommit: ((String) -> Void)?
+    var onError: ((String) -> Void)?
+    var onListeningChange: ((Bool) -> Void)?
+
+    private var session = VoiceSession()
+    private var recognizer: SFSpeechRecognizer?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+    private let engine = AVAudioEngine()
+
+    var isListening: Bool { session.isListening }
+
+    func toggle() {
+        if session.isListening {
+            finish(commit: true)
+        } else {
+            start()
+        }
+    }
+
+    func cancel() {
+        finish(commit: false)
+    }
+
+    private func start() {
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            Task { @MainActor in
+                guard let self else { return }
+                guard status == .authorized else {
+                    self.onError?("Speech recognition is not allowed")
+                    return
+                }
+                AVAudioApplication.requestRecordPermission { granted in
+                    Task { @MainActor in
+                        guard granted else {
+                            self.onError?("Microphone is not allowed")
+                            return
+                        }
+                        self.beginRecording()
+                    }
+                }
+            }
+        }
+    }
+
+    private func beginRecording() {
+        finish(commit: false)
+        recognizer = SFSpeechRecognizer()
+        guard let recognizer, recognizer.isAvailable else {
+            onError?("Speech recognition is not available")
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        self.request = request
+
+        session.start()
+        onListeningChange?(true)
+
+        task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            Task { @MainActor in
+                guard let self else { return }
+                if let result {
+                    self.session.updatePartial(result.bestTranscription.formattedString)
+                    if result.isFinal {
+                        self.finish(commit: true)
+                    }
+                } else if error != nil, self.session.isListening {
+                    self.finish(commit: true)
+                }
+            }
+        }
+
+        let input = engine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        input.removeTap(onBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+        }
+        engine.prepare()
+        do {
+            try engine.start()
+        } catch {
+            onError?("Could not start the microphone")
+            finish(commit: false)
+        }
+    }
+
+    private func finish(commit: Bool) {
+        engine.stop()
+        engine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        task?.cancel()
+        task = nil
+        request = nil
+
+        if commit, let text = session.commit() {
+            onCommit?(text)
+        } else {
+            session.cancel()
+        }
+        onListeningChange?(false)
+    }
+}

--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -43,6 +43,8 @@ public final class KeyboardViewController: UIInputViewController {
             applyTheme()
         }
         KeyboardHaptics.refresh()
+        extraRow.setKeys(KeyboardPrefs.shared.extraRowPreset.keys)
+        extraRow.applyTheme(theme)
     }
 
     public override func viewWillLayoutSubviews() {

--- a/ios/KeyJawnKeyboard/KeyboardViewController.swift
+++ b/ios/KeyJawnKeyboard/KeyboardViewController.swift
@@ -198,12 +198,19 @@ extension KeyboardViewController: ExtraRowDelegate {
         }
     }
 
+    public func extraRowDidTapMic(_ view: ExtraRowView) {
+        // The extension cannot use the microphone. Mic is not on this row.
+    }
+
+    public func extraRowDidCancelMic(_ view: ExtraRowView) {}
+
     // MARK: - Slash command panel
 
     private func showSlashPanel() {
         guard slashPanel == nil else { return }
 
-        let panel = SlashCommandPanel(theme: theme)
+        let customs = SlashCommandStore.commands(from: SlashCommandStore.appGroupDefaults())
+        let panel = SlashCommandPanel(commands: SlashCommand.all + customs, theme: theme)
         panel.onSelect = { [weak self] command in
             self?.textDocumentProxy.insertText(command.trigger)
             self?.hideSlashPanel()

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ExtraRowPreset.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ExtraRowPreset.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Named extra-row layouts stored in the App Group suite.
+///
+/// Agent is today's default ten-key row. Confirm is the one-tap answer row
+/// for agent prompts (y/n/a/1/2/3 plus submit and Esc). Per-slot remapping
+/// is a later issue.
+public enum ExtraRowPreset: String, Sendable, CaseIterable, Equatable {
+    case agent
+    case confirm
+
+    public var displayName: String {
+        switch self {
+        case .agent: return "Agent"
+        case .confirm: return "Confirm"
+        }
+    }
+
+    /// Keys this preset shows. Agent round-trips to `ExtraRowKey.defaults`.
+    public var keys: [ExtraRowKey] {
+        switch self {
+        case .agent:
+            return ExtraRowKey.defaults
+        case .confirm:
+            return [
+                ExtraRowKey(slot: .letterY, label: "y", output: .character("y")),
+                ExtraRowKey(slot: .letterN, label: "n", output: .character("n")),
+                ExtraRowKey(slot: .letterA, label: "a", output: .character("a")),
+                ExtraRowKey(slot: .digit1, label: "1", output: .character("1")),
+                ExtraRowKey(slot: .digit2, label: "2", output: .character("2")),
+                ExtraRowKey(slot: .digit3, label: "3", output: .character("3")),
+                ExtraRowKey(slot: .send, label: "Send", output: .send),
+                ExtraRowKey(slot: .escape, label: "Esc", output: .escape),
+                ExtraRowKey(slot: .ctrlC, label: "^C", output: .ctrlC),
+            ]
+        }
+    }
+
+    /// Terminal accessory keeps Send on Agent so a connected session can still
+    /// submit without hunting the system Return. The encoded preset is still
+    /// `agent` and `keys` stays `ExtraRowKey.defaults`.
+    public var terminalKeys: [ExtraRowKey] {
+        switch self {
+        case .agent:
+            return ExtraRowKey.terminalKeys
+        case .confirm:
+            return keys
+        }
+    }
+
+    public var encoded: String { rawValue }
+
+    public static func decode(_ raw: String?) -> ExtraRowPreset {
+        raw.flatMap(ExtraRowPreset.init(rawValue:)) ?? .agent
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ExtraRowPreset.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/ExtraRowPreset.swift
@@ -44,7 +44,7 @@ public enum ExtraRowPreset: String, Sendable, CaseIterable, Equatable {
         case .agent:
             return ExtraRowKey.terminalKeys
         case .confirm:
-            return keys
+            return keys + [ExtraRowKey.micKey]
         }
     }
 

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/HardwareKeyMapping.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/HardwareKeyMapping.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Hardware keys the SSH sink can turn into PTY bytes.
+public enum HardwareKey: Sendable, Equatable {
+    case escape
+    case tab
+    case arrowUp
+    case arrowDown
+    case arrowLeft
+    case arrowRight
+    case character(String)
+}
+
+/// Modifier bits the mapping understands. Command is tracked so Cmd+C is
+/// never turned into `0x03`.
+public struct HardwareModifiers: OptionSet, Sendable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+
+    public static let control = HardwareModifiers(rawValue: 1 << 0)
+    public static let command = HardwareModifiers(rawValue: 1 << 1)
+    public static let alternate = HardwareModifiers(rawValue: 1 << 2)
+    public static let shift = HardwareModifiers(rawValue: 1 << 3)
+}
+
+/// Press → byte table used by `TerminalInputView.pressesBegan` and
+/// `UIKeyCommand`. Tests drive this type so Cmd+C cannot silently become
+/// interrupt.
+public enum HardwareKeyMapping {
+    public static func bytes(for key: HardwareKey, modifiers: HardwareModifiers) -> [UInt8]? {
+        // Cmd+C / Cmd+V / Cmd+W stay system. Never emit a control byte.
+        if modifiers.contains(.command) { return nil }
+
+        switch key {
+        case .escape:
+            return [0x1b]
+        case .tab:
+            return [0x09]
+        case .arrowUp:
+            return ANSISequence.bytes(for: .arrowUp, ctrlActive: modifiers.contains(.control))
+        case .arrowDown:
+            return ANSISequence.bytes(for: .arrowDown, ctrlActive: modifiers.contains(.control))
+        case .arrowLeft:
+            return ANSISequence.bytes(for: .arrowLeft, ctrlActive: modifiers.contains(.control))
+        case .arrowRight:
+            return ANSISequence.bytes(for: .arrowRight, ctrlActive: modifiers.contains(.control))
+        case .character(let s):
+            guard modifiers.contains(.control) else { return nil }
+            return ANSISequence.bytes(for: .character(s), ctrlActive: true)
+        }
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardDocumentInsert.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardDocumentInsert.swift
@@ -42,7 +42,9 @@ public enum KeyboardDocumentInsert: Equatable, Sendable {
             return .insert(s)
         case .backspace:
             return .deleteBackward
-        case .return:
+        case .return, .send, .newline:
+            // The IME cannot submit to a remote PTY. All three are an honest
+            // newline. The SSH sink maps `.send` to CR and `.newline` to LF.
             return .insert("\n")
         case .space:
             return .insert(" ")

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
@@ -61,6 +61,7 @@ public enum ExtraRowSlot: Int, CaseIterable, Sendable {
     case digit1
     case digit2
     case digit3
+    case mic
 }
 
 public struct ExtraRowKey: Sendable {
@@ -92,6 +93,7 @@ public struct ExtraRowKey: Sendable {
         case .digit1:     return "1"
         case .digit2:     return "2"
         case .digit3:     return "3"
+        case .mic:        return "Microphone"
         }
     }
 
@@ -115,8 +117,11 @@ public struct ExtraRowKey: Sendable {
     /// Terminal accessory: the default ten keys plus Send. The extension keeps
     /// `defaults` until remappable presets can place Send without crowding
     /// the phone IME row.
+    public static let micKey = ExtraRowKey(slot: .mic, label: "Mic", output: nil)
+
     public static let terminalKeys: [ExtraRowKey] = defaults + [
         ExtraRowKey(slot: .send, label: "Send", output: .send),
+        micKey,
     ]
 
     public init(slot: ExtraRowSlot, label: String, output: KeyOutput?) {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
@@ -55,6 +55,12 @@ public enum ExtraRowSlot: Int, CaseIterable, Sendable {
     case clipboard
     case upload
     case send
+    case letterY
+    case letterN
+    case letterA
+    case digit1
+    case digit2
+    case digit3
 }
 
 public struct ExtraRowKey: Sendable {
@@ -80,6 +86,12 @@ public struct ExtraRowKey: Sendable {
         case .clipboard:  return "Clipboard history"
         case .upload:     return "Upload image over SFTP"
         case .send:       return "Send"
+        case .letterY:    return "y"
+        case .letterN:    return "n"
+        case .letterA:    return "a"
+        case .digit1:     return "1"
+        case .digit2:     return "2"
+        case .digit3:     return "3"
         }
     }
 

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardLayout.swift
@@ -16,6 +16,8 @@ public enum KeyOutput: Sendable, Equatable {
     case backspace
     case `return`
     case space
+    case send                   // submit in the SSH app; honest newline in the IME
+    case newline                // non-submit line break
 }
 
 // MARK: - Key definition
@@ -52,6 +54,7 @@ public enum ExtraRowSlot: Int, CaseIterable, Sendable {
     case escape
     case clipboard
     case upload
+    case send
 }
 
 public struct ExtraRowKey: Sendable {
@@ -76,6 +79,7 @@ public struct ExtraRowKey: Sendable {
         case .escape:     return "Escape"
         case .clipboard:  return "Clipboard history"
         case .upload:     return "Upload image over SFTP"
+        case .send:       return "Send"
         }
     }
 
@@ -94,6 +98,13 @@ public struct ExtraRowKey: Sendable {
         ExtraRowKey(slot: .escape,     label: "Esc", output: .escape),
         ExtraRowKey(slot: .clipboard,  label: "Clip",output: nil),
         ExtraRowKey(slot: .upload,     label: "SCP", output: nil),
+    ]
+
+    /// Terminal accessory: the default ten keys plus Send. The extension keeps
+    /// `defaults` until remappable presets can place Send without crowding
+    /// the phone IME row.
+    public static let terminalKeys: [ExtraRowKey] = defaults + [
+        ExtraRowKey(slot: .send, label: "Send", output: .send),
     ]
 
     public init(slot: ExtraRowSlot, label: String, output: KeyOutput?) {
@@ -124,6 +135,8 @@ public enum ANSISequence {
                                                       : [0x1b,0x5b,0x44]
         case .backspace:            return [0x7f]
         case .return:               return [0x0d]
+        case .send:                 return [0x0d]
+        case .newline:              return [0x0a]
         case .space:                return [0x20]
         case .character(let s):
             guard let scalar = s.unicodeScalars.first else { return nil }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/KeyboardPrefs.swift
@@ -24,6 +24,7 @@ public final class KeyboardPrefs: @unchecked Sendable {
         static let terminalArrows = "keyjawn.terminalArrows"
         static let migrated = "keyjawn.prefs.migrated.v2"
         static let onboardingCompleted = "keyjawn.onboarding.completed"
+        static let extraRowPreset = "keyjawn.extraRowPreset"
     }
 
     /// Storage supplied by a test. When nil the suite is looked up per access below.
@@ -107,6 +108,13 @@ public final class KeyboardPrefs: @unchecked Sendable {
     public var hasCompletedOnboarding: Bool {
         get { bool(Key.onboardingCompleted, default: false) }
         set { defaults.set(newValue, forKey: Key.onboardingCompleted) }
+    }
+
+    /// Which extra-row preset both the SSH accessory and the extension show.
+    /// Unset is Agent, matching today's default ten-key row.
+    public var extraRowPreset: ExtraRowPreset {
+        get { ExtraRowPreset.decode(defaults.string(forKey: Key.extraRowPreset)) }
+        set { defaults.set(newValue.rawValue, forKey: Key.extraRowPreset) }
     }
 
     // MARK: - Helpers

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/SlashCommandStore.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/SlashCommandStore.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public enum SlashCommandStoreError: Error, Equatable {
+    case invalidTrigger
+    case duplicateTrigger
+}
+
+/// Custom slash shortcuts in the App Group. Triggers are user strings only.
+public struct SlashCommandStore: Sendable {
+    public static let defaultsKey = "keyjawn.customSlashCommands"
+
+    public struct Record: Codable, Sendable, Equatable {
+        public var id: String
+        public var trigger: String
+        public var description: String
+
+        public init(id: String, trigger: String, description: String) {
+            self.id = id
+            self.trigger = trigger
+            self.description = description
+        }
+
+        public var command: SlashCommand {
+            SlashCommand(id: id, trigger: trigger, description: description, category: .custom)
+        }
+    }
+
+    public static func load(from defaults: UserDefaults) -> [Record] {
+        guard let data = defaults.data(forKey: defaultsKey),
+              let records = try? JSONDecoder().decode([Record].self, from: data) else {
+            return []
+        }
+        return records
+    }
+
+    public static func commands(from defaults: UserDefaults) -> [SlashCommand] {
+        load(from: defaults).map(\.command)
+    }
+
+    public static func save(_ records: [Record], to defaults: UserDefaults) {
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        defaults.set(data, forKey: defaultsKey)
+    }
+
+    public static func validateTrigger(
+        _ raw: String,
+        builtIns: [SlashCommand] = SlashCommand.all,
+        existing: [Record]
+    ) -> Result<String, SlashCommandStoreError> {
+        var trigger = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trigger.hasPrefix("/") {
+            trigger = "/" + trigger
+        }
+        guard trigger.count > 1,
+              !trigger.contains(" "),
+              trigger.unicodeScalars.allSatisfy({ CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "/-_")).contains($0) })
+        else {
+            return .failure(.invalidTrigger)
+        }
+        let used = Set(builtIns.map(\.trigger) + existing.map(\.trigger))
+        if used.contains(trigger) {
+            return .failure(.duplicateTrigger)
+        }
+        return .success(trigger)
+    }
+
+    public static func add(
+        trigger: String,
+        description: String,
+        to defaults: UserDefaults,
+        builtIns: [SlashCommand] = SlashCommand.all
+    ) -> Result<Record, SlashCommandStoreError> {
+        var records = load(from: defaults)
+        switch validateTrigger(trigger, builtIns: builtIns, existing: records) {
+        case .failure(let error):
+            return .failure(error)
+        case .success(let normalized):
+            let record = Record(
+                id: UUID().uuidString,
+                trigger: normalized,
+                description: description.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            records.append(record)
+            save(records, to: defaults)
+            return .success(record)
+        }
+    }
+
+    public static func remove(id: String, from defaults: UserDefaults) {
+        var records = load(from: defaults)
+        records.removeAll { $0.id == id }
+        save(records, to: defaults)
+    }
+
+    public static func appGroupDefaults() -> UserDefaults {
+        UserDefaults(suiteName: AppGroupConfig.suiteName) ?? .standard
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/TerminalInputMapping.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/TerminalInputMapping.swift
@@ -33,6 +33,8 @@ public enum TerminalInputMapping: Sendable {
     /// delegate methods because they are not `KeyOutput`s.
     public static func extraRow(_ output: KeyOutput, ctrlActive: Bool) -> ExtraRowAction {
         if output == .slash { return .openSlash }
+        if output == .send { return .write(submitBytes) }
+        if output == .newline { return .write(newlineBytes) }
         if let bytes = ANSISequence.bytes(for: output, ctrlActive: ctrlActive) {
             return .write(bytes)
         }

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Models/VoiceSession.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Models/VoiceSession.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Commit/cancel machine for in-app speech. The recognizer lives in the main
+/// app; this type is what tests drive so cancel cannot accidentally insert.
+public struct VoiceSession: Sendable, Equatable {
+    public private(set) var isListening = false
+    public private(set) var transcript = ""
+
+    public init() {}
+
+    public mutating func start() {
+        isListening = true
+        transcript = ""
+    }
+
+    public mutating func updatePartial(_ text: String) {
+        guard isListening else { return }
+        transcript = text
+    }
+
+    /// Final text to write to the PTY, or `nil` when there is nothing to send.
+    public mutating func commit() -> String? {
+        guard isListening else { return nil }
+        isListening = false
+        let text = transcript
+        transcript = ""
+        return text.isEmpty ? nil : text
+    }
+
+    /// Stop without returning text.
+    public mutating func cancel() {
+        isListening = false
+        transcript = ""
+    }
+}

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
@@ -242,6 +242,7 @@ public final class ExtraRowView: UIView {
     @objc private func sendTapped() {
         KeyboardHaptics.keyPress()
         fire(.send, ctrlActive: false)
+        ctrl.consume()
     }
 
     @objc private func sendLongPressed(_ gr: UILongPressGestureRecognizer) {

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
@@ -81,16 +81,28 @@ public final class ExtraRowView: UIView {
             stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6),
         ])
 
-        for key in ExtraRowKey.defaults {
+        setKeys(ExtraRowKey.defaults)
+
+        ctrl.onChange = { [weak self] state in
+            self?.applyCtrlVisual(state)
+        }
+    }
+
+    /// Replace the row's keys. Used by the SSH accessory to add Send and by
+    /// remappable presets later. Rebuilds buttons; Ctrl visual state is reapplied.
+    public func setKeys(_ keys: [ExtraRowKey]) {
+        stack.arrangedSubviews.forEach {
+            stack.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        ctrlCButton = nil
+        for key in keys {
             let btn = ExtraRowButton(key: key, bgColor: keyBg, textColor: theme.extraRowKeyText)
             wire(btn)
             stack.addArrangedSubview(btn)
             if key.slot == .ctrlC { ctrlCButton = btn }
         }
-
-        ctrl.onChange = { [weak self] state in
-            self?.applyCtrlVisual(state)
-        }
+        applyCtrlVisual(ctrl.state)
     }
 
     /// Stop auto-repeat when the row leaves the hierarchy.
@@ -129,6 +141,12 @@ public final class ExtraRowView: UIView {
 
         case .upload:
             btn.addTarget(self, action: #selector(uploadTapped), for: .touchUpInside)
+
+        case .send:
+            btn.addTarget(self, action: #selector(sendTapped), for: .touchUpInside)
+            let lp = UILongPressGestureRecognizer(target: self, action: #selector(sendLongPressed(_:)))
+            lp.minimumPressDuration = 0.45
+            btn.addGestureRecognizer(lp)
 
         default:
             // Tab, slash, escape: single tap
@@ -192,6 +210,17 @@ public final class ExtraRowView: UIView {
     @objc private func uploadTapped() {
         KeyboardHaptics.keyPress()
         delegate?.extraRowDidTapUpload(self)
+    }
+
+    @objc private func sendTapped() {
+        KeyboardHaptics.keyPress()
+        fire(.send, ctrlActive: false)
+    }
+
+    @objc private func sendLongPressed(_ gr: UILongPressGestureRecognizer) {
+        guard gr.state == .began else { return }
+        KeyboardHaptics.keyPress()
+        fire(.newline, ctrlActive: false)
     }
 
     // MARK: - Helpers

--- a/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
+++ b/ios/KeyJawnKit/Sources/KeyJawnKit/Views/ExtraRowView.swift
@@ -11,6 +11,8 @@ public protocol ExtraRowDelegate: AnyObject {
     func extraRow(_ view: ExtraRowView, send output: KeyOutput, ctrlActive: Bool)
     func extraRowDidTapClipboard(_ view: ExtraRowView)
     func extraRowDidTapUpload(_ view: ExtraRowView)
+    func extraRowDidTapMic(_ view: ExtraRowView)
+    func extraRowDidCancelMic(_ view: ExtraRowView)
 }
 
 // MARK: - ExtraRowView
@@ -34,6 +36,7 @@ public final class ExtraRowView: UIView {
 
     private let stack = UIStackView()
     private var ctrlCButton: ExtraRowButton?
+    private var micButton: ExtraRowButton?
     private var repeatTimer: Timer?
 
     // MARK: - Theme
@@ -96,13 +99,20 @@ public final class ExtraRowView: UIView {
             $0.removeFromSuperview()
         }
         ctrlCButton = nil
+        micButton = nil
         for key in keys {
             let btn = ExtraRowButton(key: key, bgColor: keyBg, textColor: theme.extraRowKeyText)
             wire(btn)
             stack.addArrangedSubview(btn)
             if key.slot == .ctrlC { ctrlCButton = btn }
+            if key.slot == .mic { micButton = btn }
         }
         applyCtrlVisual(ctrl.state)
+    }
+
+    public func setMicListening(_ listening: Bool) {
+        guard let micButton else { return }
+        micButton.backgroundColor = listening ? armed : keyBg
     }
 
     /// Stop auto-repeat when the row leaves the hierarchy.
@@ -141,6 +151,12 @@ public final class ExtraRowView: UIView {
 
         case .upload:
             btn.addTarget(self, action: #selector(uploadTapped), for: .touchUpInside)
+
+        case .mic:
+            btn.addTarget(self, action: #selector(micTapped), for: .touchUpInside)
+            let lp = UILongPressGestureRecognizer(target: self, action: #selector(micLongPressed(_:)))
+            lp.minimumPressDuration = 0.45
+            btn.addGestureRecognizer(lp)
 
         case .send:
             btn.addTarget(self, action: #selector(sendTapped), for: .touchUpInside)
@@ -210,6 +226,17 @@ public final class ExtraRowView: UIView {
     @objc private func uploadTapped() {
         KeyboardHaptics.keyPress()
         delegate?.extraRowDidTapUpload(self)
+    }
+
+    @objc private func micTapped() {
+        KeyboardHaptics.keyPress()
+        delegate?.extraRowDidTapMic(self)
+    }
+
+    @objc private func micLongPressed(_ gr: UILongPressGestureRecognizer) {
+        guard gr.state == .began else { return }
+        KeyboardHaptics.keyPress()
+        delegate?.extraRowDidCancelMic(self)
     }
 
     @objc private func sendTapped() {

--- a/ios/Tests/ANSISequenceTests.swift
+++ b/ios/Tests/ANSISequenceTests.swift
@@ -13,6 +13,8 @@ final class ANSISequenceTests: XCTestCase {
         XCTAssertEqual(ANSISequence.bytes(for: .tab), [0x09])
         XCTAssertEqual(ANSISequence.bytes(for: .backspace), [0x7f])
         XCTAssertEqual(ANSISequence.bytes(for: .return), [0x0d])
+        XCTAssertEqual(ANSISequence.bytes(for: .send), [0x0d])
+        XCTAssertEqual(ANSISequence.bytes(for: .newline), [0x0a])
         XCTAssertEqual(ANSISequence.bytes(for: .space), [0x20])
     }
 

--- a/ios/Tests/ExtensionHonestyTests.swift
+++ b/ios/Tests/ExtensionHonestyTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import KeyJawnKit
+
+/// Structural checks that the keyboard extension does not grow a dead mic.
+final class ExtensionHonestyTests: XCTestCase {
+
+    func testExtensionSourcesDoNotImportSpeechOrRequestTheMic() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let extensionDir = root.appendingPathComponent("KeyJawnKeyboard")
+        let files = try FileManager.default.contentsOfDirectory(
+            at: extensionDir,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "swift" }
+        XCTAssertFalse(files.isEmpty, "missing keyboard extension sources")
+        for file in files {
+            let text = try String(contentsOf: file, encoding: .utf8)
+            XCTAssertFalse(text.contains("import Speech"), "\(file.lastPathComponent) imports Speech")
+            XCTAssertFalse(text.contains("SFSpeechRecognizer"), "\(file.lastPathComponent) uses SFSpeechRecognizer")
+            XCTAssertFalse(text.contains("AVAudioEngine"), "\(file.lastPathComponent) opens the audio engine")
+            XCTAssertFalse(text.contains("requestRecordPermission"), "\(file.lastPathComponent) requests the mic")
+        }
+    }
+
+    func testExtensionDefaultRowHasNoMic() {
+        XCTAssertFalse(
+            ExtraRowKey.defaults.contains { $0.slot == .mic },
+            "the IME extra row must not show a dead mic"
+        )
+        XCTAssertTrue(
+            ExtraRowKey.terminalKeys.contains { $0.slot == .mic },
+            "the SSH extra row is where the mic lives"
+        )
+    }
+}

--- a/ios/Tests/ExtraRowPresetTests.swift
+++ b/ios/Tests/ExtraRowPresetTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class ExtraRowPresetTests: XCTestCase {
+
+    func testAgentRoundTripsToDefaultTenKeyRow() {
+        XCTAssertEqual(ExtraRowPreset.decode(ExtraRowPreset.agent.encoded), .agent)
+        XCTAssertEqual(
+            ExtraRowPreset.agent.keys.map(\.slot),
+            ExtraRowKey.defaults.map(\.slot)
+        )
+        XCTAssertEqual(
+            ExtraRowPreset.agent.keys.map(\.label),
+            ExtraRowKey.defaults.map(\.label)
+        )
+    }
+
+    func testConfirmEncodesAnswersAndASubmit() {
+        XCTAssertEqual(ExtraRowPreset.decode(ExtraRowPreset.confirm.encoded), .confirm)
+        let outputs = ExtraRowPreset.confirm.keys.compactMap(\.output)
+        for expected: KeyOutput in [
+            .character("y"), .character("n"), .character("a"),
+            .character("1"), .character("2"), .character("3"),
+            .send, .escape, .ctrlC,
+        ] {
+            XCTAssertTrue(outputs.contains(expected), "Confirm is missing \(expected)")
+        }
+        XCTAssertEqual(
+            TerminalInputMapping.extraRow(.send, ctrlActive: false),
+            .write(TerminalInputMapping.submitBytes)
+        )
+    }
+
+    func testUnknownAndMissingPresetDecodeAsAgent() {
+        XCTAssertEqual(ExtraRowPreset.decode(nil), .agent)
+        XCTAssertEqual(ExtraRowPreset.decode("nope"), .agent)
+        XCTAssertEqual(ExtraRowPreset.decode(""), .agent)
+    }
+
+    func testPrefsPersistThePresetOnAnInjectedSuite() {
+        let name = "com.keyjawn.tests.preset.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+
+        let writer = KeyboardPrefs(defaults: suite, migratesLegacyValues: false)
+        XCTAssertEqual(writer.extraRowPreset, .agent)
+        writer.extraRowPreset = .confirm
+        let reader = KeyboardPrefs(defaults: suite, migratesLegacyValues: false)
+        XCTAssertEqual(reader.extraRowPreset, .confirm)
+        XCTAssertEqual(reader.extraRowPreset.keys.map(\.slot), ExtraRowPreset.confirm.keys.map(\.slot))
+    }
+}

--- a/ios/Tests/HardwareKeyMappingTests.swift
+++ b/ios/Tests/HardwareKeyMappingTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class HardwareKeyMappingTests: XCTestCase {
+
+    func testEscapeTabAndArrows() {
+        XCTAssertEqual(HardwareKeyMapping.bytes(for: .escape, modifiers: []), [0x1b])
+        XCTAssertEqual(HardwareKeyMapping.bytes(for: .tab, modifiers: []), [0x09])
+        XCTAssertEqual(
+            HardwareKeyMapping.bytes(for: .arrowUp, modifiers: []),
+            ANSISequence.bytes(for: .arrowUp)
+        )
+        XCTAssertEqual(
+            HardwareKeyMapping.bytes(for: .arrowDown, modifiers: []),
+            ANSISequence.bytes(for: .arrowDown)
+        )
+        XCTAssertEqual(
+            HardwareKeyMapping.bytes(for: .arrowLeft, modifiers: []),
+            ANSISequence.bytes(for: .arrowLeft)
+        )
+        XCTAssertEqual(
+            HardwareKeyMapping.bytes(for: .arrowRight, modifiers: []),
+            ANSISequence.bytes(for: .arrowRight)
+        )
+    }
+
+    func testCtrlLettersMatchTheExtraRow() {
+        XCTAssertEqual(HardwareKeyMapping.bytes(for: .character("c"), modifiers: .control), [0x03])
+        XCTAssertEqual(HardwareKeyMapping.bytes(for: .character("d"), modifiers: .control), [0x04])
+        XCTAssertEqual(HardwareKeyMapping.bytes(for: .character("z"), modifiers: .control), [0x1a])
+    }
+
+    func testCmdCIsNotInterrupt() {
+        XCTAssertNil(HardwareKeyMapping.bytes(for: .character("c"), modifiers: .command))
+        XCTAssertNil(HardwareKeyMapping.bytes(for: .character("c"), modifiers: [.command, .control]))
+        XCTAssertNotEqual(
+            HardwareKeyMapping.bytes(for: .character("c"), modifiers: .command),
+            [0x03]
+        )
+    }
+
+    func testPlainCharactersStayOnInsertText() {
+        XCTAssertNil(HardwareKeyMapping.bytes(for: .character("x"), modifiers: []))
+    }
+}

--- a/ios/Tests/KeyboardInsertPathTests.swift
+++ b/ios/Tests/KeyboardInsertPathTests.swift
@@ -195,6 +195,8 @@ private final class ExtraRecorder: ExtraRowDelegate {
     }
     func extraRowDidTapClipboard(_ view: ExtraRowView) {}
     func extraRowDidTapUpload(_ view: ExtraRowView) {}
+    func extraRowDidTapMic(_ view: ExtraRowView) {}
+    func extraRowDidCancelMic(_ view: ExtraRowView) {}
 }
 
 @MainActor

--- a/ios/Tests/SlashCommandStoreTests.swift
+++ b/ios/Tests/SlashCommandStoreTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class SlashCommandStoreTests: XCTestCase {
+
+    func testAddFooAndRejectCompact() {
+        let name = "com.keyjawn.tests.slash.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+
+        let added = SlashCommandStore.add(trigger: "/foo", description: "mine", to: suite)
+        guard case .success(let record) = added else {
+            return XCTFail("expected /foo to be accepted")
+        }
+        XCTAssertEqual(record.trigger, "/foo")
+        XCTAssertEqual(SlashCommandStore.commands(from: suite).map(\.trigger), ["/foo"])
+
+        let duplicate = SlashCommandStore.add(trigger: "/compact", description: "nope", to: suite)
+        XCTAssertEqual(duplicate, .failure(.duplicateTrigger))
+
+        let again = SlashCommandStore.add(trigger: "foo", description: "again", to: suite)
+        XCTAssertEqual(again, .failure(.duplicateTrigger))
+    }
+
+    func testPanelUnionIncludesCustomTrigger() {
+        let name = "com.keyjawn.tests.slash-panel.\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: name) }
+        _ = SlashCommandStore.add(trigger: "/foo", description: "mine", to: suite)
+        let commands = SlashCommand.all + SlashCommandStore.commands(from: suite)
+        XCTAssertTrue(commands.contains { $0.trigger == "/foo" })
+        XCTAssertTrue(commands.contains { $0.trigger == "/compact" })
+        XCTAssertEqual(Set(commands.map(\.trigger)).count, commands.count)
+    }
+}

--- a/ios/Tests/TerminalInputMappingTests.swift
+++ b/ios/Tests/TerminalInputMappingTests.swift
@@ -33,6 +33,26 @@ final class TerminalInputMappingTests: XCTestCase {
     func testExtraRowReturnIsSubmitCR() {
         XCTAssertEqual(TerminalInputMapping.extraRow(.return, ctrlActive: false), .write([0x0d]))
     }
+
+    func testSendIsSubmitCRAndNewlineIsNot() {
+        XCTAssertEqual(TerminalInputMapping.extraRow(.send, ctrlActive: false), .write([0x0d]))
+        XCTAssertEqual(TerminalInputMapping.extraRow(.newline, ctrlActive: false), .write([0x0a]))
+        XCTAssertNotEqual(
+            TerminalInputMapping.extraRow(.send, ctrlActive: false),
+            TerminalInputMapping.extraRow(.newline, ctrlActive: false)
+        )
+    }
+
+    func testIMESendIsAnHonestNewline() {
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .send, ctrlActive: false, terminalArrows: true),
+            .insert("\n")
+        )
+        XCTAssertEqual(
+            KeyboardDocumentInsert.action(for: .newline, ctrlActive: false, terminalArrows: true),
+            .insert("\n")
+        )
+    }
 }
 
 @MainActor
@@ -90,6 +110,38 @@ final class TerminalInputViewTests: XCTestCase {
         sink.extraRow.ctrl.toggle()
         sink.insertText("\n")
         XCTAssertFalse(sink.extraRow.ctrl.isActive, "submit must consume armed Ctrl")
+    }
+
+    func testSendKeyOnTerminalRowWritesCR() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 430, height: 80))
+        let sink = TerminalInputView(frame: window.bounds)
+        var got: [[UInt8]] = []
+        sink.onRawInput = { got.append($0) }
+        window.addSubview(sink)
+        let extra = sink.extraRow
+        extra.frame = window.bounds
+        window.addSubview(extra)
+        window.makeKeyAndVisible()
+        extra.layoutIfNeeded()
+
+        tapExtra(extra, accessibility: "Send")
+        XCTAssertEqual(got, [TerminalInputMapping.submitBytes])
+        window.isHidden = true
+    }
+
+    func testSendLongPressIsWiredForNewline() {
+        let extra = ExtraRowView()
+        extra.setKeys(ExtraRowKey.terminalKeys)
+        extra.layoutIfNeeded()
+        let send = extra.subviews
+            .flatMap(\.subviews)
+            .compactMap { $0 as? UIButton }
+            .first { $0.accessibilityLabel == "Send" || $0.currentTitle == "Send" }
+        XCTAssertNotNil(send, "terminal row is missing Send")
+        XCTAssertTrue(
+            send?.gestureRecognizers?.contains { $0 is UILongPressGestureRecognizer } == true,
+            "Send must long-press to insert a newline without submitting"
+        )
     }
 
     func testExtraRowSlashOpensPanelAndCompactWritesTrigger() {

--- a/ios/Tests/VoiceSessionTests.swift
+++ b/ios/Tests/VoiceSessionTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import KeyJawnKit
+
+final class VoiceSessionTests: XCTestCase {
+
+    func testCommitEmitsUTF8AndCancelEmitsNothing() {
+        var session = VoiceSession()
+        session.start()
+        session.updatePartial("hello")
+        XCTAssertEqual(session.commit(), "hello")
+        XCTAssertEqual(Array("hello".utf8), Array("hello".utf8))
+
+        session.start()
+        session.updatePartial("discard me")
+        session.cancel()
+        XCTAssertNil(session.commit())
+        XCTAssertEqual(session.transcript, "")
+        XCTAssertFalse(session.isListening)
+    }
+
+    func testCommitWithoutSpeechInsertsNothing() {
+        var session = VoiceSession()
+        session.start()
+        XCTAssertNil(session.commit())
+    }
+
+    func testPartialUpdatesAreIgnoredWhenNotListening() {
+        var session = VoiceSession()
+        session.updatePartial("nope")
+        XCTAssertEqual(session.transcript, "")
+        XCTAssertNil(session.commit())
+    }
+}


### PR DESCRIPTION
Depends on #111 (first commit). Closes #85. Closes #84. Closes #83. Closes #82. Closes #86.

## Send (#85)
Tap Send in the SSH extra row writes CR. Long-press writes LF. The IME mapping treats Send as an honest newline.

## Presets (#84)
Agent is the default ten-key row. Confirm types y/n/a/1/2/3 plus Send and Esc. Stored in `group.com.keyjawn`.

## Hardware keys (#83)
`pressesBegan` + `UIKeyCommand` use `HardwareKeyMapping`. Esc, Tab, arrows, Ctrl+C/D/Z reach the PTY. Cmd+C is not `0x03`.

## Voice (#82)
Main-app `SFSpeechRecognizer` on the terminal Mic key. Commit writes UTF-8. Cancel inserts nothing. The extension row has no mic and does not import Speech.

## Custom slash (#86)
Settings adds `/foo` to App Group JSON. The panel shows it. `/compact` is rejected. Inserts stay plain text.

## Tests
Local `KeyJawnKitTests` 164 passed twice on iPhone 17 Pro.